### PR TITLE
[wmcb] Rename "run" command to "configure-kubelet"

### DIFF
--- a/cmd/bootstrapper/configure_kubelet.go
+++ b/cmd/bootstrapper/configure_kubelet.go
@@ -9,11 +9,11 @@ import (
 )
 
 var (
-	runCmd = &cobra.Command{
-		Use:   "run",
-		Short: "Runs the Windows Machine Config Bootstrapper",
+	initializeKubeletCmd = &cobra.Command{
+		Use:   "initialize-kubelet",
+		Short: "Initializes the kubelet service on the Windows node",
 		Long:  "",
-		Run:   runRunCmd,
+		Run:   runInitializeKubeletCmd,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			err := cmd.MarkPersistentFlagRequired("ignition-file")
 			if err != nil {
@@ -38,17 +38,17 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(runCmd)
-	runCmd.PersistentFlags().StringVar(&runOpts.ignitionFile, "ignition-file", "",
-		"Ignition file location to bootstrap the windows node")
-	runCmd.PersistentFlags().StringVar(&runOpts.kubeletPath, "kubelet-path", "",
-		"Kubelet file location to bootstrap the windows node")
-	runCmd.PersistentFlags().StringVar(&runOpts.installDir, "install-dir", "c:\\k",
-		"Kubelet file location to bootstrap the windows node. Defaults to C:\\k")
+	rootCmd.AddCommand(initializeKubeletCmd)
+	initializeKubeletCmd.PersistentFlags().StringVar(&runOpts.ignitionFile, "ignition-file", "",
+		"Ignition file location to bootstrap the Windows node")
+	initializeKubeletCmd.PersistentFlags().StringVar(&runOpts.kubeletPath, "kubelet-path", "",
+		"Kubelet file location to bootstrap the Windows node")
+	initializeKubeletCmd.PersistentFlags().StringVar(&runOpts.installDir, "install-dir", "c:\\k",
+		"Kubelet file location to bootstrap the Windows node. Defaults to C:\\k")
 }
 
-// runRunCmd starts the windows machine config bootstrapper
-func runRunCmd(cmd *cobra.Command, args []string) {
+// runInitializeKubeletCmd starts the Windows Machine Config Bootstrapper
+func runInitializeKubeletCmd(cmd *cobra.Command, args []string) {
 	flag.Parse()
 	// TODO: add validation for flags
 
@@ -58,7 +58,7 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = wmcb.Run()
+	err = wmcb.InitializeKubelet()
 	if err != nil {
 		log.Error(err, "could not run bootstrapper")
 		os.Exit(1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ make build
 ```
 
 ```
-wmcb run --ignition-file $IGNITION_FILE_PATH --kubelet-path $KUBELET_PATH
+wmcb configure-kubelet --ignition-file $IGNITION_FILE_PATH --kubelet-path $KUBELET_PATH
 ```
 
 ## Testing

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -247,8 +247,8 @@ func (wmcb *winNodeBootstrapper) parseIgnitionFileContents(ignitionFileContents 
 	return nil
 }
 
-// Initializes the kubelet after copying the kubelet to the desired location
-func (wmcb *winNodeBootstrapper) initializeKubelet() error {
+// initializeKubeletFiles initializes the files required by the kubelet
+func (wmcb *winNodeBootstrapper) initializeKubeletFiles() error {
 	filesToTranslate := map[string]fileTranslation{
 		"/etc/kubernetes/kubelet.conf": {
 			dest:            wmcb.kubeletConfPath,
@@ -418,9 +418,9 @@ func (wmcb *winNodeBootstrapper) refreshServiceManager() error {
 	return err
 }
 
-// TODO: add OVN service start here as well
-// Run runs the bootstrapper. It sets up the install directory, creates the kubelet service, and then starts the kubelet service
-func (wmcb *winNodeBootstrapper) Run() error {
+// InitializeKubelet performs the initial kubelet configuration. It sets up the install directory, creates the kubelet
+// service, and then starts the kubelet service
+func (wmcb *winNodeBootstrapper) InitializeKubelet() error {
 	var err error
 	if wmcb.kubeletSVC != nil {
 		// if the kubelet service exists, we silently remove it and continue, to preserve idempotency
@@ -434,7 +434,7 @@ func (wmcb *winNodeBootstrapper) Run() error {
 			return err
 		}
 	}
-	err = wmcb.initializeKubelet()
+	err = wmcb.initializeKubeletFiles()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change is in preparation for splitting the wmcb functionality into two parts. One part will perform the initial kubelet configuration. The second part will configure OVN CNI.

No new functionality has been added in this commit.