### PR TITLE
[wmcb] Fix path separators for Windows paths

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -47,7 +46,7 @@ const (
 	// serviceWaitTime is an arbitrary amount of time to wait for the Windows service API to complete requests
 	serviceWaitTime = time.Second * 10
 	// certDirectory is where the kubelet will look for certificates
-	certDirectory = "c:/var/lib/kubelet/pki/"
+	certDirectory = "c:\\var\\lib\\kubelet\\pki\\"
 	// cloudConfigOption is kubelet CLI option for cloud configuration
 	cloudConfigOption = "cloud-config"
 	// windowsTaints defines the taints that need to be applied on the Windows nodes.
@@ -310,7 +309,7 @@ func (wmcb *winNodeBootstrapper) parseIgnitionFileContents(ignitionFileContents 
 			}
 
 			// Set the --cloud-config option value
-			wmcb.kubeletArgs[cloudConfigOption] = path.Join(wmcb.installDir, cloudConfFilename)
+			wmcb.kubeletArgs[cloudConfigOption] = filepath.Join(wmcb.installDir, cloudConfFilename)
 		}
 
 		results = verbosityRegex.FindStringSubmatch(unit.Contents)

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -239,9 +238,9 @@ func TestCloudConfExtraction(t *testing.T) {
 
 	err = wnb.parseIgnitionFileContents([]byte(ignitionContents), map[string]fileTranslation{})
 	assert.NoError(t, err, "error parsing ignition file contents")
-	assert.FileExists(t, path.Join(dir, "cloud.conf"), "cloud.conf was not created")
+	assert.FileExists(t, filepath.Join(dir, "cloud.conf"), "cloud.conf was not created")
 
-	confContents, err := ioutil.ReadFile(path.Join(dir, "cloud.conf"))
+	confContents, err := ioutil.ReadFile(filepath.Join(dir, "cloud.conf"))
 	assert.NoError(t, err, "error reading cloud.conf")
 
 	conf := string(confContents)
@@ -288,8 +287,9 @@ func TestCloudConfExtraction(t *testing.T) {
 	// Check that the --cloud-conf option value is present in the kubelet args and matches tempdir + /cloud.conf
 	cloudConfigOptValue, present := wnb.kubeletArgs["cloud-config"]
 	assert.True(t, present, "cloud-config option is not present in kubelet args")
-	assert.Equal(t, path.Join(dir, "cloud.conf"), cloudConfigOptValue,
+	assert.Equal(t, filepath.Join(dir, "cloud.conf"), cloudConfigOptValue,
 		"unexpected --cloud-config value %s", cloudConfigOptValue)
+	assert.Contains(t, cloudConfigOptValue, string(os.PathSeparator), "Path not correctly set for cloud-config")
 }
 
 // TestCloudConfNotPresent tests that parseIgnitionFileContents will only create a cloud.conf file and add the
@@ -313,7 +313,7 @@ func TestCloudConfNotPresent(t *testing.T) {
 	err = wnb.parseIgnitionFileContents([]byte(ignitionContents), map[string]fileTranslation{})
 	assert.NoError(t, err, "error parsing ignition file contents")
 
-	_, err = os.Stat(path.Join(dir, "cloud.conf"))
+	_, err = os.Stat(filepath.Join(dir, "cloud.conf"))
 	assert.Error(t, err, "cloud.conf was created")
 
 	// Check that the --cloud-conf option value is not present in the kubelet args

--- a/test/e2e/configure_cni_test.go
+++ b/test/e2e/configure_cni_test.go
@@ -64,6 +64,13 @@ func testConfigureCNI(t *testing.T) {
 	isConfiguredCorrectly, err := isCNIConfigured(t, kubeletLogPath)
 	require.NoError(t, err, "Error reading kubelet log")
 	assert.True(t, isConfiguredCorrectly, "CNI was not configured correctly")
+
+	// Kubelet arguments with paths that are set by configure-cni
+	// Does not include arguments with paths that do not depend on underlying OS
+	checkPathsFor := []string{"--cni-bin-dir", "--cni-conf-dir"}
+	t.Run("Test the paths in Kubelet arguments", func(t *testing.T) {
+		testPathInKubeletArgs(t, checkPathsFor)
+	})
 }
 
 // isCNIConfigured checks if the kubelet start successfully and after applying the CNI config


### PR DESCRIPTION
WMCB code has used [path](https://golang.org/pkg/path/) library at many places,
however, [filepath](https://golang.org/pkg/path/filepath/) should be used whenever we are targeting file systems.
This commit changes the implementation to use filepath wherever relevant.

WMCB code was setting the kubelet argument for certDirectory with non-Windows
path separator. This commit fixes it.

Added Unit Test for path separator of cloud.conf
Added E2E test for paths in kubelet arguments. Excluded checks for
values of node-labels and pod-infra-container-image

Code reorganization:
Changed func getSvcState in bootstrapper e2e to func getSvcInfo,
repurposing the code to fetch service path along with state.