### PR TITLE
[wni] fix wni aws output

### DIFF
--- a/tools/windows-node-installer/cmd/aws.go
+++ b/tools/windows-node-installer/cmd/aws.go
@@ -39,9 +39,6 @@ func newAWSCmd() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return requiredAWSFlags(cmd)
 		},
-		Run: func(_ *cobra.Command, args []string) {
-			fmt.Println(args)
-		},
 	}
 	awsCmd.PersistentFlags().StringVar(&awsInfo.credentialPath, "credentials", "",
 		"file path to the cloud provider credentials of the existing OpenShift cluster (required)")


### PR DESCRIPTION
As of now, we're printing valid flags when an invalid argument
is being passed to wni, for example,  would
not throw an error but valid flag list will be printed. If
those arguments are passed, since it passed the validation
stage, we'd not get an error. This commit removes the
printing of valid flags when the command is run. It'd
rather an error with valid commands available.

The output with this commit:

```
./wni aws delete --kubeconfig kubeconfig --credentials credentials --credential-account xyz 
Create and destroy windows instances in aws

Usage:
  wni aws [command]

Available Commands:
  create      Create a Windows instance on the same provider as the existing OpenShift Cluster.
  destroy     Destroy all security groups and instances specified in 'windows-node-installer.json' file.

Flags:
      --credential-account string   account name of a credential used to create the OpenShift Cluster specified in the provider's credentials file (required)
      --credentials string          file path to the cloud provider credentials of the existing OpenShift cluster (required)
  -h, --help                        help for aws

Global Flags:
      --dir string          directory to save or read windows-node-installer.json file from (default ".")
      --kubeconfig string   file path to the kubeconfig of the existing OpenShift cluster (required)
      --log-level string    log level (e.g. 'info') (default "info")

Use "wni aws [command] --help" for more information about a command.
```

Note that this is `delete` is not a valid command

without this commit:

```
./wni aws delete --kubeconfig kubeconfig --credentials credentials --credential-account xyz
[delete]
```