### PR TITLE
[wni] Fix the trailing slash

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -89,7 +89,10 @@ func makeValidAbsPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
+	// Add a trailing slash if it doesn't exist.
+	if path[len(path)-1:] != "/" {
+		path = path + "/"
+	}
 	if _, err := os.Stat(path); err != nil {
 		return "", fmt.Errorf("path %s does not exist", path)
 	}

--- a/tools/windows-node-installer/pkg/cloudprovider/factory_test.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory_test.go
@@ -23,7 +23,7 @@ func TestMakeValidAbsPath(t *testing.T) {
 		{
 			description:  "Empty path should resolve to current working directory",
 			inputPath:    "",
-			expectedPath: getCWD(),
+			expectedPath: getCWD() + "/",
 		},
 		{
 			description:   "Non existent file should return an error and should resolve to empty string",


### PR DESCRIPTION
Fix the trailing slash error. Without this we would be creating files in
unnecessary directories and cannot read the resources we created 
from the required directories.
/cc @aravindhp @Bowenislandsong 