### PR TITLE
[ci] Update framework for launching multiple VMs

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -1,81 +1,86 @@
 package framework
 
 import (
-	"bytes"
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"os"
-	"time"
 
-	"github.com/masterzen/winrm"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/cloudprovider"
-	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
-	"golang.org/x/crypto/ssh"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	// user for the Windows node created.
-	// TODO: remove this hardcoding to any user.
-	user = "Administrator"
-	// winrm port to be used
-	winRMPort = 5986
-	// remotePowerShellCmdPrefix holds the powershell prefix that needs to be prefixed to every command run on the
-	// remote powershell session opened
-	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
+var (
+	// kubeconfig is the location of the kubeconfig for the cluster the test suite will run on
+	kubeconfig string
+	// awsCredentials is the Credentials file for the aws account the cluster will be created with
+	awsCredentials string
+	// artifactDir is the directory CI will read from once the test suite has finished execution
+	artifactDir string
+	// privateKeyPath is the path to the key that will be used to retrieve the password of each Windows VM
+	privateKeyPath string
 )
 
 // TestFramework holds the info to run the test suite.
-// This is not clean
 type TestFramework struct {
-	// Credentials to access the Windows VM created
-	Credentials *types.Credentials
-	// WinrmClient to access the Windows VM created
-	WinrmClient *winrm.Client
-	// remoteDir is the directory to which files will be transferred to, on the Windows VM
-	RemoteDir string
-	// SSHClient contains the ssh client information to access the Windows VM via ssh
-	SSHClient *ssh.Client
-	// CloudProvider holds the information related to cloud provider
-	cloudProvider cloudprovider.Cloud
+	// WinVms contains the Windows VMs that are created to execute the test suite
+	WinVMs []WindowsVM
 	// k8sclientset is the kubernetes clientset we will use to query the cluster's status
 	K8sclientset *kubernetes.Clientset
 	// OSConfigClient is the OpenShift config client, we will use to query the OpenShift api object status
 	OSConfigClient *configclient.Clientset
 }
 
-// Setup sets up the Windows node so that it can join the existing OpenShift cluster
-// TODO: move this to return error and do assertions there
-func (f *TestFramework) Setup() {
-	if err := f.createWindowsVM(); err != nil {
-		log.Fatalf("failed to create Windows VM: %v", err)
+// initCIvars gathers the values of the environment variables which configure the test suite
+func initCIvars() error {
+	kubeconfig = os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return fmt.Errorf("KUBECONFIG environment variable not set")
 	}
-	// TODO: Add some options to skip certain parts of the test
-	if err := f.setupWinRMClient(); err != nil {
-		log.Fatalf("failed to setup winRM client for the Windows VM: %v", err)
+	awsCredentials = os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if awsCredentials == "" {
+		return fmt.Errorf("AWS_SHARED_CREDENTIALS_FILE environment variable not set")
 	}
-	// Wait for some time before starting configuring of ssh server. This is to let sshd service be available
-	// in the list of services
-	// TODO: Parse the output of the `Get-Service sshd, ssh-agent` on the Windows node to check if the windows nodes
-	// has those services present
-	time.Sleep(time.Minute)
-	if err := f.configureOpenSSHServer(); err != nil {
-		log.Fatalf("failed to configure OpenSSHServer on the Windows VM: %v", err)
+	artifactDir = os.Getenv("ARTIFACT_DIR")
+	if awsCredentials == "" {
+		return fmt.Errorf("ARTIFACT_DIR environment variable not set")
 	}
-	if err := f.createRemoteDir(); err != nil {
-		log.Fatalf("failed to create remote dir with error: %v", err)
+	privateKeyPath = os.Getenv("KUBE_SSH_KEY_PATH")
+	if privateKeyPath == "" {
+		return fmt.Errorf("KUBE_SSH_KEY_PATH environment variable not set")
 	}
-	if err := f.getSSHClient(); err != nil {
-		log.Fatalf("failed to get ssh client for the Windows VM created: %v", err)
+	return nil
+}
+
+// Setup creates and initializes a variable amount of Windows VMs
+func (f *TestFramework) Setup(vmCount int) error {
+	// Use Windows 2019 server image with containers in us-east1 zone for CI testing.
+	// TODO: Move to environment variable that can be fetched from the cloud provider
+	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
+	// Microsoft Windows Server 2019 Base with Containers.
+	imageID := "ami-0b8d82dea356226d3"
+	// Using an AMD instance type, as the Windows hybrid overlay currently does not work on on machines using
+	// the Intel 82599 network driver
+	instanceType := "m5a.large"
+	if err := initCIvars(); err != nil {
+		return fmt.Errorf("unable to initialize CI variables: %v", err)
+	}
+	f.WinVMs = make([]WindowsVM, vmCount)
+	// TODO: make them run in parallel: https://issues.redhat.com/browse/WINC-178
+	for i := 0; i < vmCount; i++ {
+		var err error
+		f.WinVMs[i], err = newWindowsVM(imageID, instanceType)
+		if err != nil {
+			return fmt.Errorf("unable to instantiate Windows VM: %v", err)
+		}
 	}
 	if err := f.getKubeClient(); err != nil {
-		log.Fatalf("failed to get kube client with error: %v", err)
+		return fmt.Errorf("unable to get kube client: %v", err)
 	}
 	if err := f.getOpenShiftConfigClient(); err != nil {
-		log.Fatalf("failed to get kube client with error: %v", err)
+		return fmt.Errorf("unable to get OpenShift client: %v", err)
 	}
+	return nil
 }
 
 // getKubeClient setups the kubeclient that can be used across all the test suites.
@@ -95,7 +100,6 @@ func (f *TestFramework) getKubeClient() error {
 
 // getOpenShiftConfigClient gets the new OpenShift config v1 client
 func (f *TestFramework) getOpenShiftConfigClient() error {
-	kubeconfig := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return fmt.Errorf("could not build config from flags: %v", err)
@@ -109,135 +113,21 @@ func (f *TestFramework) getOpenShiftConfigClient() error {
 	return nil
 }
 
-// createWindowsVM spins up the Windows VM in the given cloud provider and gives us the credentials to access the
-// windows VM created
-func (f *TestFramework) createWindowsVM() error {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		return fmt.Errorf("KUBECONFIG environment variable not set")
-	}
-	awsCredentials := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
-	if awsCredentials == "" {
-		return fmt.Errorf("AWS_SHARED_CREDENTIALS_FILE environment variable not set")
-	}
-	artifactDir := os.Getenv("ARTIFACT_DIR")
-	if awsCredentials == "" {
-		return fmt.Errorf("ARTIFACT_DIR environment variable not set")
-	}
-	privateKeyPath := os.Getenv("KUBE_SSH_KEY_PATH")
-	if privateKeyPath == "" {
-		return fmt.Errorf("KUBE_SSH_KEY_PATH environment variable not set")
-	}
-
-	// Use Windows 2019 server image with containers in us-east1 zone for CI testing.
-	// TODO: Move to environment variable that can be fetched from the cloud provider
-	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
-	// Microsoft Windows Server 2019 Base with Containers.
-	imageID := "ami-0b8d82dea356226d3"
-	// Using an AMD instance type, as the Windows hybrid overlay currently does not work on on machines using
-	// the Intel 82599 network driver
-	instanceType := "m5a.large"
-	sshKey := "libra"
-	cloud, err := cloudprovider.CloudProviderFactory(kubeconfig, awsCredentials, "default", artifactDir,
-		imageID, instanceType, sshKey, privateKeyPath)
-	if err != nil {
-		return fmt.Errorf("error instantiating cloud provider %v", err)
-	}
-	f.cloudProvider = cloud
-	credentials, err := cloud.CreateWindowsVM()
-	if err != nil {
-		return fmt.Errorf("error creating Windows VM: %v", err)
-	}
-	f.Credentials = credentials
-	return nil
-}
-
-// setupWinRMClient sets up the winrm client to be used while accessing Windows node
-func (f *TestFramework) setupWinRMClient() error {
-	host := f.Credentials.GetIPAddress()
-	password := f.Credentials.GetPassword()
-
-	// Connect to the bootstrapped host. Timeout is high as the Windows Server image is slow to download
-	endpoint := winrm.NewEndpoint(host, winRMPort, true, true,
-		nil, nil, nil, time.Minute*10)
-	winrmClient, err := winrm.NewClient(endpoint, user, password)
-	if err != nil {
-		return fmt.Errorf("failed to set up winrm client with error: %v", err)
-	}
-	f.WinrmClient = winrmClient
-	return nil
-}
-
-// configureOpenSSHServer configures the OpenSSH server using WinRM client installed on the Windows VM.
-// The OpenSSH server is installed as part of WNI tool's CreateVM method.
-func (f *TestFramework) configureOpenSSHServer() error {
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	// This dependency is needed for the subsequent module installation we're doing. This version of NuGet
-	// needed for OpenSSH server 0.0.1
-	installDependentPackages := "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force"
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+installDependentPackages,
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to install dependent packages for OpenSSH server with error %v", err)
-	}
-	// Configure OpenSSH for all users.
-	// TODO: Limit this to Administrator.
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Install-Module -Force OpenSSHUtils -Scope AllUsers",
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to configure OpenSSHUtils for all users: %v", err)
-	}
-	// Setup ssh-agent Windows Service.
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name ssh-agent -StartupType ‘Automatic’",
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to set up ssh-agent Windows Service: %v", err)
-	}
-	// Setup sshd Windows service
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name sshd -StartupType ‘Automatic’",
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to set up sshd Windows Service: %v", err)
-	}
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service ssh-agent",
-		stdout, stderr); err != nil {
-		return fmt.Errorf("start ssh-agent failed: %v", err)
-	}
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"Start-Service sshd",
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to start sshd: %v", err)
-	}
-	return nil
-}
-
-// createRemoteDir creates a directory on the Windows VM to which file can be transferred
-func (f *TestFramework) createRemoteDir() error {
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
-	// Create a directory on the Windows node where the file has to be transferred
-	if _, err := f.WinrmClient.Run(remotePowerShellCmdPrefix+"mkdir"+" "+f.RemoteDir,
-		stdout, stderr); err != nil {
-		return fmt.Errorf("failed to created a temporary dir on the remote Windows node with %v", err)
-	}
-	return nil
-}
-
-// getSSHClient gets the ssh client associated with Windows VM created
-func (f *TestFramework) getSSHClient() error {
-	config := &ssh.ClientConfig{
-		User:            "Administrator",
-		Auth:            []ssh.AuthMethod{ssh.Password(f.Credentials.GetPassword())},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	}
-
-	sshClient, err := ssh.Dial("tcp", f.Credentials.GetIPAddress()+":22", config)
-	if err != nil {
-		return fmt.Errorf("failed to dial to ssh server: %s", err)
-	}
-	f.SSHClient = sshClient
-	return nil
-}
-
-// TearDown tears down the set up done for test suite
+// TearDown destroys the resources created by the Setup function
 func (f *TestFramework) TearDown() {
-	if err := f.cloudProvider.DestroyWindowsVMs(); err != nil {
-		log.Fatalf("failed tearing down the Windows VM with error: %v", err)
+	if f.WinVMs == nil {
+		return
+	}
+
+	for _, vm := range f.WinVMs {
+		if vm == nil {
+			continue
+		}
+		if err := vm.Destroy(); err != nil {
+			log.Printf("failed tearing down the Windows VM %v with error: %v", vm, err)
+		} else {
+			// WNI will delete all the VMs in windows-node-installer.json so we need this to succeed only once
+			return
+		}
 	}
 }

--- a/internal/test/framework/windowsvm.go
+++ b/internal/test/framework/windowsvm.go
@@ -1,0 +1,235 @@
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/masterzen/winrm"
+	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/cloudprovider"
+	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	// remotePowerShellCmdPrefix holds the PowerShell prefix that needs to be prefixed  for every remote PowerShell
+	// command executed on the remote Windows VM
+	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
+	// sshKey is the key that will be used to access created Windows VMs
+	sshKey = "libra"
+	// user for the Windows node created.
+	// TODO: remove this hardcoding to any user.
+	user = "Administrator"
+	// winRMPort is port used for WinRM communication
+	winRMPort = 5986
+)
+
+// windowsVM represents a Windows VM in the test framework
+type windowsVM struct {
+	// cloudProvider holds the information related to cloud provider
+	cloudProvider cloudprovider.Cloud
+	// credentials to access the Windows VM created
+	credentials *types.Credentials
+	// sshClient contains the ssh client information to access the Windows VM via ssh
+	sshClient *ssh.Client
+	// winrmClient to access the Windows VM created
+	winrmClient *winrm.Client
+}
+
+// WindowsVM is the interface for interacting with a Windows VM in the test framework
+type WindowsVM interface {
+	// CopyFile copies the given file to the remote directory in the Windows VM. The remote directory is created if it
+	// does not exist
+	CopyFile(string, string) error
+	// Run executes the given command remotely on the Windows VM and returns the output of stdout and stderr. If the
+	// bool is set, it implies that the cmd is to be execute in PowerShell.
+	Run(string, bool) (string, string, error)
+	// GetCredentials returns the interface for accessing the VM credentials. It is up to the caller to check if non-nil
+	// Credentials are returned before usage.
+	GetCredentials() *types.Credentials
+	// Destroy destroys the Windows VM
+	Destroy() error
+}
+
+// newWindowsVM creates and sets up a Windows VM in the cloud and returns the WindowsVM interface that can be used to
+// interact with the VM. If no error is returned then it is guaranteed that the VM was created and can be  interacted
+// with.
+func newWindowsVM(imageID, instanceType string) (WindowsVM, error) {
+	w := &windowsVM{}
+	var err error
+
+	w.cloudProvider, err = cloudprovider.CloudProviderFactory(kubeconfig, awsCredentials, "default", artifactDir,
+		imageID, instanceType, sshKey, privateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("error instantiating cloud provider %v", err)
+	}
+
+	w.credentials, err = w.cloudProvider.CreateWindowsVM()
+	if err != nil {
+		return nil, fmt.Errorf("error creating Windows VM: %v", err)
+	}
+
+	// TODO: Add some options to skip certain parts of the test
+	if err := w.setupWinRMClient(); err != nil {
+		return w, fmt.Errorf("failed to setup winRM client for the Windows VM: %v", err)
+	}
+	// Wait for some time before starting configuring of ssh server. This is to let sshd service be available
+	// in the list of services
+	// TODO: Parse the output of the `Get-Service sshd, ssh-agent` on the Windows node to check if the windows nodes
+	// has those services present
+	time.Sleep(time.Minute)
+	if err := w.configureOpenSSHServer(); err != nil {
+		return w, fmt.Errorf("failed to configure OpenSSHServer on the Windows VM: %v", err)
+	}
+	if err := w.getSSHClient(); err != nil {
+		return w, fmt.Errorf("failed to get ssh client for the Windows VM created: %v", err)
+	}
+
+	return w, nil
+}
+
+func (w *windowsVM) CopyFile(filePath, remoteDir string) error {
+	if w.sshClient == nil {
+		return fmt.Errorf("CopyFile cannot be called without a SSH client")
+	}
+
+	ftp, err := sftp.NewClient(w.sshClient)
+	if err != nil {
+		return fmt.Errorf("sftp client initialization failed: %v", err)
+	}
+	defer ftp.Close()
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening %s file to be transferred: %v", filePath, err)
+	}
+	defer f.Close()
+
+	if err = ftp.MkdirAll(remoteDir); err != nil {
+		return fmt.Errorf("error creating remote directory %s: %v", remoteDir, err)
+	}
+
+	remoteFile := remoteDir + "\\" + filepath.Base(filePath)
+	dstFile, err := ftp.Create(remoteFile)
+	if err != nil {
+		return fmt.Errorf("error initializing %s file on Windows VMs: %v", remoteFile, err)
+	}
+
+	_, err = io.Copy(dstFile, f)
+	if err != nil {
+		return fmt.Errorf("error copying %s to the Windows VM: %v", filePath, err)
+	}
+
+	// Forcefully close it so that we can execute the binary later
+	dstFile.Close()
+	return nil
+}
+
+func (w *windowsVM) Run(cmd string, psCmd bool) (string, string, error) {
+	if w.winrmClient == nil {
+		return "", "", fmt.Errorf("Run cannot be called without a WinRM client")
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	if psCmd {
+		cmd = remotePowerShellCmdPrefix + cmd
+	}
+	// Remotely execute the test binary.
+	exitCode, err := w.winrmClient.Run(cmd, stdout, stderr)
+	if err != nil {
+		return "", "", fmt.Errorf("error while executing %s remotely: %v", cmd, err)
+	}
+
+	if exitCode != 0 {
+		return stdout.String(), stderr.String(), fmt.Errorf("%s returned %d exit code", cmd, exitCode)
+	}
+
+	return stdout.String(), stderr.String(), nil
+}
+
+func (w *windowsVM) GetCredentials() *types.Credentials {
+	return w.credentials
+}
+
+func (w *windowsVM) Destroy() error {
+	// There is no VM to destroy
+	if w.cloudProvider == nil || w.credentials == nil {
+		return nil
+	}
+	return w.cloudProvider.DestroyWindowsVMs()
+}
+
+// setupWinRMClient sets up the winrm client to be used while accessing Windows node
+func (w *windowsVM) setupWinRMClient() error {
+	host := w.credentials.GetIPAddress()
+	password := w.credentials.GetPassword()
+
+	// Connect to the bootstrapped host. Timeout is high as the Windows Server image is slow to download
+	endpoint := winrm.NewEndpoint(host, winRMPort, true, true,
+		nil, nil, nil, time.Minute*10)
+	winrmClient, err := winrm.NewClient(endpoint, user, password)
+	if err != nil {
+		return fmt.Errorf("failed to set up winrm client with error: %v", err)
+	}
+	w.winrmClient = winrmClient
+	return nil
+}
+
+// configureOpenSSHServer configures the OpenSSH server using WinRM client installed on the Windows VM.
+// The OpenSSH server is installed as part of WNI tool's CreateVM method.
+func (w *windowsVM) configureOpenSSHServer() error {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	// This dependency is needed for the subsequent module installation we're doing. This version of NuGet
+	// needed for OpenSSH server 0.0.1
+	installDependentPackages := "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force"
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+installDependentPackages, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to install dependent packages for OpenSSH server with error %v", err)
+	}
+	// Configure OpenSSH for all users.
+	// TODO: Limit this to Administrator.
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+"Install-Module -Force OpenSSHUtils -Scope AllUsers",
+		stdout, stderr); err != nil {
+		return fmt.Errorf("failed to configure OpenSSHUtils for all users: %v", err)
+	}
+	// Setup ssh-agent Windows Service.
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name ssh-agent -StartupType ‘Automatic’",
+		stdout, stderr); err != nil {
+		return fmt.Errorf("failed to set up ssh-agent Windows Service: %v", err)
+	}
+	// Setup sshd Windows service
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+"Set-Service -Name sshd -StartupType ‘Automatic’",
+		stdout, stderr); err != nil {
+		return fmt.Errorf("failed to set up sshd Windows Service: %v", err)
+	}
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+"Start-Service ssh-agent",
+		stdout, stderr); err != nil {
+		return fmt.Errorf("start ssh-agent failed: %v", err)
+	}
+	if _, err := w.winrmClient.Run(remotePowerShellCmdPrefix+"Start-Service sshd", stdout, stderr); err != nil {
+		return fmt.Errorf("failed to start sshd: %v", err)
+	}
+	return nil
+}
+
+// getSSHClient gets the ssh client associated with Windows VM created
+func (w *windowsVM) getSSHClient() error {
+	config := &ssh.ClientConfig{
+		User:            "Administrator",
+		Auth:            []ssh.AuthMethod{ssh.Password(w.credentials.GetPassword())},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	sshClient, err := ssh.Dial("tcp", w.credentials.GetIPAddress()+":22", config)
+	if err != nil {
+		return fmt.Errorf("failed to dial to ssh server: %s", err)
+	}
+	w.sshClient = sshClient
+	return nil
+}

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -1,17 +1,27 @@
 package wmcb
 
 import (
-	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
+	"log"
 	"os"
 	"testing"
+
+	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
 )
 
 // framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
-// TODO: Create a temporary remote directory on the Windows node
-var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+var (
+	framework = &e2ef.TestFramework{}
+	// TODO: expose this to the end user as a command line flag
+	// vmCount is the number of VMs the test suite requires
+	vmCount = 1
+)
 
 func TestMain(m *testing.M) {
-	framework.Setup()
+	err := framework.Setup(vmCount)
+	if err != nil {
+		framework.TearDown()
+		log.Fatal(err)
+	}
 	testStatus := m.Run()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -2,16 +2,25 @@ package wsu
 
 import (
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
+	"log"
 	"os"
 	"testing"
 )
 
 // framework holds the instantiation of test suite being executed. As of now, temp dir is hardcoded.
-// TODO: Create a temporary remote directory on the Windows node
-var framework = &e2ef.TestFramework{RemoteDir: "C:\\Temp"}
+var (
+	framework = &e2ef.TestFramework{}
+	// TODO: expose this to the end user as a command line flag
+	// vmCount is the number of VMs the test suite requires
+	vmCount = 1
+)
 
 func TestMain(m *testing.M) {
-	framework.Setup()
+	err := framework.Setup(vmCount)
+	if err != nil {
+		framework.TearDown()
+		log.Fatal(err)
+	}
 	testStatus := m.Run()
 	// TODO: Add one more check to remove lingering cloud resources
 	framework.TearDown()


### PR DESCRIPTION
Currently our framework spins up only 1 windows instance. We need to have multiple Windows instances to check communication between instances, or run WSU with different arguments. This commit changes the framework to allow it to spin up multiple Windows instances.

As a part of this commit,
- Encapsulate Windows VM is its own struct and interface separate from the  framework. This clearly separates the framework from the tests.
- Add a slice of the WindowsVM interface to the framework
- Setup takes the number of instances to be spun up as a parameter, and  TearDown destroys all instances in the slice
- In WSU and WMCB test files, the tests now run in a loop against the instances  in the slice

Some parts of the PR were added by @suhanime
Signed-off-by: Suhani Mehta <sumehta@redhat.com>

Jira: [WINC-156](https://issues.redhat.com/browse/WINC-156)