### PR TITLE
WIP: [ci] Enable running tests against multiple VMs

### DIFF
--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -13,5 +13,5 @@ make build-wmcb-unit-test
 
 # Transfer the binary and run the unit tests
 cd "${WMCB_TEST_DIR}"
-CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -timeout=30m .
+CGO_ENABLED=0 GO111MODULE=on go test -v  -timeout=30m -run=TestWMCBUnit -args -binaryToBeTransferred="../../../wmcb_unit_test.exe" .
 

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -28,6 +28,6 @@ oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"o
 
 # Run the test suite
 cd $TEST_DIR
-GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -timeout 30m .
+GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -timeout 60m .
 
 exit 0

--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"bytes"
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"os"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -27,9 +27,14 @@ const (
 	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
 )
 
-// TestFramework holds the info to run the test suite.
-// This is not clean
-type TestFramework struct {
+var (
+	kubeconfig     string
+	awsCredentials string
+	artifactDir    string
+	privateKeyPath string
+)
+
+type windowsVM struct {
 	// Credentials to access the Windows VM created
 	Credentials *types.Credentials
 	// WinrmClient to access the Windows VM created
@@ -40,35 +45,53 @@ type TestFramework struct {
 	SSHClient *ssh.Client
 	// CloudProvider holds the information related to cloud provider
 	cloudProvider cloudprovider.Cloud
+}
+
+// TestFramework holds the info to run the test suite.
+// This is not clean
+type TestFramework struct {
+	RemoteDir string
+	WinVMs    []windowsVM
 	// k8sclientset is the kubernetes clientset we will use to query the cluster's status
 	K8sclientset *kubernetes.Clientset
 	// OSConfigClient is the OpenShift config client, we will use to query the OpenShift api object status
 	OSConfigClient *configclient.Clientset
 }
 
+func initCIvars() error {
+	kubeconfig = os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return fmt.Errorf("KUBECONFIG environment variable not set")
+	}
+	awsCredentials = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if awsCredentials == "" {
+		return fmt.Errorf("AWS_SHARED_CREDENTIALS_FILE environment variable not set")
+	}
+	artifactDir = os.Getenv("ARTIFACT_DIR")
+	if awsCredentials == "" {
+		return fmt.Errorf("ARTIFACT_DIR environment variable not set")
+	}
+	privateKeyPath = os.Getenv("KUBE_SSH_KEY_PATH")
+	if privateKeyPath == "" {
+		return fmt.Errorf("KUBE_SSH_KEY_PATH environment variable not set")
+	}
+	return nil
+}
+
 // Setup sets up the Windows node so that it can join the existing OpenShift cluster
 // TODO: move this to return error and do assertions there
-func (f *TestFramework) Setup() {
-	if err := f.createWindowsVM(); err != nil {
-		log.Fatalf("failed to create Windows VM: %v", err)
+func (f *TestFramework) Setup(nrVMs int) {
+	if err := initCIvars(); err != nil {
+		log.Fatalf("failed to initialize CI variables with error: %v", err)
 	}
-	// TODO: Add some options to skip certain parts of the test
-	if err := f.setupWinRMClient(); err != nil {
-		log.Fatalf("failed to setup winRM client for the Windows VM: %v", err)
-	}
-	// Wait for some time before starting configuring of ssh server. This is to let sshd service be available
-	// in the list of services
-	// TODO: Parse the output of the `Get-Service sshd, ssh-agent` on the Windows node to check if the windows nodes
-	// has those services present
-	time.Sleep(time.Minute)
-	if err := f.configureOpenSSHServer(); err != nil {
-		log.Fatalf("failed to configure OpenSSHServer on the Windows VM: %v", err)
-	}
-	if err := f.createRemoteDir(); err != nil {
-		log.Fatalf("failed to create remote dir with error: %v", err)
-	}
-	if err := f.getSSHClient(); err != nil {
-		log.Fatalf("failed to get ssh client for the Windows VM created: %v", err)
+
+	f.WinVMs = make([]windowsVM, nrVMs)
+	// TODO: make them run in parallel
+	for _, vm := range f.WinVMs {
+		if err := vm.setup(); err != nil {
+			log.Fatalf("failed to create Windows VM with error: %v", err)
+		}
+		vm.RemoteDir = f.RemoteDir
 	}
 	if err := f.getKubeClient(); err != nil {
 		log.Fatalf("failed to get kube client with error: %v", err)
@@ -95,7 +118,6 @@ func (f *TestFramework) getKubeClient() error {
 
 // getOpenShiftConfigClient gets the new OpenShift config v1 client
 func (f *TestFramework) getOpenShiftConfigClient() error {
-	kubeconfig := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return fmt.Errorf("could not build config from flags: %v", err)
@@ -109,26 +131,37 @@ func (f *TestFramework) getOpenShiftConfigClient() error {
 	return nil
 }
 
-// createWindowsVM spins up the Windows VM in the given cloud provider and gives us the credentials to access the
-// windows VM created
-func (f *TestFramework) createWindowsVM() error {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		return fmt.Errorf("KUBECONFIG environment variable not set")
+func (w *windowsVM) setup() error {
+	if err := w.create(); err != nil {
+		return fmt.Errorf("failed to create Windows VM: %v", err)
 	}
-	awsCredentials := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
-	if awsCredentials == "" {
-		return fmt.Errorf("AWS_SHARED_CREDENTIALS_FILE environment variable not set")
+	// TODO: Add some options to skip certain parts of the test
+	if err := w.setupWinRMClient(); err != nil {
+		return fmt.Errorf("failed to setup winRM client for the Windows VM: %v", err)
 	}
-	artifactDir := os.Getenv("ARTIFACT_DIR")
-	if awsCredentials == "" {
-		return fmt.Errorf("ARTIFACT_DIR environment variable not set")
+	// Wait for some time before starting configuring of ssh server. This is to let sshd service be available
+	// in the list of services
+	// TODO: Parse the output of the `Get-Service sshd, ssh-agent` on the Windows node to check if the windows nodes
+	// has those services present
+	time.Sleep(time.Minute)
+	if err := w.configureOpenSSHServer(); err != nil {
+		return fmt.Errorf("failed to configure OpenSSHServer on the Windows VM: %v", err)
 	}
-	privateKeyPath := os.Getenv("KUBE_SSH_KEY_PATH")
-	if privateKeyPath == "" {
-		return fmt.Errorf("KUBE_SSH_KEY_PATH environment variable not set")
+	if err := w.createRemoteDir(); err != nil {
+		return fmt.Errorf("failed to create remote dir with error: %v", err)
+	}
+	if err := w.getSSHClient(); err != nil {
+		return fmt.Errorf("failed to get ssh client for the Windows VM created: %v", err)
 	}
 
+	return nil
+}
+
+// create spins up the Windows VM in the given cloud provider and gives us the credentials to access the
+// windows VM created
+func (w *windowsVM) create() error {
+	// NOTE: if we ever need to create VMs of different types, then imageID and instanceType should move to the
+	// windowsVM struct
 	// Use Windows 2019 server image with containers in us-east1 zone for CI testing.
 	// TODO: Move to environment variable that can be fetched from the cloud provider
 	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
@@ -143,19 +176,19 @@ func (f *TestFramework) createWindowsVM() error {
 	if err != nil {
 		return fmt.Errorf("error instantiating cloud provider %v", err)
 	}
-	f.cloudProvider = cloud
+	w.cloudProvider = cloud
 	credentials, err := cloud.CreateWindowsVM()
 	if err != nil {
 		return fmt.Errorf("error creating Windows VM: %v", err)
 	}
-	f.Credentials = credentials
+	w.Credentials = credentials
 	return nil
 }
 
 // setupWinRMClient sets up the winrm client to be used while accessing Windows node
-func (f *TestFramework) setupWinRMClient() error {
-	host := f.Credentials.GetIPAddress()
-	password := f.Credentials.GetPassword()
+func (w *windowsVM) setupWinRMClient() error {
+	host := w.Credentials.GetIPAddress()
+	password := w.Credentials.GetPassword()
 
 	// Connect to the bootstrapped host. Timeout is high as the Windows Server image is slow to download
 	endpoint := winrm.NewEndpoint(host, winRMPort, true, true,
@@ -164,43 +197,43 @@ func (f *TestFramework) setupWinRMClient() error {
 	if err != nil {
 		return fmt.Errorf("failed to set up winrm client with error: %v", err)
 	}
-	f.WinrmClient = winrmClient
+	w.WinrmClient = winrmClient
 	return nil
 }
 
 // configureOpenSSHServer configures the OpenSSH server using WinRM client installed on the Windows VM.
 // The OpenSSH server is installed as part of WNI tool's CreateVM method.
-func (f *TestFramework) configureOpenSSHServer() error {
+func (w *windowsVM) configureOpenSSHServer() error {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	// This dependency is needed for the subsequent module installation we're doing. This version of NuGet
 	// needed for OpenSSH server 0.0.1
 	installDependentPackages := "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force"
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+installDependentPackages,
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+installDependentPackages,
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to install dependent packages for OpenSSH server with error %v", err)
 	}
 	// Configure OpenSSH for all users.
 	// TODO: Limit this to Administrator.
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Install-Module -Force OpenSSHUtils -Scope AllUsers",
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"Install-Module -Force OpenSSHUtils -Scope AllUsers",
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to configure OpenSSHUtils for all users: %v", err)
 	}
 	// Setup ssh-agent Windows Service.
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name ssh-agent -StartupType ‘Automatic’",
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name ssh-agent -StartupType ‘Automatic’",
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to set up ssh-agent Windows Service: %v", err)
 	}
 	// Setup sshd Windows service
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name sshd -StartupType ‘Automatic’",
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name sshd -StartupType ‘Automatic’",
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to set up sshd Windows Service: %v", err)
 	}
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service ssh-agent",
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service ssh-agent",
 		stdout, stderr); err != nil {
 		return fmt.Errorf("start ssh-agent failed: %v", err)
 	}
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service sshd",
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service sshd",
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to start sshd: %v", err)
 	}
@@ -208,11 +241,11 @@ func (f *TestFramework) configureOpenSSHServer() error {
 }
 
 // createRemoteDir creates a directory on the Windows VM to which file can be transferred
-func (f *TestFramework) createRemoteDir() error {
+func (w *windowsVM) createRemoteDir() error {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	// Create a directory on the Windows node where the file has to be transferred
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"mkdir"+" "+f.RemoteDir,
+	if _, err := w.WinrmClient.Run(remotePowerShellCmdPrefix+"mkdir"+" "+w.RemoteDir,
 		stdout, stderr); err != nil {
 		return fmt.Errorf("failed to created a temporary dir on the remote Windows node with %v", err)
 	}
@@ -220,24 +253,26 @@ func (f *TestFramework) createRemoteDir() error {
 }
 
 // getSSHClient gets the ssh client associated with Windows VM created
-func (f *TestFramework) getSSHClient() error {
+func (w *windowsVM) getSSHClient() error {
 	config := &ssh.ClientConfig{
 		User:            "Administrator",
-		Auth:            []ssh.AuthMethod{ssh.Password(f.Credentials.GetPassword())},
+		Auth:            []ssh.AuthMethod{ssh.Password(w.Credentials.GetPassword())},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	sshClient, err := ssh.Dial("tcp", f.Credentials.GetIPAddress()+":22", config)
+	sshClient, err := ssh.Dial("tcp", w.Credentials.GetIPAddress()+":22", config)
 	if err != nil {
 		return fmt.Errorf("failed to dial to ssh server: %s", err)
 	}
-	f.SSHClient = sshClient
+	w.SSHClient = sshClient
 	return nil
 }
 
 // TearDown tears down the set up done for test suite
 func (f *TestFramework) TearDown() {
-	if err := f.cloudProvider.DestroyWindowsVMs(); err != nil {
-		log.Fatalf("failed tearing down the Windows VM with error: %v", err)
+	for _, vm := range f.WinVMs {
+		if err := vm.cloudProvider.DestroyWindowsVMs(); err != nil {
+			log.Fatalf("failed tearing down the Windows VM with error: %v", err)
+		}
 	}
 }

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -1,19 +1,33 @@
 package wmcb
 
 import (
+	"flag"
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
+	"log"
 	"os"
 	"testing"
 )
 
 // framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
 // TODO: Create a temporary remote directory on the Windows node
-var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+var (
+	framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+	// binaryToBeTransferred holds the binary that needs to be transferred to the Windows VM
+	// TODO: Make this an array later with a comma separated values for more binaries to be transferred
+	binaryToBeTransferred = flag.String("binaryToBeTransferred", "",
+		"Absolute path of the binary to be transferred")
+	// vmCount is the number of VMs the test suite requires
+	vmCount = 1
+)
 
 func TestMain(m *testing.M) {
-	framework.Setup(1)
-	testStatus := m.Run()
+	flag.Parse()
+	err := framework.Setup(vmCount)
+	if err != nil {
+		framework.TearDown()
+		log.Fatal(err)
+	}
+	defer framework.TearDown()
+	os.Exit(m.Run())
 	// TODO: Add one more check to remove lingering cloud resources
-	framework.TearDown()
-	os.Exit(testStatus)
 }

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -11,7 +11,7 @@ import (
 var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
 
 func TestMain(m *testing.M) {
-	framework.Setup()
+	framework.Setup(1)
 	testStatus := m.Run()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
@@ -39,38 +38,37 @@ var (
 // TestWMCBUnit runs the unit tests for WMCB
 func TestWMCBUnit(t *testing.T) {
 	// Transfer the binary to the windows using scp
-	defer framework.SSHClient.Close()
-	sftp, err := sftp.NewClient(framework.SSHClient)
-	require.NoError(t, err, "sftp client initialization failed")
-	defer sftp.Close()
-	f, err := os.Open(*binaryToBeTransferred)
-	require.NoError(t, err, "error opening binary file to be transferred")
-	dstFile, err := sftp.Create(framework.RemoteDir + "\\" + "wmcb_unit_test.exe")
-	require.NoError(t, err, "error opening binary file to be transferred")
-	_, err = io.Copy(dstFile, f)
-	require.NoError(t, err, "error copying binary to the Windows VM")
+	for _, vm := range framework.WinVMs {
+		defer vm.SSHClient.Close()
+		sftp, err := sftp.NewClient(vm.SSHClient)
+		require.NoError(t, err, "sftp client initialization failed")
+		defer sftp.Close()
+		f, err := os.Open(*binaryToBeTransferred)
+		require.NoError(t, err, "error opening binary file to be transferred")
+		dstFile, err := sftp.Create(vm.RemoteDir + "\\" + "wmcb_unit_test.exe")
+		require.NoError(t, err, "error opening binary file to be transferred")
+		_, err = io.Copy(dstFile, f)
+		require.NoError(t, err, "error copying binary to the Windows VM")
 
-	// Forcefully close it so that we can execute the binary later
-	dstFile.Close()
+		// Forcefully close it so that we can execute the binary later
+		dstFile.Close()
 
-	stdout := os.Stdout
-	r, w, err := os.Pipe()
-	assert.NoError(t, err, "error opening pipe to read stdout")
-	os.Stdout = w
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		assert.NoError(t, err, "error opening pipe to read stdout")
+		os.Stdout = w
 
-	// Remotely execute the test binary.
-	exitCode, err := framework.WinrmClient.Run(remotePowerShellCmdPrefix+framework.RemoteDir+"\\"+
-		"wmcb_unit_test.exe --test.v",
-		os.Stdout, os.Stderr)
-	assert.NoError(t, err, "error while executing the test binary remotely")
-	assert.Equal(t, 0, exitCode, "remote binary returned non-zero exit code")
-	w.Close()
-	out, err := ioutil.ReadAll(r)
-	assert.NoError(t, err, "error reading stdout from the remote Windows VM")
-	os.Stdout = stdout
-	log.Printf("%s", out)
-	assert.NotContains(t, string(out), "FAIL")
-	assert.NotContains(t, string(out), "panic")
+		// Remotely execute the test binary.
+		_, err = vm.WinrmClient.Run(remotePowerShellCmdPrefix+vm.RemoteDir+"\\"+
+			"wmcb_unit_test.exe --test.v",
+			os.Stdout, os.Stderr)
+		assert.NoError(t, err, "error while executing the test binary remotely")
+		w.Close()
+		out, err := ioutil.ReadAll(r)
+		assert.NoError(t, err, "error reading stdout from the remote Windows VM")
+		os.Stdout = stdout
+		assert.NotContains(t, string(out), "FAIL")
+	}
 }
 
 // hasWindowsTaint returns true if the given Windows node has the Windows taint

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -11,7 +11,7 @@ import (
 var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
 
 func TestMain(m *testing.M) {
-	framework.Setup()
+	framework.Setup(2)
 	testStatus := m.Run()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -2,18 +2,26 @@ package wsu
 
 import (
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
+	"log"
 	"os"
 	"testing"
 )
 
 // framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
 // TODO: Create a temporary remote directory on the Windows node
-var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+var (
+	framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+	// vmCount is the number of VMs the test suite requires. Using multiple to cover each playbook configuration option.
+	vmCount = 2
+)
 
 func TestMain(m *testing.M) {
-	framework.Setup(2)
-	testStatus := m.Run()
+	err := framework.Setup(vmCount)
+	if err != nil {
+		framework.TearDown()
+		log.Fatal(err)
+	}
+	defer framework.TearDown()
+	os.Exit(m.Run())
 	// TODO: Add one more check to remove lingering cloud resources
-	framework.TearDown()
-	os.Exit(testStatus)
 }

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -3,6 +3,8 @@ package wsu
 import (
 	"bytes"
 	"fmt"
+	"github.com/masterzen/winrm"
+	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -85,38 +87,54 @@ func TestWSU(t *testing.T) {
 	require.NotEmptyf(t, playbookPath, "WSU_PATH environment variable not set")
 	require.NotEmptyf(t, clusterAddress, "CLUSTER_ADDR environment variable not set")
 
-	// In order to run the ansible playbook we create an inventory file:
-	// https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
-	hostFilePath, err := createHostFile(framework.Credentials.GetIPAddress(), framework.Credentials.GetPassword())
-	require.NoErrorf(t, err, "Could not write to host file: %s", err)
-	cmd := exec.Command("ansible-playbook", "-vvv", "-i", hostFilePath, playbookPath)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, string(out))
+	for _, vm := range framework.WinVMs {
 
-	// Ansible will copy files to a temporary directory with a path such as:
-	// C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.z5wa1pc5.vhn\\
-	initialSplit := strings.Split(string(out), "C:\\\\Users\\\\Administrator\\\\AppData\\\\Local\\\\Temp\\\\ansible.")
-	require.True(t, len(initialSplit) > 1, "Could not find Windows temp dir: %s", out)
-	ansibleTempDir = "C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible." + strings.Split(initialSplit[1], "\"")[0]
+		// In order to run the ansible playbook we create an inventory file:
+		// https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+		hostFilePath, err := createHostFile(vm.Credentials.GetIPAddress(),
+			vm.Credentials.GetPassword())
+		require.NoErrorf(t, err, "Could not write to host file: %s", err)
+		cmd := exec.Command("ansible-playbook", "-vvv", "-i", hostFilePath, playbookPath)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, string(out))
 
-	t.Run("Files copied to Windows node", testFilesCopied)
-	t.Run("Pending CSRs were approved", testNoPendingCSRs)
-	t.Run("Node is in ready state", testNodeReady)
-	// test if the Windows node has proper worker label.
-	t.Run("Check if worker label has been applied to the Windows node", testWorkerLabelsArePresent)
-	t.Run("Network annotations were applied to node", testHybridOverlayAnnotations)
-	t.Run("HNS Networks were created", testHNSNetworksCreated)
-	t.Run("Check cni config generated on the Windows host", testCNIConfig)
-	t.Run("East-west networking", testEastWestNetworking)
-	t.Run("North-south networking", testNorthSouthNetworking)
+		// Ansible will copy files to a temporary directory with a path such as:
+		// C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.z5wa1pc5.vhn\\
+		initialSplit := strings.Split(string(out), "C:\\\\Users\\\\Administrator\\\\AppData\\\\Local\\\\Temp\\\\ansible.")
+		require.True(t, len(initialSplit) > 1, "Could not find Windows temp dir: %s", out)
+		ansibleTempDir = "C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible." + strings.Split(initialSplit[1], "\"")[0]
+
+		t.Run("Files copied to Windows node", func(t *testing.T) {
+			testFilesCopied(t, vm.WinrmClient)
+		})
+		t.Run("Pending CSRs were approved", testNoPendingCSRs)
+		t.Run("Node is in ready state", func(t *testing.T) {
+			testNodeReady(t, vm.Credentials)
+		})
+		// test if the Windows node has proper worker label.
+		t.Run("Check if worker label has been applied to the Windows node", testWorkerLabelsArePresent)
+		t.Run("Network annotations were applied to node", testHybridOverlayAnnotations)
+		t.Run("HNS Networks were created", func(t *testing.T) {
+			testHNSNetworksCreated(t, vm.WinrmClient)
+		})
+		t.Run("Check cni config generated on the Windows host", func(t *testing.T) {
+			testCNIConfig(t, vm.WinrmClient)
+		})
+		t.Run("East-west networking", func(t *testing.T) {
+			testEastWestNetworking(t, vm.WinrmClient)
+		})
+		t.Run("North-south networking", func(t *testing.T) {
+			 testNorthSouthNetworking(t, vm.WinrmClient)
+		})
+	}
 }
 
 // testCNIConfig tests if the CNI config has required hostsubnet and servicenetwork CIDR
 // NOTE: split this into multiple tests when this grows
-func testCNIConfig(t *testing.T) {
+func testCNIConfig(t *testing.T, vmWinrmClient *winrm.Client) {
 	// Read the CNI config present on the Windows host
 	cniConfigFilePath := filepath.Join(ansibleTempDir, "cni", "config", "cni.conf")
-	cniConfigFileContents, err := readRemoteFile(cniConfigFilePath)
+	cniConfigFileContents, err := readRemoteFile(cniConfigFilePath, vmWinrmClient)
 	require.NoError(t, err, "Could not get CNI config contents")
 
 	// Get the Windows node object
@@ -142,7 +160,7 @@ func testCNIConfig(t *testing.T) {
 }
 
 // testFilesCopied tests that the files we attempted to copy to the Windows host, exist on the Windows host
-func testFilesCopied(t *testing.T) {
+func testFilesCopied(t *testing.T, vmWinrmClient *winrm.Client) {
 	expectedFileList := []string{"kubelet.exe", "worker.ign", "wmcb.exe", "hybrid-overlay.exe", "kube.tar.gz"}
 
 	// Check if each of the files we expect on the Windows host are there
@@ -151,7 +169,7 @@ func testFilesCopied(t *testing.T) {
 		// This command will write to stdout, only if the file we are looking for does not exist
 		command := fmt.Sprintf("if not exist %s echo fail", fullPath)
 		stdout := new(bytes.Buffer)
-		_, err := framework.WinrmClient.Run(command, stdout, os.Stderr)
+		_, err := vmWinrmClient.Run(command, stdout, os.Stderr)
 		assert.NoError(t, err, "Error looking for %s: %s", fullPath, err)
 		assert.Emptyf(t, stdout.String(), "Missing file: %s", fullPath)
 	}
@@ -162,7 +180,7 @@ func testFilesCopied(t *testing.T) {
 	command := fmt.Sprintf("certutil -hashfile %s SHA512", kubeTarPath)
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	_, err := framework.WinrmClient.Run(command, stdout, stderr)
+	_, err := vmWinrmClient.Run(command, stdout, stderr)
 	require.NoError(t, err, "Error generating SHA512 for %s", kubeTarPath)
 	require.Equalf(t, stderr.Len(), 0, "Error generating SHA512 for %s", kubeTarPath)
 	// CertUtil output example:
@@ -174,7 +192,7 @@ func testFilesCopied(t *testing.T) {
 }
 
 // testNodeReady tests that the bootstrapped node was added to the cluster and is in the ready state
-func testNodeReady(t *testing.T) {
+func testNodeReady(t *testing.T, vmCredentials *types.Credentials) {
 	var createdNode *v1.Node
 	nodes, err := framework.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	require.NoError(t, err, "Could not get list of nodes")
@@ -183,7 +201,7 @@ func testNodeReady(t *testing.T) {
 	// Find the node that we spun up
 	for _, node := range nodes.Items {
 		for _, address := range node.Status.Addresses {
-			if address.Type == "ExternalIP" && address.Address == framework.Credentials.GetIPAddress() {
+			if address.Type == "ExternalIP" && address.Address == vmCredentials.GetIPAddress() {
 				createdNode = &node
 				break
 			}
@@ -234,12 +252,12 @@ func testWorkerLabelsArePresent(t *testing.T) {
 }
 
 // readRemoteFile returns the contents of a remote file. Returns an error on winRM failure, or if it does not exist.
-func readRemoteFile(fileName string) (string, error) {
+func readRemoteFile(fileName string, vmWinrmClient *winrm.Client) (string, error) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	// Read the file from remote host and check if the hostSubnet is present
 	command := remotePowerShellCmdPrefix + "cat " + fileName
-	errorCode, err := framework.WinrmClient.Run(command, stdout, stderr)
+	errorCode, err := vmWinrmClient.Run(command, stdout, stderr)
 	if err != nil {
 		return "", fmt.Errorf("WinRM failure trying to run cat: %s", err)
 	}
@@ -261,9 +279,9 @@ func testHybridOverlayAnnotations(t *testing.T) {
 }
 
 // testHNSNetworksCreated tests that the required HNS Networks have been created on the bootstrapped node
-func testHNSNetworksCreated(t *testing.T) {
+func testHNSNetworksCreated(t *testing.T, vmWinrmClient *winrm.Client) {
 	stdout := new(bytes.Buffer)
-	_, err := framework.WinrmClient.Run("powershell Get-HnsNetwork", stdout, os.Stderr)
+	_, err := vmWinrmClient.Run("powershell Get-HnsNetwork", stdout, os.Stderr)
 	require.NoError(t, err, "Could not run Get-HnsNetwork command")
 	stdoutString := stdout.String()
 	assert.Contains(t, stdoutString, "Name                   : BaseOpenShiftNetwork",
@@ -273,10 +291,10 @@ func testHNSNetworksCreated(t *testing.T) {
 }
 
 // testEastWestNetworking deploys Windows and Linux pods, and tests that the pods can communicate
-func testEastWestNetworking(t *testing.T) {
-	// Deploy a webserver pod on the new node
-	winServerDeployment, err := deployWindowsWebServer()
-	require.NoError(t, err, "Could not create Windows Server deployment")
+func testEastWestNetworking(t *testing.T, vmWinrmClient *winrm.Client) {
+		// Deploy a webserver pod on the new node
+		winServerDeployment, err := deployWindowsWebServer(vmWinrmClient)
+		require.NoError(t, err, "Could not create Windows Server deployment")
 	defer deleteDeployment(winServerDeployment.Name)
 
 	// Get the pod so we can use its IP
@@ -309,10 +327,10 @@ func testEastWestNetworking(t *testing.T) {
 }
 
 // deployWindowsWebServer creates a deployment with a single Windows Server pod, listening on port 80
-func deployWindowsWebServer() (*appsv1.Deployment, error) {
+func deployWindowsWebServer(winrm *winrm.Client) (*appsv1.Deployment, error) {
 	// Preload the image that will be used on the Windows node, to prevent download timeouts
 	// and separate possible failure conditions into multiple operations
-	err := pullDockerImage(windowsServerImage)
+	err := pullDockerImage(windowsServerImage, winrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not pull Windows Server image: %s", err)
 	}
@@ -509,11 +527,11 @@ func deleteDeployment(name string) error {
 }
 
 // pullDockerImage pulls the designated image on the remote host
-func pullDockerImage(name string) error {
+func pullDockerImage(name string, winrmClient *winrm.Client) error {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	command := "docker pull " + name
-	errorCode, err := framework.WinrmClient.Run(command, stdout, stderr)
+	errorCode, err := winrmClient.Run(command, stdout, stderr)
 	if err != nil {
 		return fmt.Errorf("failed to remotely run docker pull: %s", err)
 	}
@@ -526,9 +544,9 @@ func pullDockerImage(name string) error {
 }
 
 // testNorthSouthNetworking deploys a Windows Server pod, and tests that we can network with it from outside the cluster
-func testNorthSouthNetworking(t *testing.T) {
+func testNorthSouthNetworking(t *testing.T, winrmClient *winrm.Client) {
 	// Deploy a webserver pod on the new node
-	winServerDeployment, err := deployWindowsWebServer()
+	winServerDeployment, err := deployWindowsWebServer(winrmClient)
 	require.NoError(t, err, "Could not create Windows Server deployment")
 	defer deleteDeployment(winServerDeployment.Name)
 


### PR DESCRIPTION
Currently our framework spins up only 1 windows instance at a time. We would want to
    have multiple Windows instances to check communication between instances, or simply
    to run WSU with different arguments.
    
    This commit changes the framework to spin up multiple Windows instances.
    
    As a part of this commit,
    - Windows VM is its own struct in framework and we can set up the slice for the
    same in main test files for WSU or WMCB
    - Setup takes the number of instances to be spun up as a parameter, however
    TearDown destroys all instances in the slice
    - In WSU and WMCB test files, the tests now run in a loop for all instances in
    the slice
    - WMCB runs on 1 instance currently whereas WSU test file changed to spin up 2
    instances. This is done to support testing for running WSU with a pinned
    location for WMCB versus building WMCB from source
    See https://issues.redhat.com/projects/WINC/issues/WINC-128 for more details
    - Doubled the timeout for WSU E2E test. However parallelization for creation of
    and testing against multiple instances should be considered in the future
    - Code is modularized wherever possible