### PR TITLE
Add git to build_root dockerfile

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,6 +3,8 @@
 
 FROM centos:centos8
 
+RUN yum -y update && yum -y install git
+
 # Download and install Go
 RUN curl -L -s https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz > go1.13.4.linux-amd64.tar.gz \
     && sha256sum go1.13.4.linux-amd64.tar.gz \


### PR DESCRIPTION
This commit adds git to the dockerfile used for build_root in CI.
Without git, tests are failing.