### PR TITLE
Bug 1757446: [wni] Directory validation errors

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -41,15 +41,15 @@ func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, r
 	// File, dir, credential account sanity checks.
 	kubeconfigPath, err := makeValidAbsPath(kubeconfigPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid path for kubeconfig file, %v", err)
 	}
 	credentialPath, err = makeValidAbsPath(credentialPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid path for credentials file, %v", err)
 	}
 	resourceTrackerDir, err = makeValidAbsPath(resourceTrackerDir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid directory path for resource tracker file, %v", err)
 	}
 
 	// Create a new client of the given OpenShift cluster based on kubeconfig.
@@ -76,6 +76,9 @@ func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, r
 
 // makeValidAbsPath remakes a path into an absolute path and ensures that it exists.
 func makeValidAbsPath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty path")
+	}
 	if !filepath.IsAbs(path) {
 		if path[0] == '~' {
 			path = filepath.Join(homedir.HomeDir(), path[1:])


### PR DESCRIPTION
Cause:
There is no sanity check for whether a path input has content.
There is also a lack of error messages specifying which path input:
kubeconfig, credentials, and windows-node-installer.json file
failed checking against the validation of the path.

Consequence:
The empty path is checked to see if `~` present in the head of the path,
which results in an index out of range error. The error message was
returned directly without knowing which path input is failing.

Fix:
Check if the input path is empty.
Add explicit error messages to places where the validation function
is called.

Result:
Empty input path is errored out with proper messages showing which
input path is not valid.