### PR TITLE
[ci] Setup hybrid networking in WSU e2e tests

### DIFF
--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -20,6 +20,12 @@ fi
 # The WSU playbook requires the cluster address, we parse that here using oc
 CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 
+# Set up hybrid networking on the cluster, a requirement of OVNKubernetes on Windows
+oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
+
+# Even though the above patch will take non-zero time to apply, no delay is needed, as the WSU test suite
+# begins by creating a VM, an action which will take 4+ minutes. More than enough time for the patch to apply.
+
 # Run the test suite
 cd $TEST_DIR
 GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -timeout 20m .


### PR DESCRIPTION
This commit configures hybrid networking for the WSU e2e tests. This
will allow us to join Windows nodes to the cluster.