### PR TITLE
Bug 1775384: [wsu] Upgrade kubelet version to 1.16

### DIFF
--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -2,7 +2,7 @@
 - hosts: localhost
   vars:
     project_root: "{{ playbook_dir }}/../../../.."
-    kubelet_location: "https://dl.k8s.io/v1.14.0/kubernetes-node-windows-amd64.tar.gz"
+    kubelet_location: "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz"
     wmcb_exe: "wmcb.exe"
 
   tasks:


### PR DESCRIPTION
Currently WSU playbook downloads kubelet node binary for Kubernetes version 1.14,
however Kubernetes version is upgraded for OpenShift 4.3, from 1.14 to 1.16.
This commit upgrades Kubernetes node binary version to 1.16.2, and also
introduces an e2e test that checks the checksum of binary downloaded to ensure
the binary was downloaded in its entirety.