### PR TITLE
[ci] Add options for working with existing VMs

### DIFF
--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -3,6 +3,24 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SKIP_VM_SETUP=""
+VM_CREDS=""
+
+while getopts ":v:s" opt; do
+  case ${opt} in
+    v ) # process option for providing existing VM credentials
+      VM_CREDS=$OPTARG
+      ;;
+    s ) # process option for skipping setup in VMs
+      SKIP_VM_SETUP="-skipSetup"
+      ;;
+    \? )
+      echo "Usage: $0 [-v] [-s]"
+      exit 0
+      ;;
+  esac
+done
+
 # TODO: Add steps to execute code that will kick off the e2e tests in CI
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 WMCB_TEST_DIR=$WMCO_ROOT/internal/test/wmcb
@@ -13,5 +31,4 @@ make build-wmcb-unit-test
 
 # Transfer the binary and run the unit tests
 cd "${WMCB_TEST_DIR}"
-CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -timeout=30m .
-
+CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -3,6 +3,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# TODO: Add input validation
+SKIP_VM_SETUP=""
+VM_CREDS=""
+
+while getopts ":v:s" opt; do
+  case ${opt} in
+    v ) # process option for providing existing VM credentials
+      VM_CREDS=$OPTARG
+      ;;
+    s ) # process option for skipping setup in VMs
+      SKIP_VM_SETUP="-skipSetup"
+      ;;
+    \? )
+      echo "Usage: $0 [-v] [-s]"
+      exit 0
+      ;;
+  esac
+done
+
 WMCO_ROOT=$(pwd)
 TEST_DIR=$WMCO_ROOT/internal/test/wsu
 
@@ -28,6 +47,6 @@ oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"o
 
 # Run the test suite
 cd $TEST_DIR
-GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -timeout 30m .
+GO_BUILD_ARGS=CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR WSU_PATH=$WMCO_ROOT/tools/ansible/tasks/wsu/main.yaml go test -v -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout 30m .
 
 exit 0

--- a/internal/test/wmcb/main_test.go
+++ b/internal/test/wmcb/main_test.go
@@ -1,6 +1,7 @@
 package wmcb
 
 import (
+	"flag"
 	"log"
 	"os"
 	"testing"
@@ -17,7 +18,14 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	err := framework.Setup(vmCount)
+	var vmCreds e2ef.Creds
+	var skipVMSetup bool
+
+	flag.Var(&vmCreds, "vmCreds", "List of VM credentials")
+	flag.BoolVar(&skipVMSetup, "skipVMSetup", false, "Option to disable setup in the VMs")
+	flag.Parse()
+
+	err := framework.Setup(vmCount, vmCreds, skipVMSetup)
 	if err != nil {
 		framework.TearDown()
 		log.Fatal(err)

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -1,6 +1,7 @@
 package wsu
 
 import (
+	"flag"
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
 	"log"
 	"os"
@@ -16,7 +17,14 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	err := framework.Setup(vmCount)
+	var vmCreds e2ef.Creds
+	var skipVMSetup bool
+
+	flag.Var(&vmCreds, "vmCreds", "List of VM credentials")
+	flag.BoolVar(&skipVMSetup, "skipVMSetup", false, "Option to disable setup in the VMs")
+	flag.Parse()
+
+	err := framework.Setup(vmCount, vmCreds, skipVMSetup)
 	if err != nil {
 		framework.TearDown()
 		log.Fatal(err)

--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -48,3 +48,32 @@ Run the WSU playbook:
 ```
 $ ansible-playbook -i hosts tasks/wsu/main.yaml -v
 ```
+
+### End to end testing
+The following environment variables need to be set for running the end to end tests of the playbook:
+- ARTIFACT_DIR
+  - This can be set to any directory
+- AWS_SHARED_CREDENTIALS_FILE
+  - Set this to point to your AWS credentials file
+- KUBE_SSH_KEY_PATH
+  - The ssh key used to bring up the VM
+- KUBECONFIG
+  - The kubeconfig of the OpenShift cluster
+
+Once the above variables are set, you can run the end to end tests for the playbook by executing:
+```shell script
+$ hack/run-wsu-ci-e2e-test.sh
+```
+
+The hack script can be given the following options:
+- `-v` option takes a list of VM credentials in the order of `instance-id,ip-address,password`. The username defaults
+   to `Administrator`. This allows you to run the tests against existing set of VMs.
+   ```shell script
+   $ hack/run-wsu-ci-e2e-test.sh -v"aws-instance-id-1,3.135.234.23,password,aws-instance-id-2,3.135.234.23,password"
+   ```
+
+- `-s` option allows you to skip the framework setup. The assumption here is that the framework setup has already been
+  run on the VM.
+  ```shell script
+  $ hack/run-wsu-ci-e2e-test.sh -v"aws-instance-id,1.2.34.23,password" -s
+  ```


### PR DESCRIPTION
- Allow passing an array of Credentials to the framework which allows tests to run against existing VMs without them being created or destroyed by the framework.
- Add an option to skip configuration steps for the VMs

These options are useful during development.