### PR TITLE
[wsu] WSU playbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ wmcb run --ignition-file $IGNITION_FILE_PATH --kubelet-path $KUBELET_PATH
 
 ## Testing
 
+### Windows Machine Config Bootstrapper
+
 On an existing Windows instance which is ready to join the cluster, copy the worker ignition file to C:\Windows\Temp\worker.ign, and the kubelet to C:\Windows\Temp\kubelet.exe
 
 On the Windows instance, run:
@@ -45,3 +47,7 @@ oc adm certificate approve $CSR_NAME
 Repeat the above steps for the `system:node:$NODE_NAME` csr which will appear shortly. 
 
 You can now do `oc get nodes`, and see the Windows node has joined the cluster.
+
+### Ansible
+
+Follow the instructions in `tools/ansible/README.md`, and ensure the playbook completes successfully.

--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -1,0 +1,43 @@
+# Ansible Playbooks
+
+## Prerequisites for using these playbooks
+- Access to an OpenShift cluster
+- A Windows Server 2019 instance within the cluster's subnet, with WinRM [configured](https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html#winrm-setup) for ansible
+    - You can use the [wni](https://github.com/openshift/windows-machine-config-operator/tree/master/tools/windows-node-installer) tool to create a ready Windows instance on certain cloud providers
+    - If you are using a cloud provider, you may have to add a tag to the Windows instance.
+      It will be of the format `key:kubernetes.io/cluster/<infraID>` with `value: owned`.
+      - You can find the infraID in the Ignition config file metadata `metadata.json`
+- A `hosts` file with the required variables defined. See below for an example:
+```
+[win]
+# Address of a node and its Windows password
+<node_ip> ansible_password=<password>
+
+[win:vars]
+# Windows username, typically 'Administrator'
+ansible_user=<username>
+# Address of the OpenShift cluster e.g. "foo.fah.com". This should not include "https://api-" or a port
+cluster_address=<address>
+
+ansible_connection=winrm
+ansible_ssh_port=5986
+# Required if you do not wish to set up a certificate
+#ansible_winrm_server_cert_validation=ignore
+```
+Confirm that you are able to connect your Windows instance with ansible by using the following command:
+```
+$ ansible win -i hosts -m win_ping -v
+```
+
+
+## Windows Scale Up (WSU) Playbook
+This playbook is responsible for three things:
+- Preparing a Windows instance for joining an OpenShift cluster.
+- Running the WMCB
+- Ensuring the Windows node has successfully joined the cluster
+
+### Usage
+Run the WSU playbook:
+```
+$ ansible-playbook -i hosts tasks/wsu/main.yaml -v
+```

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -1,0 +1,58 @@
+---
+- hosts: localhost
+  vars:
+    project_root: "{{ playbook_dir }}/../../../.."
+    kubelet_location: "https://dl.k8s.io/v1.14.0/kubernetes-node-windows-amd64.tar.gz"
+    wmcb_exe: "wmcb.exe"
+
+  tasks:
+    - name: Gather required files
+      block:
+
+        - name: Create directory to store files to be used later
+          tempfile:
+            state: directory
+          register: tmp_dir
+
+        - name: Build WMCB
+          make:
+            target: build
+            chdir: "{{ project_root }}"
+
+        - name: Move WMCB to temporary directory
+          command: mv "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
+
+        - name: Download Windows node kubelet
+          get_url:
+            url: "{{ kubelet_location }}"
+            dest: "{{ tmp_dir.path }}/kube.tar.gz"
+
+        - name: Extract kubelet
+          unarchive:
+            src: "{{ tmp_dir.path }}/kube.tar.gz"
+            dest: "{{ tmp_dir.path }}"
+
+        - name: Grab kubelet from extracted directories
+          copy:
+            src: "./tmp/kubernetes/node/bin/kubelet.exe"
+            dest: "./tmp/kubelet.exe"
+
+- hosts: win
+  vars:
+    tmp_path: "{{ playbook_dir }}/tmp"
+
+  tasks:
+    - name: Create temporary directory
+      win_tempfile:
+        state: directory
+      register: win_temp_dir
+    - name: Copy required files to Windows host
+      win_copy:
+        src: "{{ hostvars['localhost']['tmp_dir']['path'] }}/"
+        dest: "{{ win_temp_dir.path }}"
+
+    - name: Get ignition file
+      win_get_url:
+        url: "https://api-int.{{ cluster_address }}:22623/config/worker"
+        dest: "{{ win_temp_dir.path }}\\worker.ign"
+        validate_certs: no


### PR DESCRIPTION
This pull request introduces the Windows Scale Up Playbook. The purpose of
this playbook is to prepare a Windows instance to join an OpenShift
cluster, run the WMCB, and ensure that the node has successfully
joined the cluster. Specifically, this pull request implements the
first goal, preparing the instance.

An instance is 'prepared', when it is ready to run the WMCB.
Specifically, when it has a kubelet executable, WMCB executable,
and worker ignition file present on the machine.