### PR TITLE
[ci] Add placeholder script and target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ build-tools:
 test-e2e-tools:
 	$(GO_BUILD_ARGS) go test $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
 
+.PHONY: run-wmcb-ci-e2e-test
+run-wmcb-ci-e2e-test:
+	hack/run-wmcb-ci-e2e-test.sh
+
 .PHONY: verify-all
 # TODO: Add other verifications
 verify-all:

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO: Add steps to execute code that will kick off the e2e tests in CI
+
+exit 0


### PR DESCRIPTION
- Add a Makefile target that will end up getting called by the CI job for running our e2e tests
- Add a placeholder script that will kick off the e2e tests