### PR TITLE
Specify gocache location in Dockerfile.tools

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,9 +3,6 @@
 
 FROM centos:centos8
 
-# Setting the user to root so that future layers will not run into permission issues
-USER root
-
 RUN yum -y update && yum -y install git make
 
 # Download and install Go
@@ -27,4 +24,8 @@ RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/o
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/usr/local/go"
+
+# This is being set to avoid permission errors in future layers
+ENV GOCACHE="/tmp/gocache"
+
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This commit is an attempt to fix permission errors in CI. When using
this image, and running `make build` we run into:
`failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied`
This is paired with: https://github.com/openshift/release/pull/5756

This commit also reverts the previous attempt to fix this:
https://github.com/openshift/windows-machine-config-operator/pull/81
as it did not have any effect on this issue.