### PR TITLE
[wni][azure] Enable and configure the winrm port for windows node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build-tools:
 .PHONY: test-e2e-tools
 test-e2e-tools:
 	cd ./tools/windows-node-installer && $(GO_BUILD_ARGS) go test $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
+	$(GO_BUILD_ARGS) go test -run=TestAwsE2eSerial $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
 
 .PHONY: run-wmcb-ci-e2e-test
 run-wmcb-ci-e2e-test:

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ build-tools:
 
 .PHONY: test-e2e-tools
 test-e2e-tools:
-	cd ./tools/windows-node-installer && $(GO_BUILD_ARGS) go test $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
-	$(GO_BUILD_ARGS) go test -run=TestAwsE2eSerial $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
+	cd ./tools/windows-node-installer && $(GO_BUILD_ARGS) go test -run=TestAwsE2eSerial $(TOOLS_DIR)/test/e2e/... -timeout 20m -v
 
 .PHONY: run-wmcb-ci-e2e-test
 run-wmcb-ci-e2e-test:

--- a/tools/windows-node-installer/README.md
+++ b/tools/windows-node-installer/README.md
@@ -93,12 +93,15 @@ Sample Delete Command:
 --dir ./windowsnodeinstaller/
 ```
 
-### e2e Test
+
+### End to end testing
 The e2e test for azure run under the assumption that Windows instance is already created and the instanceId's,
 subnetGroupId's are present in the windows-node-installer.json file in `--dir`. Currently it tests if `winRM` port is opened on the
 worker subnet and can ansible can execute remote commands on the Windows node.
 
 To run the e2e do:
 ```bash
- go test -run=TestWinRMSetup github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/test/e2e/... -v
+export PACKAGE=github.com/openshift/windows-machine-config-operator
+export TOOLS_DIR=$PACKAGE/tools/windows-node-installer
+go test -run=TestWinRMSetup $TOOLS_DIR/test/e2e/... -v
 ```    

--- a/tools/windows-node-installer/README.md
+++ b/tools/windows-node-installer/README.md
@@ -92,3 +92,13 @@ Sample Delete Command:
 ./wni azure destroy --kubeconfig ~/OpenShift/azure/auth/kubeconfig --credentials ~/.azure/osServicePrincipal.json \
 --dir ./windowsnodeinstaller/
 ```
+
+### e2e Test
+The e2e test for azure run under the assumption that Windows instance is already created and the instanceId's,
+subnetGroupId's are present in the windows-node-installer.json file in `--dir`. Currently it tests if `winRM` port is opened on the
+worker subnet and can ansible can execute remote commands on the Windows node.
+
+To run the e2e do:
+```bash
+ go test -run=TestWinRMSetup github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/test/e2e/... -v
+```    

--- a/tools/windows-node-installer/README.md
+++ b/tools/windows-node-installer/README.md
@@ -104,4 +104,4 @@ To run the e2e do:
 export PACKAGE=github.com/openshift/windows-machine-config-operator
 export TOOLS_DIR=$PACKAGE/tools/windows-node-installer
 go test -run=TestWinRMSetup $TOOLS_DIR/test/e2e/... -v
-```    
+```

--- a/tools/windows-node-installer/go.sum
+++ b/tools/windows-node-installer/go.sum
@@ -32,6 +32,10 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aws/aws-sdk-go v1.23.2 h1:QSdnxlC29v6b2+C6mkriHhElh02ZlsRBoPX15SOZ6jU=
 github.com/aws/aws-sdk-go v1.23.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -29,21 +30,21 @@ const (
 	// winRmPriority value
 	winRMPriority = 300
 	// winRM action type
-	winRmAction = "Allow"
+	winRMAction = "Allow"
 )
 
 // azureProvider stores Azure clients and resourceGroupName to access the windows node.
 type azureProvider struct {
 	// resourceGroupName of the Windows node
 	resourceGroupName string
-	// network security group client to check if winRmHttps port is opened or not.
+	// nsgClient to check if winRmHttps port is opened or not.
 	nsgClient network.SecurityGroupsClient
-	// vm client to check for ansible ping on the windows node.
+	// vmClient to check for ansible ping on the windows node.
 	vmClient compute.VirtualMachinesClient
 }
 
 var (
-	// get the azure Auth Credentials specified from the env variable.
+	// get the azureCredentials from the env variable "AZURE_AUTH_LOCATION".
 	azureCredentials = os.Getenv("AZURE_AUTH_LOCATION")
 	// variable to be used for running the tests
 	azureInfo = azureProvider{}
@@ -70,8 +71,6 @@ func isNil(v interface{}) bool {
 
 // setup initializes the azureProvider to be used for running the tests.
 func setup() (err error) {
-	var vmClientPtr *compute.VirtualMachinesClient
-	var nsgClientPtr *network.SecurityGroupsClient
 	oc, err := client.GetOpenShift(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize OpenShift client with error: %v", err)
@@ -86,23 +85,15 @@ func setup() (err error) {
 	}
 	getFileSettings, err := auth.GetSettingsFromFile()
 	if err != nil {
-		return fmt.Errorf("failed to get info from AZURE_AUTH_LOCATION with error: %v", err)
+		return fmt.Errorf("failed to get info from %s with error: %v", azureCredentials, err)
 	}
 	subscriptionId := getFileSettings.GetSubscriptionID()
 	if subscriptionId == "" {
-		return fmt.Errorf("failed to get the subscriptionId from the AZURE_AUTH_LOCATION")
+		return fmt.Errorf("failed to get the subscriptionId from AZURE_AUTH_LOCATION: %s", azureCredentials)
 	}
 	vmClient := compute.NewVirtualMachinesClient(subscriptionId)
-	vmClientPtr = &vmClient
-	if vmClientPtr == nil {
-		return fmt.Errorf("failed to initialize the vm client")
-	}
 	vmClient.Authorizer = resourceAuthorizer
 	nsgClient := network.NewSecurityGroupsClient(subscriptionId)
-	nsgClientPtr = &nsgClient
-	if nsgClientPtr == nil {
-		return fmt.Errorf("failed to initialize the network security group client")
-	}
 	nsgClient.Authorizer = resourceAuthorizer
 	azureInfo.resourceGroupName = provider.Azure.ResourceGroupName
 	azureInfo.vmClient = vmClient
@@ -113,10 +104,10 @@ func setup() (err error) {
 // readInstallerInfo reads the instanceIDs and secGroupsIDs from the
 // windows-node-installer.json file specified in "dir".
 func readInstallerInfo() (err error) {
-	wniFilePath := dir + "/windows-node-installer.json"
+	wniFilePath := filepath.Join(dir, "/windows-node-installer.json")
 	installerInfo, err := resource.ReadInstallerInfo(wniFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read installer info %s from ARTIFACT_DIR", dir)
+		return fmt.Errorf("failed to read installer info from %s with error: %v", dir, err)
 	}
 	if len(installerInfo.SecurityGroupIDs) == 0 {
 		return fmt.Errorf("failed to obtain the sec group Ids")
@@ -132,27 +123,21 @@ func readInstallerInfo() (err error) {
 // isWinRMPortOpen returns a bool response if winRmHttps port is opened on
 // windows instance or not.
 func isWinRMPortOpen(secGroupRules []network.SecurityRule) bool {
-	var secRulePropFormat network.SecurityRulePropertiesFormat
-	var destPortRange string
-	var access network.SecurityRuleAccess
-	var protocol network.SecurityRuleProtocol
-	var priority int32
-	var sourceAddressPrefix string
 	for _, secGroupRule := range secGroupRules {
 		if isNil(secGroupRule.SecurityRulePropertiesFormat) {
 			continue
 		}
-		secRulePropFormat = *(secGroupRule.SecurityRulePropertiesFormat)
+		secRulePropFormat := *(secGroupRule.SecurityRulePropertiesFormat)
 		if isNil(secRulePropFormat.DestinationPortRange) || isNil(secRulePropFormat.Priority) ||
 			isNil(secRulePropFormat.SourceAddressPrefix) {
 			continue
 		}
-		destPortRange = *(secRulePropFormat.DestinationPortRange)
-		protocol = secRulePropFormat.Protocol
-		access = secRulePropFormat.Access
-		priority = *(secRulePropFormat.Priority)
-		sourceAddressPrefix = *(secRulePropFormat.SourceAddressPrefix)
-		if destPortRange == winRM && access == winRmAction && protocol == winRMProtocol &&
+		destPortRange := *(secRulePropFormat.DestinationPortRange)
+		protocol := secRulePropFormat.Protocol
+		access := secRulePropFormat.Access
+		priority := *(secRulePropFormat.Priority)
+		sourceAddressPrefix := *(secRulePropFormat.SourceAddressPrefix)
+		if destPortRange == winRM && access == winRMAction && protocol == winRMProtocol &&
 			priority == winRMPriority && len(sourceAddressPrefix) != 0 {
 			return true
 		}
@@ -168,15 +153,13 @@ func testWinRmPort(t *testing.T) {
 	require.NoError(t, err, "failed to initialize azureProvider")
 	err = readInstallerInfo()
 	require.NoError(t, err, "failed to get info from wni file")
-	var secGroupPropFormat network.SecurityGroupPropertiesFormat
-	var secGroupRules []network.SecurityRule
 	for _, nsgName := range secGroupsIDs {
 		secGroupProfile, err := azureInfo.nsgClient.Get(ctx, azureInfo.resourceGroupName, nsgName, "")
-		assert.NoError(t, err, "failed to get the network security group profile")
-		assert.NotNil(t, secGroupProfile.SecurityGroupPropertiesFormat, "failed to get the security group properties format")
-		secGroupPropFormat = *(secGroupProfile.SecurityGroupPropertiesFormat)
-		assert.NotNil(t, secGroupProfile.SecurityRules, "failed to get the security rules list")
-		secGroupRules = *(secGroupPropFormat.SecurityRules)
+		require.NoError(t, err, "failed to get the network security group profile")
+		require.NotEmpty(t, secGroupProfile.SecurityGroupPropertiesFormat, "failed to get the security group properties format")
+		secGroupPropFormat := *(secGroupProfile.SecurityGroupPropertiesFormat)
+		require.NotEmpty(t, secGroupProfile.SecurityRules, "failed to get the security rules list")
+		secGroupRules := *(secGroupPropFormat.SecurityRules)
 		assert.True(t, isWinRMPortOpen(secGroupRules), "winRmHttps port is not opened")
 	}
 }
@@ -201,26 +184,25 @@ ansible_winrm_server_cert_validation=ignore`, ip, password, winRM))
 
 // testAnsiblePing checks if ansible is able to ping on opened winRmHttps port
 func testAnsiblePing(t *testing.T) {
+	// this regex looks for the IP address pattern from vmCredentialPath.
+	// the sample vmCredentialPath looks like xfreerdp /u:xxxx /v:xx.xx.xx.xx /h:1080 /w:1920 /p:'password1234'
+	ipAddressPattern := regexp.MustCompile(`\d+.\d+.\d+.\d+`)
+	// the passwordPattern extracts the characters present after the '/p:', but we are extracting
+	// 13 characters even though the windows password length is of size 12 because we got a single quote
+	// character included in the password.
+	passwordPattern := regexp.MustCompile(`/p:.{13}`)
 	for _, vmName := range instanceIDs {
-		vmRDPFilePath := dir + "/" + vmName
-		b, err := ioutil.ReadFile(vmRDPFilePath)
+		vmCredentialPath := filepath.Join(dir, "/", vmName)
+		b, err := ioutil.ReadFile(vmCredentialPath)
 		assert.NoError(t, err, "failed to read file %s", vmName)
-		// this regex looks for the IP address pattern from vmRDPFilePath.
-		// the sample vmRDPFilePath looks like xfreerdp /u:xxxx /v:xx.xx.xx.xx /h:1080 /w:1920 /p:'password1234'
-		ipAddressPattern := regexp.MustCompile(`\d+.\d+.\d+.\d+`)
 		ipAddress := ipAddressPattern.FindString(string(b))
-		// the passwordPattern extracts the characters present after the '/p:', but we are extracting
-		// 13 characters even though the windows password length is of size 12 because we got a single quote
-		// character included in the password.
-		passwordPattern := regexp.MustCompile(`/p:.{13}`)
 		password := passwordPattern.FindString(string(b))[3:]
 		// we are trimming out the unnecessary single quotes.
 		password = strings.Trim(password, `'`)
 		hostFileName, err := createHostFile(ipAddress, password)
-		assert.NoError(t, err, "failed to create a temp file")
-		cmd := exec.Command("ansible", "win", "-i", hostFileName, "-m", "win_ping", "-vvvv")
+		require.NoError(t, err, "failed to create a temp file")
+		cmd := exec.Command("ansible", "win", "-i", hostFileName, "-m", "win_ping")
 		out, err := cmd.CombinedOutput()
-		assert.NoError(t, err, "failed to execute the ansible ping check %s", string(out))
-
+		assert.NoError(t, err, "ansible ping check failed with error: %s", string(out))
 	}
 }

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -26,7 +26,7 @@ const (
 	// winRm Https port for the Windows node.
 	winRM = "5986"
 	// winRm protocol type.
-	winRMProtocol = "TCP"
+	winRMProtocol = "Tcp"
 	// winRmPriority value
 	winRMPriority = 300
 	// winRM action type
@@ -44,9 +44,9 @@ type azureProvider struct {
 }
 
 var (
-	// get the azureCredentials from the env variable "AZURE_AUTH_LOCATION".
+	// azureCredentials is the location of the env variable "AZURE_AUTH_LOCATION".
 	azureCredentials = os.Getenv("AZURE_AUTH_LOCATION")
-	// variable to be used for running the tests
+	// azureInfo initializes the azureProvider type, holds the info to drive the tests.
 	azureInfo = azureProvider{}
 	// instanceIDs that are obtained from the windows-node-installer.json
 	instanceIDs []string
@@ -194,7 +194,7 @@ func testAnsiblePing(t *testing.T) {
 	for _, vmName := range instanceIDs {
 		vmCredentialPath := filepath.Join(dir, "/", vmName)
 		b, err := ioutil.ReadFile(vmCredentialPath)
-		assert.NoError(t, err, "failed to read file %s", vmName)
+		require.NoError(t, err, "failed to read file %s", vmName)
 		ipAddress := ipAddressPattern.FindString(string(b))
 		assert.NotEmpty(t, ipAddress, "the IP address can't be empty")
 		password := passwordPattern.FindString(string(b))[3:]

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -1,0 +1,197 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-04-01/network"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/client"
+	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/resource"
+)
+
+const (
+	// winRm Https port for the Windows node.
+	winRmPortHttps = "5986"
+	// winRm Protocol type
+	winRmProtocol = "TCP"
+	// winRM action type
+	winRmAction = "Allow"
+	// winRmPriority value
+	winRmPriority = 300
+)
+
+// azureProvider stores Azure clients and resourceGroupName to access the windows node.
+type azureProvider struct {
+	// resourceGroupName of the Windows node
+	resourceGroupName string
+	// network security group client to check if winRmHttps port is opened or not.
+	nsgClient network.SecurityGroupsClient
+	// vm client to check for ansible ping on the windows node.
+	vmClient compute.VirtualMachinesClient
+}
+
+var (
+	// get the azure Auth Credentials specified from the env variable.
+	azureCredentials = os.Getenv("AZURE_AUTH_LOCATION")
+	// variable to be used for running the tests
+	azureInfo = azureProvider{}
+	// instanceIDs that are obtained from the windows-node-installer.json
+	instanceIDs []string
+	// secGroupIDs that are obtained from the windows-node-installer.json
+	secGroupsIDs []string
+)
+
+// TestWinRMSetup runs two tests i.e checks if the winRMHttps port is opened or not and
+// other test does an ansible ping check to confirm that windows node is correctly
+// configured to execute the remote ansible commands.
+func TestWinRMSetup(t *testing.T) {
+	setupAzureClients(t)
+	readInstallerInfo(t)
+	t.Run("check if WinRmHttps port is opened in the inbound security group rules list", testWinRmPort)
+	t.Run("check if ansible is able to ping on the WinRmHttps port", testAnsiblePing)
+}
+
+// checkForNil is a helper functions which checks if the object is a nil pointer or not.
+func checkForNil(v interface{}) bool {
+	return v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr &&
+		reflect.ValueOf(v).IsNil())
+}
+
+// setupAzureClients basically initializes the azure clients to be used in the tests.
+func setupAzureClients(t *testing.T) {
+	oc, err := client.GetOpenShift(kubeconfig)
+	require.NoError(t, err, "failed to initialize OpenShift client")
+	provider, err := oc.GetCloudProvider()
+	require.NoError(t, err, "failed to get cloud provider information")
+	resourceAuthorizer, err := auth.NewAuthorizerFromFileWithResource(azure.PublicCloud.ResourceManagerEndpoint)
+	require.NoError(t, err, "failed to get azure authorization token")
+	getFileSettings, err := auth.GetSettingsFromFile()
+	require.NoError(t, err, "failed to get info from AZURE_AUTH_LOCATION")
+	subscriptionId := getFileSettings.GetSubscriptionID()
+	vmClient := compute.NewVirtualMachinesClient(subscriptionId)
+	vmClient.Authorizer = resourceAuthorizer
+	nsgClient := network.NewSecurityGroupsClient(subscriptionId)
+	nsgClient.Authorizer = resourceAuthorizer
+	azureInfo.resourceGroupName = provider.Azure.ResourceGroupName
+	azureInfo.vmClient = vmClient
+	azureInfo.nsgClient = nsgClient
+}
+
+// readInstallerInfo reads the instanceIDs and secGroupsIDs from the
+// windows-node-installer.json file specified in "dir".
+func readInstallerInfo(t *testing.T) {
+	filePath := dir + "/windows-node-installer.json"
+	installerInfo, err := resource.ReadInstallerInfo(filePath)
+	require.NoError(t, err, "failed to read from ARTIFACT_DIR")
+	secGroupsIDs = installerInfo.SecurityGroupIDs
+	instanceIDs = installerInfo.InstanceIDs
+}
+
+// checkForWinRmPort returns a bool response if winRmHttps port is opened on
+// windows instance or not.
+func checkForWinRmPort(t *testing.T, secGroupRules []network.SecurityRule) bool {
+	var secRulePropFormat network.SecurityRulePropertiesFormat
+	var destPortRange string
+	var access network.SecurityRuleAccess
+	var protocol network.SecurityRuleProtocol
+	var priority int32
+	var sourceAddressPrefix string
+	for _, secGroupRule := range secGroupRules {
+		if checkForNil(secGroupRule.SecurityRulePropertiesFormat) {
+			continue
+		}
+		secRulePropFormat = *(secGroupRule.SecurityRulePropertiesFormat)
+		if checkForNil(secRulePropFormat.DestinationPortRange) && checkForNil(secRulePropFormat.Priority) &&
+			checkForNil(secRulePropFormat.SourceAddressPrefix) {
+			continue
+		}
+		destPortRange = *(secRulePropFormat.DestinationPortRange)
+		protocol = secRulePropFormat.Protocol
+		access = secRulePropFormat.Access
+		priority = *(secRulePropFormat.Priority)
+		sourceAddressPrefix = *(secRulePropFormat.SourceAddressPrefix)
+		if destPortRange != winRmPortHttps && access != winRmAction && protocol != winRmProtocol &&
+			priority != winRmPriority && len(sourceAddressPrefix) == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// testWinRmPort checks if winRmHttps port is mentioned in the inbound security
+// group rules in the worker subnet.
+func testWinRmPort(t *testing.T) {
+	ctx := context.Background()
+	var secGroupPropFormat network.SecurityGroupPropertiesFormat
+	var secGroupRules []network.SecurityRule
+	for _, nsgName := range secGroupsIDs {
+		secGroupProfile, err := azureInfo.nsgClient.Get(ctx, azureInfo.resourceGroupName, nsgName, "")
+
+		assert.NoError(t, err, "failed to get the network security group profile")
+		if !checkForNil(secGroupProfile.SecurityGroupPropertiesFormat) {
+			secGroupPropFormat = *(secGroupProfile.SecurityGroupPropertiesFormat)
+		} else {
+			assert.FailNow(t, "failed to get the security group properties format")
+		}
+		if !checkForNil(secGroupPropFormat.SecurityRules) {
+			secGroupRules = *(secGroupPropFormat.SecurityRules)
+		} else {
+			assert.FailNow(t, "failed to get the security rules list")
+		}
+		assert.True(t, checkForWinRmPort(t, secGroupRules), "winRmHttps port is not opened")
+	}
+}
+
+// createhostFile creates an ansible host file and returns the path of it
+func createHostFile(ip, password string) (string, error) {
+	hostFile, err := ioutil.TempFile("", "test")
+	if err != nil {
+		return "", fmt.Errorf("coud not make temporary file: %s", err)
+	}
+	defer hostFile.Close()
+
+	_, err = hostFile.WriteString(fmt.Sprintf(`[win]
+%s ansible_password=%s
+[win:vars]
+ansible_user=core
+ansible_port=5986
+ansible_connection=winrm
+ansible_winrm_server_cert_validation=ignore`, ip, password))
+	return hostFile.Name(), err
+}
+
+// testAnsiblePing checks if ansible is able to ping on opened winRmHttps port
+func testAnsiblePing(t *testing.T) {
+	for _, vmName := range instanceIDs {
+		filePath := dir + "/" + vmName
+		b, err := ioutil.ReadFile(filePath)
+		assert.NoError(t, err, "failed to read file %s", vmName)
+		re := regexp.MustCompile(`\d+.\d+.\d+.\d+`)
+		ipAddress := re.FindString(string(b))
+		re = regexp.MustCompile(`/p:.{13}`)
+		password := re.FindString(string(b))[3:]
+		password = strings.Trim(password, `'`)
+		t.Logf("password is %s, the ip is %s", password, ipAddress)
+
+		hostFileName, err := createHostFile(ipAddress, password)
+		t.Logf("password is %s,", hostFileName)
+		assert.NoError(t, err, "failed to create a temp file")
+		cmd := exec.Command("ansible", "win", "-i", hostFileName, "-m", "win_ping", "-vvvv")
+		out, err := cmd.CombinedOutput()
+		assert.NoError(t, err, "failed to execute the ansible ping check %s", string(out))
+
+	}
+}

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -196,7 +196,9 @@ func testAnsiblePing(t *testing.T) {
 		b, err := ioutil.ReadFile(vmCredentialPath)
 		assert.NoError(t, err, "failed to read file %s", vmName)
 		ipAddress := ipAddressPattern.FindString(string(b))
+		assert.NotEmpty(t, ipAddress, "the IP address can't be empty")
 		password := passwordPattern.FindString(string(b))[3:]
+		assert.NotEmpty(t, password, "the password can't be empty")
 		// we are trimming out the unnecessary single quotes.
 		password = strings.Trim(password, `'`)
 		hostFileName, err := createHostFile(ipAddress, password)


### PR DESCRIPTION
This commit ensures that winrm Https port is opened on
the windows node and the custom script is executed to ensure
that ansible can talk to the windows node.