### PR TITLE
Dockerfile for CI

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,25 @@
+# This image will be used in OpenShift CI so that we can run tests which require more utilities
+# than the default golang image has to offer
+
+FROM centos:centos8
+
+# Download and install Go
+RUN curl -L -s https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz > go1.13.4.linux-amd64.tar.gz \
+    && sha256sum go1.13.4.linux-amd64.tar.gz \
+    && echo "692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c go1.13.4.linux-amd64.tar.gz" | sha256sum -c \
+    && tar -xzf go1.13.4.linux-amd64.tar.gz \
+    && mv go /usr/local \
+    && rm -rf ./go*
+
+# Download and install oc
+RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/openshift-client-linux-4.2.2.tar.gz -o openshift-origin-client-tools.tar.gz \
+    && echo "8f853477fa99cfc4087ad2ddf9b13b9d22e5fc4d5dc24c63ec5b0a91bb337fc9 openshift-origin-client-tools.tar.gz" | sha256sum -c \
+    && tar -xzf openshift-origin-client-tools.tar.gz \
+    && mv oc /usr/bin/oc \
+    && mv kubectl /usr/bin/kubectl \
+    && rm -rf ./openshift* \
+    && oc version
+
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="/usr/local/go"
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This commit includes a dockerfile which we can use for test running
within OpenShift CI. This is an attempt to fix the issues we are seeing
with the current CI image, that we cannot install packages in our test
containers, which need ansible and OC. I have opted to not install
ansible, as not all containers need ansible installed, and that can be
done within the individual tests that need it.

This is not guaranteed to work, as the image requirements in the CI docs
are somewhat vague, and its possible that this dockerfile is missing a
CI requirement that is unknown. This can changed in a future commit,
however it is worthwhile to see if this image is usable for our CI jobs
in its current state.