### PR TITLE
[wni] Add tags for Windows instance created

### DIFF
--- a/tools/windows-node-installer/test/e2e/aws_test.go
+++ b/tools/windows-node-installer/test/e2e/aws_test.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/cloudprovider"
+	awscp "github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/cloudprovider/aws"
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/resource"
 	"github.com/stretchr/testify/assert"
 	"os"
@@ -33,23 +35,56 @@ func TestCreateDestroyWindowsInstance(t *testing.T) {
 	// The e2e test uses Microsoft Windows Server 2019 Base with Containers image, m4.large type, and libra ssh key.
 	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
 	// Microsoft Windows Server 2019 Base with Containers.
-	awsCloud, err := cloudprovider.CloudProviderFactory(kubeconfig, awscredentials, "default", dir,
+	cloud, err := cloudprovider.CloudProviderFactory(kubeconfig, awscredentials, "default", dir,
 		"ami-0b8d82dea356226d3", "m4.large", "libra")
 	assert.NoError(t, err, "error creating clients")
 
-	err = awsCloud.CreateWindowsVM()
+	err = cloud.CreateWindowsVM()
 	assert.NoError(t, err, "error creating Windows instance")
-
+	if err != nil {
+		// TODO: Remove the lingering resources as part of test setup.
+		t.Fatalf("Error while creating a VM delete the virtual machine")
+	}
+	// Type Assert to AWS so that we can test other functionality
+	aws, ok := cloud.(*awscp.AwsProvider)
+	if !ok {
+		t.Fatal("Error asserting cloudprovider to aws")
+	}
 	// Check instance and security group information in windows-node-installer.json.
 	info, err := resource.ReadInstallerInfo(dir + "/" + "windows-node-installer.json")
 	assert.NoError(t, err, "error reading windows-node-installer.json file")
 	assert.NotEmpty(t, info.SecurityGroupIDs, "security group is not created")
 	assert.NotEmpty(t, info.InstanceIDs, "instance is not created")
-
-	err = awsCloud.DestroyWindowsVMs()
+	instance, err := aws.GetInstance(info.InstanceIDs[0])
+	if err != nil {
+		t.Fatalf("error getting ec2 instance object from instance ID %v", info.InstanceIDs[0])
+	}
+	infraID, err := aws.GetInfraID()
+	if err != nil {
+		t.Fatalf("error while getting infrastructure ID for the given OpenShift cluster")
+	}
+	if !checkIfInfraTagExists(instance, infraID) {
+		t.Fatalf("Infrastructure tag not available for %v", info.InstanceIDs[0])
+	}
+	err = cloud.DestroyWindowsVMs()
 	assert.NoError(t, err, "error deleting instance")
 
 	// the windows-node-installer.json should be removed after resource is deleted.
 	_, err = resource.ReadInstallerInfo(dir)
 	assert.Error(t, err, "error deleting windows-node-installer.json file")
+}
+
+// checkIfInfraTagExists checks if the infrastructure tag exists on the created instance
+func checkIfInfraTagExists(instance *ec2.Instance, infraID string) bool {
+	if instance == nil {
+		return false
+	}
+	key := "kubernetes.io/cluster/" + infraID
+	value := "owned"
+	for _, tag := range instance.Tags {
+		if *tag.Key == key && *tag.Value == value {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
As of now, we don't have tags associated with Windows VM created
This makes it hard for the kubelet to communicate with cloud
provider api and for OpenShift CI jobs to delete the VM
associated with this tag. This commit should solve both
the problems

/cc @Bowenislandsong @aravindhp @vinaykns 