### PR TITLE
Bug 1760536: [wsu] Fixing kubelet path

### DIFF
--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -34,8 +34,8 @@
 
         - name: Grab kubelet from extracted directories
           copy:
-            src: "./tmp/kubernetes/node/bin/kubelet.exe"
-            dest: "./tmp/kubelet.exe"
+            src: "{{ tmp_dir.path }}/kubernetes/node/bin/kubelet.exe"
+            dest: "{{ tmp_dir.path }}/kubelet.exe"
 
 - hosts: win
   vars:


### PR DESCRIPTION
This commit fixes a bug, where the kubelet exe is not being
copied to the same directory as the rest of the required wmcb files