### PR TITLE
[wmcb] Fix e2e tests that reference "run"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build build-tools build-wmcb-unit-test verify-all
+all: build build-tools build-wmcb-unit-test build-wmcb-e2e-test verify-all
 
 PACKAGE=github.com/openshift/windows-machine-config-operator
 MAIN_PACKAGE=$(PACKAGE)/cmd/bootstrapper
@@ -17,6 +17,10 @@ build:
 .PHONY: build-wmcb-unit-test
 build-wmcb-unit-test:
 	$(GO_BUILD_ARGS) GOOS=windows GOFLAGS=-v go test -c ./pkg/... -o wmcb_unit_test.exe
+
+.PHONY: build-wmcb-e2e-test
+build-wmcb-e2e-test:
+	$(GO_BUILD_ARGS) GOOS=windows GOFLAGS=-v go test -c ./test/e2e... -o wmcb_e2e_test.exe
 
 test-e2e-prepared-node:
 	$(GO_BUILD_ARGS) GOOS=windows go test -run=TestBootstrapper ./test/e2e

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,13 +30,22 @@ wmcb initialize-kubelet --ignition-file $IGNITION_FILE_PATH --kubelet-path $KUBE
 
 ### Windows Machine Config Bootstrapper
 
+#### End to end testing
+
 On an existing Windows instance which is ready to join the cluster, copy the worker ignition file to C:\Windows\Temp\worker.ign, and the kubelet to C:\Windows\Temp\kubelet.exe
 
-On the Windows instance, run:
+On your Linux development machine, build the e2e test binary:
 ```
-make test-e2e-prepared-node
+make build-wmcb-e2e-test
 ```
-If the test passes:
+This will build a binary called `wmcb_e2e_test.exe`. Copy this binary to the Windows node and execute it. The expected
+output should be as follows:
+```
+PS C:\wmcb> .\wmcb_e2e_test.exe
+PASS
+```
+If the test passes run the following on your Linux development machine that has access to the cluster where the Windows
+node is present:
 ```
 oc get csr
 ```

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -53,7 +53,7 @@ func TestBootstrapper(t *testing.T) {
 	// Run the bootstrapper, which will start the kubelet service
 	wmcb, err := bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath)
 	assert.Nilf(t, err, "Could not create WinNodeBootstrapper: %s", err)
-	err = wmcb.Run()
+	err = wmcb.InitializeKubelet()
 	assert.Nilf(t, err, "Could not run bootstrapper: %s", err)
 	err = wmcb.Disconnect()
 	assert.Nilf(t, err, "Could not disconnect from windows svc API: %s", err)
@@ -77,7 +77,7 @@ func TestBootstrapper(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	wmcb, err = bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath)
 	assert.Nilf(t, err, "Could not create WinNodeBootstrapper: %s", err)
-	err = wmcb.Run()
+	err = wmcb.InitializeKubelet()
 	assert.Nilf(t, err, "Could not run bootstrapper: %s", err)
 	err = wmcb.Disconnect()
 	assert.Nilf(t, err, "Could not disconnect from windows svc API: %s", err)


### PR DESCRIPTION
Replace "run" with "initialize-kubelet" that was introduced in #70.