### PR TITLE
[wni] Fix the path validation err

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/factory.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory.go
@@ -76,6 +76,8 @@ func CloudProviderFactory(kubeconfigPath, credentialPath, credentialAccountID, r
 }
 
 // makeValidAbsPath remakes a path into an absolute path and ensures that it exists.
+// TODO: Break this function to validate files. dirs etc. As of now, we don't differentiate
+// between files and dirs
 func makeValidAbsPath(path string) (string, error) {
 	if len(path) > 0 && !filepath.IsAbs(path) {
 		// Expand `~` to `/home` directory of the user
@@ -89,12 +91,15 @@ func makeValidAbsPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Add a trailing slash if it doesn't exist.
-	if path[len(path)-1:] != "/" {
-		path = path + "/"
-	}
-	if _, err := os.Stat(path); err != nil {
+	file, err := os.Stat(path)
+	if err != nil {
 		return "", fmt.Errorf("path %s does not exist", path)
+	}
+	if file.IsDir() {
+		// Add a trailing slash if it doesn't exist only for directories
+		if path[len(path)-1:] != "/" {
+			path = path + "/"
+		}
 	}
 	return path, nil
 }

--- a/tools/windows-node-installer/pkg/cloudprovider/factory_test.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/factory_test.go
@@ -1,6 +1,7 @@
 package cloudprovider
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -14,6 +15,14 @@ func getCWD() string {
 // TestMakeValidAbsPath tests if makeValidAbsPath is returning an error or not in various conditions.
 // TODO: Add more test cases here
 func TestMakeValidAbsPath(t *testing.T) {
+	// create Temporary file for testing
+	file, _ := ioutil.TempFile("/tmp", "test-")
+	fileName := file.Name()
+	defer os.Remove(fileName)
+	// create Temporary directory for testing
+	dir, _ := ioutil.TempDir("/tmp", "test-")
+	defer os.Remove(dir)
+
 	tests := []struct {
 		description   string
 		inputPath     string
@@ -30,6 +39,18 @@ func TestMakeValidAbsPath(t *testing.T) {
 			inputPath:     "/somerandomPath",
 			expectedPath:  "",
 			expectedError: true,
+		},
+		{
+			description:   "a temporary file which exists on machine should not get a trailing /",
+			inputPath:     fileName,
+			expectedPath:  fileName,
+			expectedError: false,
+		},
+		{
+			description:   "a temporary dir which exists on machine should get a trailing /",
+			inputPath:     dir,
+			expectedPath:  dir + "/",
+			expectedError: false,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
#43 introduced a bug, where we're not checking if the
given path is file or dir and appending trailing "/" while this
should have been normalized, in order to keep us
moving forward, providing this fix which ensures
trailing slash will be added only to directories

/cc @Bowenislandsong @aravindhp @vinaykns 