### PR TITLE
[wmcb] Add Makefile target for unit test binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build build-tools verify-all
+all: build build-tools build-wmcb-unit-test verify-all
 
 PACKAGE=github.com/openshift/windows-machine-config-operator
 MAIN_PACKAGE=$(PACKAGE)/cmd/bootstrapper
@@ -14,11 +14,12 @@ GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on
 build:
 	$(GO_BUILD_ARGS) GOOS=windows go build -o wmcb.exe  $(MAIN_PACKAGE)
 
+.PHONY: build-wmcb-unit-test
+build-wmcb-unit-test:
+	GOOS=windows GOFLAGS=-v go test -c ./pkg/... -o wmcb_unit_test.exe
+
 test-e2e-prepared-node:
 	GOOS=windows go test -run=TestBootstrapper ./test/e2e
-
-test-unit:
-	go test ./pkg/...
 
 .PHONY: build-tools
 build-tools:

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,19 @@ Repeat the above steps for the `system:node:$NODE_NAME` csr which will appear sh
 
 You can now do `oc get nodes`, and see the Windows node has joined the cluster.
 
+#### Unit testing
+
+On your Linux development machine, build the unit test binary:
+```
+make build-wmcb-unit-test
+```
+This will build a binary called `wmcb_unit_test.exe`. Copy this binary to a Windows node and execute it. The expected
+output should be as follows:
+```
+PS C:\wmcb> .\wmcb_test.exe
+PASS
+```
+
 ### Ansible
 
 Follow the instructions in `tools/ansible/README.md`, and ensure the playbook completes successfully.


### PR DESCRIPTION
- Add a Makefile target called "build-wmcb-unit-test", that will build a Windows unit test binary
- Update the README with instructions on how to run unit tests