### PR TITLE
[wsu] enable e2e tests

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -3,9 +3,11 @@
 
 FROM centos:centos8
 
+WORKDIR /go/src/github.com/openshift/windows-machine-config-operator/
+
 COPY . .
 
-RUN yum -y update && yum -y install git make python2 python2-pip
+RUN yum -y update && yum -y install git make python2 python2-pip gcc
 
 # Download and install Go
 RUN curl -L -s https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz > go1.12.13.linux-amd64.tar.gz \
@@ -25,9 +27,15 @@ RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/o
     && oc version
 
 # Install ansible and required packages
-RUN pip2 install --user ansible pywinrm
+RUN pip2 install ansible pywinrm
+
+# Make Ansible happy with arbitrary UID/GID in OpenShift.
+RUN chmod g=u /etc/passwd /etc/group
+
+# Allow building the WMCB
+RUN chmod -R g=u /go
 
 ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="/usr/local/go"
+ENV GOPATH="/go"
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -3,19 +3,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
+WMCO_ROOT=$(pwd)
 TEST_DIR=$WMCO_ROOT/tools/ansible/tasks/wsu/test/e2e
 
-#TODO: Currently exiting early as the CI operator job which runs this does not have pip installed,
-#      which is a requirement to run this script
-exit 0
+# Make gopath if doesnt exist
+mkdir -p $GOPATH
+
+# If current user cannot be found add it to /etc/passwd. This is the case when this is run by an OpenShift cluster,
+# as OpenShift uses an arbitrarily assigned user ID to run the container.
+if ! whoami; then
+  echo "Creating user"
+  echo "tempuser:x:$(id -u):$(id -g):,,,:${HOME}:/bin/bash" >> /etc/passwd
+  echo "tempuser:x:$(id -G | cut -d' ' -f 2)" >> /etc/group
+fi
 
 # The WSU playbook requires the cluster address, we parse that here using oc
 CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 
 # Run the test suite
-
 cd $TEST_DIR
-CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v .
+GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v .
 
 exit 0

--- a/tools/ansible/tasks/wsu/test/e2e/wsu_test.go
+++ b/tools/ansible/tasks/wsu/test/e2e/wsu_test.go
@@ -33,7 +33,7 @@ var (
 	// Microsoft Windows Server 2019 Base with Containers.
 	imageID      = "ami-0b8d82dea356226d3"
 	instanceType = "m4.large"
-	sshKey       = "openshift-dev"
+	sshKey       = "libra"
 
 	// Cloud provider factory that we will use in these tests
 	cloud cloudprovider.Cloud
@@ -104,7 +104,7 @@ func TestWSU(t *testing.T) {
 	require.NoErrorf(t, err, "Could not write to host file: %s", err)
 	cmd := exec.Command("ansible-playbook", "-vvv", "-i", hostFilePath, playbookPath)
 	out, err := cmd.CombinedOutput()
-	assert.NoError(t, err, "WSU playbook returned error: %s, with output: ", err, string(out))
+	require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, string(out))
 
 	// Ansible will copy files to a temporary directory with a path such as:
 	// C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.z5wa1pc5.vhn\\


### PR DESCRIPTION
This commit enables wsu e2e tests now that we have an image that is
capable of running them. The image was introduced in:
openshift/release#5842

This commit also changes the Dockerfile, hack script, and the tests
to allow the tests to run properly within OpenShift CI.