### PR TITLE
[wsu] Add wsu Ansible playbook

### DIFF
--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -1,0 +1,46 @@
+## Windows Scale Up (WSU) Playbook
+This playbook is responsible for setting up your Windows instance so it is ready and can be added to your OpenShift cluster.
+There are couple prerequisites for using this playbook.
+- Set up a running OpenShift cluster.
+- An ansible environment to run the Ansible playbook with required packages. Here are a sample step to set up your Ansible environment.
+  Here are the steps to set up the Ansible Envrionment on a Fedora system:
+  ```
+  $ sudo dnf install libselinux-python
+  $ pip install ansible pywinrm kubernetes openshift
+  ```
+- A Windows Server 2019 instance running in the same VPC as the OpenShift cluster with winrm enabled.
+  You can use `wni` tool to setup the Windows instance following this [link](https://github.com/openshift/windows-machine-config-operator/tree/master/tools/windows-node-installer). The winrm module is enabled automatically if you use `wni` tool to create the server node. But this `wni` is currently not supported in production use cases.
+- You need to add a tag to your Windows Server 2019 instance, with the `key: <cluster_name>` and `value: owned` before your run the playbook. 
+- Login to your cluster using `oc` command.
+
+Once you have your Windows instance setup, a `hosts` file is need to run this Ansible playbook (the `hosts` file can be on any directory of your system) with your instance information. You can create a new `hosts` file or modify any existing `hosts` file on your system. 
+Here is a sample `hosts` file. Inside the sample `hosts` field, `<username>` and `<password>` are the account information to login to the Windows instance, `<node_ip>` is the public ip address of your Windows instance. This file can be in the same directory with your playbook.
+```
+[win]
+<node_ip>
+[win:vars]
+ansible_user=<username>
+ansible_password=<password>
+ansible_connection=winrm
+ansible_ssh_port=5986
+ansible_winrm_server_cert_validation=ignore
+```
+Confirm that you are able to ping your Windows instance using the following command (this command can be run anywhere):
+```
+# replace <host file location> with the hosts file contains your Windows instance information.
+$ ansible win -i <host file location> -m win_ping -vvvvv
+```
+If you are able to ping the Windows instance, you are ready to use `wsu.yaml` playbook to configure your Windows instance and let it join your cluster.
+These are the environment variables for executing the wsu playbook. All the environment variable are **required**.
+- `ansible_password` if this is not given in the hosts file
+- `kubelet_location`: kubelet binary download link
+- `wmcb_location`: wmcb binary download link
+- `openshift_node_bootstrap_server`: cluster server namespace for fetching the ignition file
+
+Here is a sample command to execute this ansible playbook.
+```
+$ ansible-playbook -vvvv -i hosts wsu.yaml --extra-vars "ansible_password=<decrypted_password> kubelet_location=<kubelet location> wmcb_location=<wmcb_location> openshift_node_bootstrap_server=<openshift_node_bootstrap_server>"
+```
+Just replace the argument in arrow bracket with corresponding information in your system, and this ansible playbook will prepare your Windows instance.
+Once you have done that follow these [steps](https://github.com/openshift/windows-machine-config-operator#testing) to verify your node is joined.
+

--- a/tools/ansible/wsu.yaml
+++ b/tools/ansible/wsu.yaml
@@ -1,0 +1,97 @@
+---
+- hosts: localhost
+  vars:
+     bootstrap_node_machineconfigpool: 'worker'
+     bootstrap_node_port: 22623
+     bootstrap_node_endpoint: "{{ openshift_node_bootstrap_server }}:{{ bootstrap_node_port }}/config/{{ bootstrap_node_machineconfigpool }}"
+    
+  tasks:
+    - name: Validate given input parameters meet the requirement
+      fail:
+          msg: "Please provide the following parameters to run this playbook [ kubelet_location, kubeovn_location, wmcb_location, openshift_node_bootstrap_server ]"
+      when: kubelet_location is not defined or
+            wmcb_location is not defined or
+            openshift_node_bootstrap_server is not defined
+
+    - name: Show ignition file endpoint 
+      debug:
+        msg: "Ignition file endpoint is {{ bootstrap_node_endpoint }}"
+
+    - name: Create temporary build directory to store files
+      tempfile:
+        state: directory
+      register: build_tmp
+
+    - name: Show temporary path directory
+      debug:
+        msg: "Temporary build path is {{ build_tmp.path }}"
+      when: build_tmp is defined
+
+    - name: Check that you can connect (GET) to a page and it returns a status 200
+      uri:
+        url: "{{ bootstrap_node_endpoint }}"
+        dest: "{{ build_tmp.path }}/worker.ign"
+      when: build_tmp is defined
+
+    - name: Download Kubernetes archive to controller machine
+      get_url:
+        url: "{{ kubelet_location }}"
+        dest: "{{ build_tmp.path }}/kube.tar.gz"
+      when: build_tmp is defined
+
+    - name: Unarchive Kubenetes binary
+      unarchive:
+        src: "{{ build_tmp.path }}/kube.tar.gz"
+        dest: "{{ build_tmp.path }}" 
+      when: build_tmp is defined
+
+    - name: Download wmcb binary to controller machine
+      get_url:
+        url: "{{ wmcb_location }}"
+        dest: "{{ build_tmp.path }}/wmcb.exe"
+      when: build_tmp is defined
+
+
+- hosts: win
+  vars:
+    build_tmp: "{{ hostvars['localhost']['build_tmp'] }}"
+  tasks:
+    - name: Description 
+      debug:
+        msg: Preparing your Windows node 
+
+    - name: Check Windows container runtime
+      win_service:
+        name: docker
+        state: started
+
+    - name: Create temporary build path on Windows
+      win_tempfile:
+        state: directory
+      register: win_build_tmp
+
+    - name: Show temporary build path location
+      debug:
+        msg: "Temporary build path on Windows is {{ win_build_tmp.path }}"
+
+    - name: Transfer kubelet binary from controller machine to Windows host
+      win_copy: 
+        src: "{{ build_tmp.path }}/kubernetes/node/bin/kubelet.exe"
+        dest: "{{ win_build_tmp.path }}/kubelet.exe"
+      when: win_build_tmp is defined and build_tmp is defined
+
+    - name: Transfer wmcb binary from controller machine to Windows host
+      win_copy:
+        src: "{{ build_tmp.path }}/wmcb.exe"
+        dest: "{{ win_build_tmp.path }}/wmcb.exe"
+      when: win_build_tmp is defined and build_tmp is defined
+
+    - name: Transfer ignition file from controller machine to Windows host
+      win_copy:
+        src: "{{ build_tmp.path }}/worker.ign"
+        dest: "{{ win_build_tmp.path }}/worker.ign"
+      when: win_build_tmp is defined and build_tmp is defined
+
+    - name: Show what is in Windows temporary build directory
+      raw: ls "{{ win_build_tmp.path }}"
+


### PR DESCRIPTION
This PR contains a `wsu.yaml` Ansible Playbook that prepare the Windows instance and ready for running the bootstraper.

`wsu.yaml` is responsible for downloading `worker.ign`, `kubelet.exe`, `wmcb.exe` and transfering these files to remote Windows instance. The result is that all the files are available in the Windows instance.

A README file provides document and instructions for using and testing this playbook.

You can verify the outcome after running this playbook by checking the stdout of the ls command that all the files are available in the temp directory.