### PR TITLE
Change Dockerfile.tools for new CI template

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,7 +3,9 @@
 
 FROM centos:centos8
 
-RUN yum -y update && yum -y install git make
+COPY . .
+
+RUN yum -y update && yum -y install git make python2 python2-pip
 
 # Download and install Go
 RUN curl -L -s https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz > go1.12.13.linux-amd64.tar.gz \
@@ -22,10 +24,10 @@ RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/o
     && rm -rf ./openshift* \
     && oc version
 
+# Install ansible and required packages
+RUN pip2 install --user ansible pywinrm
+
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/usr/local/go"
-
-# This is being set to avoid permission errors in future layers
-ENV GOCACHE="/tmp/gocache"
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -10,10 +10,6 @@ TEST_DIR=$WMCO_ROOT/tools/ansible/tasks/wsu/test/e2e
 #      which is a requirement to run this script
 exit 0
 
-# Required packages to run the test suite
-sudo yum install -y python libselinux-python python-pip
-pip install --user ansible pywinrm
-
 # The WSU playbook requires the cluster address, we parse that here using oc
 CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 


### PR DESCRIPTION
This commit changes the images specified by Dockerfile.tools so that we
can use the openshift_installer_custom_test_image template in OpenShift
CI.

This commit also removes superfluous steps from
hack/run-wsu-ci-e2e-test.sh, that are now being covered in the
Dockerfile