### PR TITLE
[wni] Increase tools e2e test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-tools:
 
 .PHONY: test-e2e-tools
 test-e2e-tools:
-	$(GO_BUILD_ARGS) go test $(TOOLS_DIR)/test/e2e/... -v
+	$(GO_BUILD_ARGS) go test $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
 
 .PHONY: verify-all
 # TODO: Add other verifications


### PR DESCRIPTION
The default timeout for  `go test` is 10min causing
the tests to timeout in our CI. This commit should
address that issue. We're now increasing the
timeout to 20 minutes to ensure that aws-sdk
can return the password generated for us. The
maximum suggested wait time as per aws-sdk
for the GetPassword function is 15min, so we
should be good. 

PR #52 depends on this.