### PR TITLE
[wni] Cleanup assert usage

### DIFF
--- a/tools/windows-node-installer/pkg/resource/tracker_test.go
+++ b/tools/windows-node-installer/pkg/resource/tracker_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"encoding/json"
 	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -42,7 +43,7 @@ var (
 // expectedInfo.
 func TestAppendInstallerInfo(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("."+string(os.PathSeparator), "*.json")
-	assert.NoError(t, err, "error making temp file in the current folder")
+	require.NoError(t, err, "error making temp file in the current folder")
 	filePath := tmpFile.Name()
 	defer os.Remove(filePath)
 
@@ -71,7 +72,7 @@ func TestReadInstallerInfo(t *testing.T) {
 // up by deleting the file.
 func TestRemoveInstallerInfo(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("."+string(os.PathSeparator), "*.json")
-	assert.NoError(t, err, "error making temp file in the current folder")
+	require.NoError(t, err, "error making temp file in the current folder")
 	filePath := tmpFile.Name()
 
 	expectedInfoByte, err := json.Marshal(expectedInfo)

--- a/tools/windows-node-installer/test/e2e/azure_test.go
+++ b/tools/windows-node-installer/test/e2e/azure_test.go
@@ -188,7 +188,7 @@ func testAnsiblePing(t *testing.T) {
 	for _, vmName := range instanceIDs {
 		vmCredentialPath := filepath.Join(dir, "/", vmName)
 		rdpCmd, err := ioutil.ReadFile(vmCredentialPath)
-		require.NoError(t, err, "failed to read file %s", vmName)
+		require.NoErrorf(t, err, "failed to read file %s", vmName)
 		ipAddress := ipAddressPattern.FindString(string(rdpCmd))
 		assert.NotEmpty(t, ipAddress, "the IP address can't be empty")
 		password := passwordPattern.FindString(string(rdpCmd))[3:]
@@ -199,6 +199,6 @@ func testAnsiblePing(t *testing.T) {
 		require.NoError(t, err, "failed to create a temp file")
 		pingCmd := exec.Command("ansible", "win", "-i", hostFileName, "-m", "win_ping")
 		out, err := pingCmd.CombinedOutput()
-		assert.NoError(t, err, "ansible ping check failed with error: %s", string(out))
+		assert.NoErrorf(t, err, "ansible ping check failed with error: %s", string(out))
 	}
 }


### PR DESCRIPTION
In wni there are few places we are causing NPE, so this PR will ensure assert usage is replaced with
require at appropriate places. Also replaced condition checking on the err with assert/require in aws e2e.