### PR TITLE
Specify root user in Dockerfile.tools

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,6 +3,9 @@
 
 FROM centos:centos8
 
+# Setting the user to root so that future layers will not run into permission issues
+USER root
+
 RUN yum -y update && yum -y install git make
 
 # Download and install Go


### PR DESCRIPTION
This commit is an attempt to fix permission errors in CI. When using
this image, and running `make build` we run into:
`failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied`
This is paired with: openshift/release#5756