### PR TITLE
[wni] Refactor interface to be cloud provider agnostic 

### DIFF
--- a/tools/windows-node-installer/cmd/aws.go
+++ b/tools/windows-node-installer/cmd/aws.go
@@ -80,11 +80,12 @@ func createCmd() *cobra.Command {
 		TraverseChildren: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			cloud, err := cloudprovider.CloudProviderFactory(rootInfo.kubeconfigPath, awsInfo.credentialPath,
-				awsInfo.credentialAccountID, rootInfo.resourceTrackerDir)
+				awsInfo.credentialAccountID, rootInfo.resourceTrackerDir,
+				awsInfo.imageID, awsInfo.instanceType, awsInfo.sshKey)
 			if err != nil {
 				return fmt.Errorf("error creating aws client, %v", err)
 			}
-			err = cloud.CreateWindowsVM(awsInfo.imageID, awsInfo.instanceType, awsInfo.sshKey)
+			err = cloud.CreateWindowsVM()
 			if err != nil {
 				return fmt.Errorf("error creating Windows Instance, %v", err)
 			}
@@ -130,7 +131,7 @@ func destroyCmd() *cobra.Command {
 
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cloud, err := cloudprovider.CloudProviderFactory(rootInfo.kubeconfigPath, awsInfo.credentialPath,
-				awsInfo.credentialAccountID, rootInfo.resourceTrackerDir)
+				awsInfo.credentialAccountID, rootInfo.resourceTrackerDir, "", "", "")
 			if err != nil {
 				return fmt.Errorf("error creating cloud provider clients, %v", err)
 			}

--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -15,9 +15,9 @@ import (
 // Cloud is the interface that needs to be implemented per provider to allow support for creating Windows nodes on
 // that provider.
 type Cloud interface {
-	// CreateWindowsVM creates a Windows VM based on available image id, instance type, and ssh key name.
+	// CreateWindowsVM creates a Windows VM for a given cloud provider
 	// TODO: CreateWindowsVM should return a provider object for further interaction with the created instance.
-	CreateWindowsVM(imageId, instanceType, sshKey string) error
+	CreateWindowsVM() error
 	// DestroyWindowsVMs uses 'windows-node-installer.json' file that contains IDs of created instance and
 	// security group and deletes them.
 	// Example 'windows-node-installer.json' file:
@@ -37,7 +37,8 @@ type Cloud interface {
 // this function requires specifying the credentialAccountID of the user's credential account.
 // The resourceTrackerDir is where the `windows-node-installer.json` file which contains IDs of created instance and
 // security group will be created.
-func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, resourceTrackerDir string) (Cloud, error) {
+func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, resourceTrackerDir,
+	imageID, instanceType, sshKey string) (Cloud, error) {
 	// File, dir, credential account sanity checks.
 	kubeconfigPath, err := makeValidAbsPath(kubeconfigPath)
 	if err != nil {
@@ -68,7 +69,7 @@ func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, r
 
 	switch provider := cloudProvider.Type; provider {
 	case v1.AWSPlatformType:
-		return aws.New(oc, credentialPath, credentialAccountID, resourceTrackerFilePath)
+		return aws.New(oc, imageID, instanceType, sshKey, credentialPath, credentialAccountID, resourceTrackerFilePath)
 	default:
 		return nil, fmt.Errorf("the '%v' cloud provider is not supported", provider)
 	}


### PR DESCRIPTION
Refactor interface to be cloud provider agnostic:

As of now, CreateVM method in cloudprovider interface has AWS specific
arguments, removing them to make the cloud provider interface
generic enough across all cloud providers


Should used on top of https://github.com/openshift/windows-machine-config-operator/pull/37/commits/818e3d27c936ba6e3e1fe6400a9924f720b56b7a, the commit to review is https://github.com/openshift/windows-machine-config-operator/pull/38/commits/8abaeb0ac7c67cd28e24effe01c942fad17dc3cb

/cc @aravindhp @Bowenislandsong @vinaykns 