### PR TITLE
Add make to build_root dockerfile

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,7 +3,7 @@
 
 FROM centos:centos8
 
-RUN yum -y update && yum -y install git
+RUN yum -y update && yum -y install git make
 
 # Download and install Go
 RUN curl -L -s https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz > go1.13.4.linux-amd64.tar.gz \


### PR DESCRIPTION
This commit adds make to the dockerfile used for build_root in CI.
Without make, tests are failing.