### PR TITLE
Bug 1768568: [logging] Allow redirects for Ruby installer download

### DIFF
--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -7,6 +7,11 @@
     - If you are using a cloud provider, you may have to add a tag to the Windows instance.
       It will be of the format `key:kubernetes.io/cluster/<infraID>` with `value: owned`.
       - You can find the infraID in the Ignition config file metadata `metadata.json`
+- Ansible 2.9 and pywinrm installed, and selinux bindings exist on the system
+```
+sudo dnf install libselinux-python
+pip install selinux ansible==2.9 pywinrm
+```
 - A `hosts` file with the required variables defined. See below for an example:
 ```
 [win]

--- a/tools/ansible/tasks/logging/install_fluentd.yml
+++ b/tools/ansible/tasks/logging/install_fluentd.yml
@@ -10,6 +10,8 @@
   win_get_url:
     url: "{{ ruby_fetch_url }}"
     dest: "{{ tempdir_win.path }}\\"
+    # Requires Ansible version 2.9
+    follow_redirects: all
   register: ruby_devkit
 - name: Check install path
   win_stat:


### PR DESCRIPTION
Currently the module that downloads Ruby installer does not allow redirects,
hence the download does not complete successfully in some cases.
This commit allows the module to accept redirects to solve that problem.
Note: This requires Ansible version 2.9 or higher.