### PR TITLE
[logging] Install Fluentd on Windows instance

### DIFF
--- a/tools/ansible/tasks/logging/README.md
+++ b/tools/ansible/tasks/logging/README.md
@@ -1,0 +1,35 @@
+# Logging on Windows instance
+
+These playbooks install Fluentd on Windows Instance, in order to enable logging support.
+
+Before running,
+- Set up an OpenShift cluster.
+- Set up a Windows instance as part of the cluster. You can use `wni` tool to set it up by following this [link](https://github.com/openshift/windows-machine-config-operator/tree/master/tools/windows-node-installer).
+- Ensure Ansible environment is set up to run the playbook.
+- Ensure a valid inventory file is set up.
+
+Run `main.yml` with the following command:
+```
+$ ansible-playbook -v -i <inventory_file> main.yml --extra-vars "ruby_fetch_url=<ruby_fetch_url>"
+```
+As a part of Fluentd installation, Ruby DevKit is required.
+Here, `<ruby_fetch_url>` is the URL to fetch Ruby DevKit. The version of the same should be >=2.4 and < 2.6
+The URL can be found [here](https://rubyinstaller.org/downloads/).
+
+Sample command with URL:
+```
+$ ansible-playbook -v -i hosts main.yml --extra-vars "ruby_fetch_url=
+'https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.7-1/rubyinstaller-devkit-2.5.7-1-x64.exe'"
+```
+
+There are also some optional arguments which could be provided while running the playbook:
+- `install_dir` is the directory where you would like Ruby to be installed.
+This path should already exist on the system.
+- `fluentd_version` is the version of Fluentd to be installed. `1.5.1` is recommended version for
+[OpenShift 4.3 release](https://github.com/openshift/origin-aggregated-logging/tree/master/fluentd)
+
+The run command with optional arguments could look like:
+```
+$ ansible-playbook -v -i <inventory_file> main.yml --extra-vars "ruby_fetch_url=<ruby_fetch_url>
+install_dir=<install_dir_path> fluentd_version=<fluentd_version>"
+```

--- a/tools/ansible/tasks/logging/install_fluentd.yml
+++ b/tools/ansible/tasks/logging/install_fluentd.yml
@@ -1,0 +1,39 @@
+---
+- name: Create temporary directory on windows host
+  win_tempfile:
+    state: directory
+  register: tempdir_win
+  # Ruby Devkit installs Ruby + MSYS2 packages and adds Ruby executables to PATH
+  # Enable installation of RubyGems
+  # Ruby version < 2.6 and >= 2.4, 64 bit
+- name: Fetch ruby devkit exe
+  win_get_url:
+    url: "{{ ruby_fetch_url }}"
+    dest: "{{ tempdir_win.path }}\\"
+  register: ruby_devkit
+- name: Check install path
+  win_stat:
+    path: "{{ install_dir }}"
+  when: install_dir is defined
+  register: install_dir_exists
+- name: Install ruby to particular directory
+  win_shell: "{{ ruby_devkit.dest }} /VERYSILENT /SUPPRESSMSGBOXES /DIR={{ install_dir }}"
+  when: install_dir is defined and install_dir_exists.stat.exists
+- name: Install ruby
+  win_shell: "{{ ruby_devkit.dest }} /VERYSILENT /SUPPRESSMSGBOXES"
+  when: install_dir is not defined or
+        (install_dir_exists is defined and install_dir_exists.stat.exists==false)
+- name: Check ruby installed
+  win_shell: "ruby --version"
+  # Install Fluentd RubyGem. Fluentd version 1.5.1 or higher
+- name: Install fluentd (version specific)
+  win_shell: gem install fluentd -v '~> {{ fluentd_version }}'
+  when: fluentd_version is defined
+- name: Install fluentd
+  win_shell: gem install fluentd
+  when: fluentd_version is not defined
+- name: Delete temporary directory on windows host
+  win_file:
+    path: "{{ tempdir_win.path }}"
+    state: absent
+  when: tempdir_win.path is defined

--- a/tools/ansible/tasks/logging/main.yml
+++ b/tools/ansible/tasks/logging/main.yml
@@ -1,0 +1,7 @@
+---
+- hosts: win
+  tasks:
+   - name: Logging | Install Fluentd
+     include_tasks: install_fluentd.yml
+   # - name: Logging | Install Fluentd plugins
+   #   include_tasks: install_plugins.yml


### PR DESCRIPTION
This commit sets up an Ansible Playbook to install Ruby Development Kit
and Fluentd on the Windows instance to enable logging.