### PR TITLE
[git] modify gitignore to exclude IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Directory of IDE settings
+*.idea/*
+*.vscode/*


### PR DESCRIPTION
This addition is needed because we never want to push the contents inside of settings directory.