### PR TITLE
[logging] E2E tests for logging playbook

### DIFF
--- a/tools/ansible/tasks/logging/test/logging_test.go
+++ b/tools/ansible/tasks/logging/test/logging_test.go
@@ -1,18 +1,21 @@
 package test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Making this a map so that if we want a specific version, the value can be the version
 var requiredPluginList = map[string]string{
-	"elasticsearch-transport":                  "",
-	"elasticsearch-api":                        "",
-	"elasticsearch":                            "",
+	// Pinning down version of Fluentd to 1.5
+	"fluentd":                 "1.5",
+	"elasticsearch-transport": "",
+	"elasticsearch-api":       "",
+	"elasticsearch":           "",
 	"fluent-plugin-kubernetes_metadata_filter": "",
 	"fluent-plugin-concat":                     "",
 	"fluent-plugin-elasticsearch":              "",
@@ -25,7 +28,22 @@ var requiredPluginList = map[string]string{
 	"fluent-plugin-prometheus":                 "",
 }
 
-// TestPluginsInstalled tests that the fluentd plugins were all installed correctly.
+// TestRubyInstalled tests if Ruby is installed correctly
+// This test should be run on a node after the logging playbook has been run against it
+func TestRubyInstalled(t *testing.T) {
+	// Pinning down version of Ruby Devkit to 2.5.7, 64 bit version
+	// Ruby installation path assumed to be default
+	var rubyExecutablePath = "C:\\Ruby25-x64\\bin\\ruby.exe"
+	var rubyVersion = "2.5.7"
+	// exec.Command requires fully qualified path for ruby.exe
+	out, err := exec.Command(rubyExecutablePath, "--version").Output()
+	require.NoError(t, err)
+	// Grabbing the version of Ruby in the format 2.5.7
+	actualVersion := strings.Split(string(out), " ")[1][:5]
+	assert.Equalf(t, actualVersion, rubyVersion, "Ruby expected version %s, got %s", rubyVersion, actualVersion)
+}
+
+// TestPluginsInstalled tests that the fluentd and related plugins were all installed correctly.
 // This test should be run on a node after the logging playbook has been run against it
 func TestPluginsInstalled(t *testing.T) {
 	out, err := exec.Command("fluent-gem", "list").Output()
@@ -37,8 +55,16 @@ func TestPluginsInstalled(t *testing.T) {
 		installedVersion, ok := installedPlugins[pluginName]
 		assert.Truef(t, ok, "Missing plugin %s", pluginName)
 		if pluginVersion != "" {
-			assert.Equalf(t, pluginVersion, installedVersion,
-				"%s expected version: %s, got: %s", pluginName, pluginVersion, installedVersion)
+			// Test version specific to fluentd
+			if pluginName == "fluentd" {
+				// Matching only upto the minor version (ex 1.5), not the patch (ex 1.5.1) of Fluentd because
+				// current gem install of fluentd is upgrading to the latest patch
+				assert.Equalf(t, pluginVersion, installedVersion[:3],
+					"%s expected version: %s, got: %s", pluginName, pluginVersion, installedVersion)
+			} else {
+				assert.Equalf(t, pluginVersion, installedVersion,
+					"%s expected version: %s, got: %s", pluginName, pluginVersion, installedVersion)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit add the tests to ensure Ruby and Fluentd are installed correctly
The tests are meant to run on the Windows instance after the logging
playbook has been run successfully against it