### PR TITLE
[wmcb] Register kubelet with Windows taint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,18 @@ jobs that the bootstrapper does:
 - Ensures that the kubelet gets the correct kubelet config
 - Run the kubelet as a windows service
 
+Once the bootstrapper has been run and the CSR associated with the Windows node is approved, the Windows 
+node will have a taint called `os=Windows:NoSchedule`, only the pods with matching toleration can 
+be scheduled onto the Windows node. An example pod spec with the toleration would be:
+
+```
+tolerations:
+  - key: "os"
+    operator: "Equal"
+    value: "Windows"
+    effect: "NoSchedule"
+```
+
 This will be remotely invoked from a Ansible script or can be run locally
 
 ## Requirements

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -14,5 +14,5 @@ make build-wmcb-unit-test
 # Transfer the binary and run the unit tests
 cd "${INTERNAL_TEST_DIR}"
 CGO_ENABLED=0 GO111MODULE=on go test -c wmcb_test.go -o wmcb_framework
-./wmcb_framework -binaryToBeTransferred=../../wmcb_unit_test.exe
+./wmcb_framework -test.run=TestWMCBUnit -binaryToBeTransferred=../../wmcb_unit_test.exe
 

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -8,4 +8,7 @@ require (
 	github.com/pkg/sftp v1.10.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
+	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
+	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 )

--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -50,6 +50,18 @@ const (
 	certDirectory = "c:/var/lib/kubelet/pki/"
 	// cloudConfigOption is kubelet CLI option for cloud configuration
 	cloudConfigOption = "cloud-config"
+	// windowsTaints defines the taints that need to be applied on the Windows nodes.
+	/*
+			TODO: As of now, this is limited to os=Windows, so every Windows pod in
+			OpenShift cluster should have a toleration for this.
+			Example toleration in the pod spec:
+			tolerations:
+			  - key: "os"
+		      	operator: "Equal"
+		      	value: "Windows"
+		      	effect: "NoSchedule"
+	*/
+	windowsTaints = "os=Windows:NoSchedule"
 )
 
 // These regex are global, so that we only need to compile them once
@@ -298,6 +310,11 @@ func (wmcb *winNodeBootstrapper) createKubeletService() error {
 		"--windows-service",
 		"--logtostderr=false",
 		"--log-file=" + filepath.Join(wmcb.installDir, "kubelet.log"),
+		// Registers the Kubelet with Windows specific taints so that linux pods won't get scheduled onto
+		// Windows nodes.
+		// TODO: Write a `against the cluster` e2e test which checks for the Windows node object created
+		// and check for taint.
+		"--register-with-taints=" + windowsTaints,
 		// TODO: Uncomment this when we have a CNI solution
 		/*
 			network-plugin=cni",


### PR DESCRIPTION
As of now, linux pods can be scheduled onto Windows
VM because there is no taint on the node which will
prevent it. This commit addresses that problem
Also, updated the readme with a sample pod
spec for the Windows pods.

~~I'll add an e2e once I start working on the `against the cluster` test suite.~~

Added an e2e which will not be running yet.