### PR TITLE
Bug 1768835:  Fix pod manifest directory creation

### DIFF
--- a/pkg/bootstrapper/bootstrapper.go
+++ b/pkg/bootstrapper/bootstrapper.go
@@ -350,6 +350,17 @@ func (wmcb *winNodeBootstrapper) initializeKubeletFiles() error {
 			dest: filepath.Join(wmcb.installDir, "kubelet-ca.crt"),
 		},
 	}
+
+	// Create the manifest directory needed by kubelet for the static pods, we shouldn't override if the pod manifest
+	// directory already exists
+	podManifestDirectory := filepath.Join(wmcb.installDir, "etc", "kubernetes", "manifests")
+	if _, err := os.Stat(podManifestDirectory); os.IsNotExist(err) {
+		err := os.MkdirAll(podManifestDirectory, os.ModeDir)
+		if err != nil {
+			return fmt.Errorf("could not make pod manifest directory: %s", err)
+		}
+	}
+
 	err := os.MkdirAll(wmcb.installDir, os.ModeDir)
 	if err != nil {
 		return fmt.Errorf("could not make install directory: %s", err)

--- a/pkg/bootstrapper/bootstrapper_test.go
+++ b/pkg/bootstrapper/bootstrapper_test.go
@@ -551,3 +551,21 @@ func testCNIUpdateKubeletArgs(t *testing.T) {
 		assert.Contains(t, err.Error(), "nil kubelet cmd passed")
 	})
 }
+
+// TestPodManifestDirCreation tests if the pod manifest directory was created
+func TestPodManifestDirCreation(t *testing.T) {
+	// Create a temp directory with wmcb prefix
+	dir, err := ioutil.TempDir("", "wmcb")
+	require.NoError(t, err, "error creating temp directory")
+	// Ignore the return error as there is not much we can do if the temporary directory is not deleted
+	defer os.RemoveAll(dir)
+	// podManifestDirectory which has to be created by wmcb.
+	podManifestDirectory := filepath.Join(dir, "etc", "kubernetes", "manifests")
+	wnb := winNodeBootstrapper{
+		installDir:  dir,
+		kubeletArgs: make(map[string]string),
+	}
+	err = wnb.initializeKubeletFiles()
+	assert.NoError(t, err, "error initializing kubelet files")
+	assert.DirExists(t, podManifestDirectory, "pod manifest directory was not created")
+}


### PR DESCRIPTION
As of now, we're not creating pod manifest dir
causing kubelet to throw error
`Unable to read config path
c:\\k\\etc\\kubernetes\\manifests: path
does not exist, ignoring
error`. This commit should resolve that.