### PR TITLE
[wmcb] minor assert fix

### DIFF
--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -76,7 +76,7 @@ func TestBootstrapper(t *testing.T) {
 	// Run it again, to ensure it maintains state if the bootstrapper is already started
 	time.Sleep(5 * time.Second)
 	wmcb, err = bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath)
-	assert.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
+	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
 	err = wmcb.InitializeKubelet()
 	assert.NoErrorf(t, err, "Could not run bootstrapper: %s", err)
 	err = wmcb.Disconnect()


### PR DESCRIPTION
This is another minor fix for assert vs require usage in the
wmcb test files. This got missed addressing in the original
PR #97 . Thx aravindh for catching this out.