### PR TITLE
Use go1.12.13 in Dockerfile.tools

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -6,10 +6,10 @@ FROM centos:centos8
 RUN yum -y update && yum -y install git make
 
 # Download and install Go
-RUN curl -L -s https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz > go1.13.4.linux-amd64.tar.gz \
-    && sha256sum go1.13.4.linux-amd64.tar.gz \
-    && echo "692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c go1.13.4.linux-amd64.tar.gz" | sha256sum -c \
-    && tar -xzf go1.13.4.linux-amd64.tar.gz \
+RUN curl -L -s https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz > go1.12.13.linux-amd64.tar.gz \
+    && sha256sum go1.12.13.linux-amd64.tar.gz \
+    && echo "da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc go1.12.13.linux-amd64.tar.gz" | sha256sum -c \
+    && tar -xzf go1.12.13.linux-amd64.tar.gz \
     && mv go /usr/local \
     && rm -rf ./go*
 


### PR DESCRIPTION
This commit switches from using go1.13 to go1.12, as the verify-gofmt
make target does not allow the use of go.13.
This is paired with: openshift/release#5756