### PR TITLE
[aws-wni] Provide credentials to access Windows Node

### DIFF
--- a/tools/windows-node-installer/cmd/azure.go
+++ b/tools/windows-node-installer/cmd/azure.go
@@ -95,7 +95,7 @@ func azCreateCmd() *cobra.Command {
 			// Provide the azCreateFlagInfo.credentialAccountID as a default
 			cloud, err := cloudprovider.CloudProviderFactory(rootInfo.kubeconfigPath, azCreateFlagInfo.credentialPath,
 				azCreateFlagInfo.subscriptionID, rootInfo.resourceTrackerDir,
-				azCreateFlagInfo.imageID, azCreateFlagInfo.instanceType, "")
+				azCreateFlagInfo.imageID, azCreateFlagInfo.instanceType, "", "")
 			if err != nil {
 				return fmt.Errorf("error creating azure clients, %v", err)
 			}
@@ -110,8 +110,8 @@ func azCreateCmd() *cobra.Command {
 			} else {
 				return fmt.Errorf("error type asserting. %v", err)
 			}
-
-			err = cloud.CreateWindowsVM()
+			// TODO: Use the credentials object and print password, user name etc here.
+			_, err = cloud.CreateWindowsVM()
 			if err != nil {
 				return fmt.Errorf("error creating Windows Instance, %v", err)
 			}
@@ -164,7 +164,7 @@ func azDestroyCmd() *cobra.Command {
 			}
 			cloud, err := cloudprovider.CloudProviderFactory(rootInfo.kubeconfigPath, azCreateFlagInfo.credentialPath,
 				azCreateFlagInfo.subscriptionID, rootInfo.resourceTrackerDir,
-				azCreateFlagInfo.imageID, azCreateFlagInfo.instanceType, "")
+				azCreateFlagInfo.imageID, azCreateFlagInfo.instanceType, "", "")
 			if err != nil {
 				return fmt.Errorf("error creating azure clients, %v", err)
 			}

--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -178,10 +178,12 @@ func (a *AwsProvider) CreateWindowsVM() (credentials *types.Credentials, rerr er
 		return nil, fmt.Errorf("error with instance creation %v", err)
 	}
 
-	// Build new credentials structure to be used by other actors
+	// Build new credentials structure to be used by other actors. The actor is responsible for checking if
+	// the credentials are being generated properly. This method won't guarantee the existence of credentials
+	// if the VM is spun up
 	credentials = types.NewCredentials(instanceID, publicIPAddress, decryptedPassword)
 	err = resource.AppendInstallerInfo([]string{instanceID}, []string{}, a.resourceTrackerDir)
-	if err != nil || credentials == nil {
+	if err != nil {
 		return nil, fmt.Errorf("failed to record instance ID to file at '%s',instance will not be able to be deleted, "+
 			"%v", a.resourceTrackerDir, err)
 	}

--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2_test.go
@@ -1,0 +1,39 @@
+package aws
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+// generateKeyPair generates a new key pair
+func generateKeyPair() (*rsa.PrivateKey, *rsa.PublicKey) {
+	var bits = 2048
+	privKey, _ := rsa.GenerateKey(rand.Reader, bits)
+	return privKey, &privKey.PublicKey
+}
+
+// encryptWithPublicKey encrypts data with public key
+func encryptWithPublicKey(msg []byte, pub *rsa.PublicKey) []byte {
+	ciphertext, _ := rsa.EncryptPKCS1v15(rand.Reader, pub, msg)
+	return ciphertext
+}
+
+// TestRSADecrypt tests rsaDecrypt function which  decrypts the given encrypted data
+func TestRSADecrypt(t *testing.T) {
+	privKey, publicKey := generateKeyPair()
+	msg := "abcdefghijklmnopqrstuvwxyz"
+	encryptedData := encryptWithPublicKey([]byte(msg), publicKey)
+	privKeyBytes := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+		},
+	)
+	decryptedMsg, _ := rsaDecrypt(encryptedData, privKeyBytes)
+	if string(decryptedMsg) != msg {
+		t.Fatalf("Error decrypting message expected %v got %v", msg, decryptedMsg)
+	}
+}

--- a/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
@@ -682,7 +682,7 @@ func (az *AzureProvider) CreateWindowsVM() (*types.Credentials, error) {
 		log.Info(fmt.Sprintf("Please Check for file %s in %s directory on how to access the node",
 			instanceName, az.resourceTrackerDir))
 	}
-	credentials := types.NewCredentials("", *ipAddress, adminPassword)
+	credentials := types.NewCredentials(instanceName, *ipAddress, adminPassword)
 	return credentials, nil
 }
 

--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -1,0 +1,36 @@
+package types
+
+// This package should have the types that will be used by component. For example, aws should have it's own
+// sub-package
+// TODO: Move every cloud provider types here
+
+// Credentials holds the information to access the Windows instance created.
+type Credentials struct {
+	// instanceID uniquely identifies the instanceID
+	instanceID string
+	// ipAddress contains the public ipaddress of the instance created
+	ipAddress string
+	// password to access the instance created
+	password string
+}
+
+// NewCredentials takes the instanceID, ipaddress and password of the Windows instance created and returns the
+// Credentials structure
+func NewCredentials(instanceID, ipAddress, password string) *Credentials {
+	return &Credentials{instanceID: instanceID, ipAddress: ipAddress, password: password}
+}
+
+// GetIPAddress returns the ipaddress of the given node
+func (cred *Credentials) GetIPAddress() string {
+	return cred.ipAddress
+}
+
+// GetPassword returns the password associated with the given node
+func (cred *Credentials) GetPassword() string {
+	return cred.password
+}
+
+// GetInstanceID returns the instanceId associated with the given node
+func (cred *Credentials) GetInstanceId() string {
+	return cred.instanceID
+}

--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -8,19 +8,19 @@ package types
 type Credentials struct {
 	// instanceID uniquely identifies the instanceID
 	instanceID string
-	// ipAddress contains the public ipaddress of the instance created
+	// ipAddress contains the public ip address of the instance created
 	ipAddress string
 	// password to access the instance created
 	password string
 }
 
-// NewCredentials takes the instanceID, ipaddress and password of the Windows instance created and returns the
+// NewCredentials takes the instanceID, ip address and password of the Windows instance created and returns the
 // Credentials structure
 func NewCredentials(instanceID, ipAddress, password string) *Credentials {
 	return &Credentials{instanceID: instanceID, ipAddress: ipAddress, password: password}
 }
 
-// GetIPAddress returns the ipaddress of the given node
+// GetIPAddress returns the ip address of the given node
 func (cred *Credentials) GetIPAddress() string {
 	return cred.ipAddress
 }


### PR DESCRIPTION
As of now, we're not providing information to the user
who ran aws wni to access the Windows VM created, this
commit address that problem. We're now printing the
password to access the Windows VM created along with
the public ipadress. We're also adding a new top level
package called types, whose intention is to hold all
the structures that we need to be used across multiple
cloud providers.

/cc @aravindhp @Bowenislandsong @leonjia0112 @vinaykns 