### PR TITLE
Bug 1787646: Update hybrid-overlay.exe for 4.4

### DIFF
--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -41,7 +41,7 @@ var (
 	// windowsLabel represents the node label that need to be applied to the Windows node created
 	windowsLabel = "node.openshift.io/os_id=Windows"
 	// hybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
-	hybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-hostsubnet"
+	hybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"
 	// hybridOverlayMac is an annotation applied by the hybrid overlay
 	hybridOverlayMac = "k8s.ovn.org/hybrid-overlay-distributed-router-gateway-mac"
 

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -75,14 +75,14 @@
 
     - name: Get hybrid overlay exe
       win_get_url:
-        url: "https://github.com/openshift/windows-machine-config-operator/releases/download/0.1/hybrid-overlay.exe"
+        url: "https://github.com/openshift/windows-machine-config-operator/releases/download/v0.3-alpha/hybrid-overlay.exe"
         dest: "{{ win_temp_dir.path }}\\hybrid-overlay.exe"
         follow_redirects: all
 
     - name: Check hybrid overlay SHA256
       win_shell: "certutil -hashfile {{ win_temp_dir.path }}\\hybrid-overlay.exe sha256"
       register: hybrid_sha256
-      failed_when: "hybrid_sha256.stdout_lines[1] != 'fa0ecdc4abd3e3cf6b88541a32eba59e947be08b783be9a39951126182f30f65'"
+      failed_when: "hybrid_sha256.stdout_lines[1] != 'c399a53722eccae06af49c9e8091b664ba42aa22be397bbbd86517cf2c40a16d'"
 
     - name: Run bootstrapper
       win_shell: "{{ win_temp_dir.path }}\\wmcb.exe initialize-kubelet --ignition-file {{ win_temp_dir.path }}\\worker.ign --kubelet-path {{ win_temp_dir.path }}\\kubelet.exe"
@@ -177,7 +177,7 @@
     # include hybrid overlay config
     - name: Get the subnet associated with host
       delegate_to: localhost
-      shell: "oc get nodes {{ node_name.stdout}} -o=jsonpath='{.metadata.annotations.k8s\\.ovn\\.org\\/hybrid-overlay-hostsubnet}'"
+      shell: "oc get nodes {{ node_name.stdout}} -o=jsonpath='{.metadata.annotations.k8s\\.ovn\\.org\\/hybrid-overlay-node-subnet}'"
       register: ovn_host_subnet
 
     # Get the service CIDR associated with the OpenShift network operator object. We assume that network always object


### PR DESCRIPTION
**Problem**:
The execution of the hybrid-overlay.exe is failing in the Windows node as it cannot find the required `k8s.ovn.org/hybrid-overlay-hostsubnet` annotation on the node object that should be applied on enabling hybrid OVN networking.

**Solution**:
The hybrid annotation has changed to `k8s.ovn.org/hybrid-overlay-node-subnet` in 4.4 and to pick those changes up we need to use a newer version of the hybrid-overlay.exe. A [release](https://github.com/openshift/windows-machine-config-operator/releases/tag/v0.3-alpha) was cut that included the newer version built from the master (4.4) branch of openshift/ovn-kubernetes and WSU was updated to use this
version.

**Jira**: [WINC-194](https://issues.redhat.com/browse/WINC-194)