### PR TITLE
[wsu] Add option to use pinned wmcb

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -1,14 +1,19 @@
 package framework
 
 import (
+	"context"
 	"fmt"
+	"github.com/google/go-github/v29/github"
+	v1 "k8s.io/api/core/v1"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -46,6 +51,10 @@ type TestFramework struct {
 	OSConfigClient *configclient.Clientset
 	// noTeardown is an indicator that the user supplied the VMs and they should not be destroyed
 	noTeardown bool
+	// ClusterVersion is the major.minor.patch version of the OpenShift cluster
+	ClusterVersion string
+	// LatestRelease is the latest release of the wmcb
+	LatestRelease *github.RepositoryRelease
 }
 
 // Creds is used for parsing the vmCreds command line argument
@@ -141,6 +150,12 @@ func (f *TestFramework) Setup(vmCount int, credentials []*types.Credentials, ski
 	if err := f.getOpenShiftConfigClient(); err != nil {
 		return fmt.Errorf("unable to get OpenShift client: %v", err)
 	}
+	if err := f.getClusterVersion(); err != nil {
+		return fmt.Errorf("unable to get OpenShift cluster version: %v", err)
+	}
+	if err := f.getLatestGithubRelease(); err != nil {
+		return fmt.Errorf("unable to get latest github release: %v", err)
+	}
 	return nil
 }
 
@@ -159,6 +174,81 @@ func (f *TestFramework) getKubeClient() error {
 	return nil
 }
 
+// GetNode returns a pointer to the node object associated with the external IP provided
+func (f *TestFramework) GetNode(externalIP string) (*v1.Node, error) {
+	var matchedNode *v1.Node
+
+	nodes, err := f.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get list of nodes")
+	}
+	if len(nodes.Items) == 0 {
+		return nil, fmt.Errorf("no nodes found")
+	}
+
+	// Find the node that has the given IP
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == "ExternalIP" && address.Address == externalIP {
+				matchedNode = &node
+				break
+			}
+		}
+		if matchedNode != nil {
+			break
+		}
+	}
+	if matchedNode == nil {
+		return nil, fmt.Errorf("could not find node with IP: %s", externalIP)
+	}
+	return matchedNode, nil
+}
+
+// k8sVersionToOpenShiftVersion converts a Kubernetes minor version to an OpenShift version in format
+// "major.minor". This function works under the assumption that for OpenShift 4, every OpenShift minor version increase
+// corresponds with a kubernetes minor version increase
+func k8sVersionToOpenShiftVersion(k8sMinorVersion int) (string, error) {
+	openshiftMajorVersion := "4"
+	baseKubernetesMinorVersion := 16
+	baseOpenShiftMinorVersion := 3
+
+	if k8sMinorVersion < baseKubernetesMinorVersion {
+		return "", fmt.Errorf("kubernetes minor version %d is not supported", k8sMinorVersion)
+	}
+
+	// find how many minor versions past OpenShift 4.3 we are
+	versionIncrements := k8sMinorVersion - baseKubernetesMinorVersion
+	openShiftMinorVersion := strconv.Itoa(versionIncrements + baseOpenShiftMinorVersion)
+	return openshiftMajorVersion + "." + openShiftMinorVersion, nil
+}
+
+// getClusterVersion gets the OpenShift cluster version in major.minor format. This is being done this way, and not with
+// oc get clusterversion, as OpenShift CI doesn't have the actual version attached to its clusters, instead replacing it
+// with 0.0.1 and information about the release creation date
+func (f *TestFramework) getClusterVersion() error {
+	versionInfo, err := f.OSConfigClient.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+
+	// Convert kubernetes version to major.minor format. v1.17.0 -> 1.17
+	k8sVersion := strings.TrimLeft(versionInfo.GitVersion, "v")
+	k8sSemver := strings.Split(k8sVersion, ".")
+	k8sMinorVersion, err := strconv.Atoi(k8sSemver[1])
+	if err != nil {
+		return fmt.Errorf("could not conver k8s minor version %s to int", err)
+	}
+
+	// Map kubernetes version to OpenShift version
+	openshiftVersion, err := k8sVersionToOpenShiftVersion(k8sMinorVersion)
+	if err != nil {
+		return fmt.Errorf("could not map kubernetes version to an OpenShift version: %s", err)
+	}
+
+	f.ClusterVersion = openshiftVersion
+	return nil
+}
+
 // getOpenShiftConfigClient gets the new OpenShift config v1 client
 func (f *TestFramework) getOpenShiftConfigClient() error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
@@ -172,6 +262,27 @@ func (f *TestFramework) getOpenShiftConfigClient() error {
 	}
 	f.OSConfigClient = configClient
 	return nil
+}
+
+// getLatestGithubRelease gets the latest github release for the wmcb repo. This release is specific to the cluster version
+func (f *TestFramework) getLatestGithubRelease() error {
+	client := github.NewClient(nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
+	releases, _, err := client.Repositories.ListReleases(ctx, "openshift", "windows-machine-config-operator",
+		&github.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, release := range releases {
+		if strings.Contains(release.GetName(), f.ClusterVersion) {
+			f.LatestRelease = release
+			return nil
+		}
+	}
+	return fmt.Errorf("could not fetch latest release")
 }
 
 // TearDown destroys the resources created by the Setup function

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -9,6 +9,7 @@ replace (
 )
 
 require (
+	github.com/google/go-github/v29 v29.0.2
 	github.com/masterzen/winrm v0.0.0-20190308153735-1d17eaf15943
 	github.com/openshift/client-go v0.0.0-20190813201236-5a5508328169
 	github.com/openshift/windows-machine-config-operator/tools/windows-node-installer v0.0.0-20191123092711-1eb1f9837741

--- a/internal/test/go.sum
+++ b/internal/test/go.sum
@@ -69,6 +69,10 @@ github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4er
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
+github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -165,6 +169,7 @@ golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c h1:/nJuwDLoL/zrqY6gf57vxC
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=

--- a/internal/test/wsu/main_test.go
+++ b/internal/test/wsu/main_test.go
@@ -13,7 +13,9 @@ var (
 	framework = &e2ef.TestFramework{}
 	// TODO: expose this to the end user as a command line flag
 	// vmCount is the number of VMs the test suite requires
-	vmCount = 1
+	// Set to two to test multiple VM bootstraps at the same time, as well as testing both using a pinned WMCB version
+	// and a built version
+	vmCount = 2
 )
 
 func TestMain(m *testing.M) {

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -1,18 +1,21 @@
 package wsu
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v29/github"
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
-	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,8 +30,6 @@ var (
 	// Path of the WSU playbook
 	playbookPath = os.Getenv("WSU_PATH")
 
-	// Temp directory ansible created on the windows host
-	ansibleTempDir = ""
 	// kubernetes-node-windows-amd64.tar.gz SHA512
 	// Value from https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#node-binaries-1
 	// This value should be updated when we change the kubelet version in WSU
@@ -45,28 +46,102 @@ var (
 	windowsServerImage = "mcr.microsoft.com/windows/servercore:ltsc2019"
 	// ubi8Image is the name/location of the linux image we will use for testing
 	ubi8Image = "registry.access.redhat.com/ubi8/ubi:latest"
-	// remotePowerShellCmdPrefix holds the powershell prefix that needs to be prefixed to every command run on the
-	// remote powershell session opened
-	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
+	//wmcbExeRegex searches for the path of the WMCB exe
+	wmcbExeRegex = regexp.MustCompile(`\/tmp\S*\/wmcb\.exe`)
+
+	// pinnedWMCBVM indicates which VM will use a pinned wmcb version
+	pinnedWMCBVM = 1
 )
 
-// createhostFile creates an ansible host file and returns the path of it
-func createHostFile(ip, password string) (string, error) {
+// getLatestReleaseArtifactURL returns the URL of the releases artifact matching the given name
+func getReleaseArtifactURL(assets []github.ReleaseAsset, artifactName string) (string, error) {
+	for _, asset := range assets {
+		if asset.GetName() == artifactName {
+			return asset.GetBrowserDownloadURL(), nil
+		}
+	}
+	return "", fmt.Errorf("no artifact with name %s", artifactName)
+}
+
+//getReleaseArtifactSHA returns the SHA256 of the release artifact specified, given the body of the release
+func getReleaseArtifactSHA(body string, artifactName string) (string, error) {
+	// The release body looks like:
+	// f819c2df76bc89fe0bd1311eea7dae2a11c40bc26b48b85fd4718e286b0a257e  wmcb.exe
+	// 92c24c250ef81b565e2f59916f722d8fcb0a5ec1821899d590b781e3c883a7d3  wni
+	// a476f9b7e8b223f5d2efb2066ae48be514d57b66e04038308d1787a770784084  hybrid-overlay.exe
+	lines := strings.Split(body, "\r\n")
+	for _, line := range lines {
+		// Get the line that ends with the artifact name
+		if strings.HasSuffix(line, " "+artifactName) {
+			return strings.Split(line, " ")[0], nil
+		}
+	}
+	return "", fmt.Errorf("no artifact with name %s", artifactName)
+}
+
+// createhostFile creates an ansible host file for the VMs we have spun up
+func createHostFile(vmList []e2ef.WindowsVM) (string, error) {
 	hostFile, err := ioutil.TempFile("", "testWSU")
 	if err != nil {
 		return "", fmt.Errorf("coud not make temporary file: %s", err)
 	}
 	defer hostFile.Close()
 
-	_, err = hostFile.WriteString(fmt.Sprintf(`[win]
-%s ansible_password='%s'
-[win:vars]
+	// Add each host to the host file
+	hostFileContents := "[win]\n"
+	for i := 0; i < len(vmList); i++ {
+		creds := vmList[i].GetCredentials()
+		hostFileContents += creds.GetIPAddress() + " " + "ansible_password='" + creds.GetPassword() + "'" + "\n"
+	}
+
+	// Add the common variables
+	hostFileContents += fmt.Sprintf(`[win:vars]
 ansible_user=Administrator
 cluster_address=%s
 ansible_port=5986
 ansible_connection=winrm
-ansible_winrm_server_cert_validation=ignore`, ip, password, e2ef.ClusterAddress))
+ansible_winrm_server_cert_validation=ignore
+`, e2ef.ClusterAddress)
+	_, err = hostFile.WriteString(hostFileContents)
 	return hostFile.Name(), err
+}
+
+// hashDownloadedWMCB returns the hash of the wmcb.exe which was downloaded during the run of the WSU
+func hashDownloadedWMCB(ansibleOutput string) ([sha256.Size]byte, error) {
+	wmcbPath := wmcbExeRegex.FindString(ansibleOutput)
+	if wmcbPath == "" {
+		return [sha256.Size]byte{}, fmt.Errorf("could not find a reference to downloaded wmcb in ansible output")
+	}
+	wmcbContents, err := ioutil.ReadFile(wmcbPath)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("could not read wmcb")
+	}
+	return sha256.Sum256(wmcbContents), nil
+}
+
+// testPinnedWMCB tests that we used a pinned version of the WMCB, instead of building it at runtime
+func testPinnedWMCB(t *testing.T, ansibleOutput string, wmcbPinnedURL string) {
+	// Check that we used the pinned version
+	require.Contains(t, ansibleOutput, wmcbPinnedURL, "Pinned version was not used in WSU")
+
+	// Get the SHA of the wmcb release from the release body
+	wmcbPinnedURLSha256, err := getReleaseArtifactSHA(framework.LatestRelease.GetBody(), "wmcb.exe")
+	require.NoError(t, err, "Could not get hash of pinned wmcb")
+
+	// Hash the wmcb WSU used
+	downloadedWMCBSha, err := hashDownloadedWMCB(ansibleOutput)
+	require.NoError(t, err, "Could not get hash of downloaded wmcb")
+	downloadedWMCBShaString := fmt.Sprintf("%x", downloadedWMCBSha)
+
+	// Ensure the WSU used the correct WMCB via SHA256
+	assert.Equal(t, wmcbPinnedURLSha256, downloadedWMCBShaString, "Downloaded WMCB has different SHA256 than expected")
+}
+
+// testBuiltWMCB tests that the WMCB was built, and not downloaded
+func testBuiltWMCB(t *testing.T, ansibleOutput string) {
+	require.Contains(t, ansibleOutput,
+		"CGO_ENABLED=0 GO111MODULE=on GOOS=windows go build -o wmcb.exe  "+
+			"github.com/openshift/windows-machine-config-operator/cmd/bootstrapper")
 }
 
 // TestWSU creates a Windows instance, runs the WSU, and then runs a series of tests to ensure all expected
@@ -75,73 +150,148 @@ ansible_winrm_server_cert_validation=ignore`, ip, password, e2ef.ClusterAddress)
 func TestWSU(t *testing.T) {
 	require.NotEmptyf(t, playbookPath, "WSU_PATH environment variable not set")
 
-	for _, vm := range framework.WinVMs {
-		// Run the test suite twice, to ensure that the WSU can be run multiple times against the same VM
-		runWSUTestSuite(t, vm)
-		t.Run("Run the WSU against the same VM again", func(t *testing.T) {
-			runWSUTestSuite(t, vm)
-		})
-	}
+	t.Run("VM specific tests", func(t *testing.T) {
+		testAllVMs(t)
+	})
+
+	// Run cluster wide tests
+	t.Run("Pending CSRs were approved", testNoPendingCSRs)
 }
 
-// runWSUTestSuite runs the WSU test suite against the VM
-func runWSUTestSuite(t *testing.T, vm e2ef.WindowsVM) {
+// testAllVMs runs all VM specific tests
+func testAllVMs(t *testing.T) {
+	wmcbPinnedURL, err := getReleaseArtifactURL(framework.LatestRelease.Assets, "wmcb.exe")
+	require.NoError(t, err, "Could not get WMCB url")
+
+	for i := range framework.WinVMs {
+		t.Run("VM "+strconv.Itoa(i), func(t *testing.T) {
+			setupAndTest(t, i, wmcbPinnedURL)
+		})
+	}
+
+}
+
+// setupAndTest runs the WSU and runs tests against the setup node
+func setupAndTest(t *testing.T, vmNum int, wmcbPinnedURL string) {
+	// Indicate that we can run the test suite on each node in parallel
+	t.Parallel()
+
+	// Run the WSU against the VM
+	wsuOut, pinnedWMCB, err := runWSU(vmNum, framework.WinVMs[vmNum], wmcbPinnedURL)
+	require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, wsuOut)
+
+	// Run our VM test suite
+	runTest(t, pinnedWMCB, framework.WinVMs[vmNum], wsuOut, wmcbPinnedURL)
+}
+
+// runWSU runs the WSU playbook against a VM. Returns WSU stdout and whether it used a pinned WMCB
+func runWSU(vmNum int, vm e2ef.WindowsVM, wmcbURL string) (string, bool, error) {
+	var usedPinned bool
+	var ansibleCmd *exec.Cmd
+	pinnedWMCBOption := "wmcb_url=" + wmcbURL
+
 	// In order to run the ansible playbook we create an inventory file:
 	// https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
-	require.NotNil(t, vm.GetCredentials())
-	hostFilePath, err := createHostFile(vm.GetCredentials().GetIPAddress(),
-		vm.GetCredentials().GetPassword())
-	require.NoErrorf(t, err, "Could not write to host file: %s", err)
-	cmd := exec.Command("ansible-playbook", "-vvv", "-i", hostFilePath, playbookPath)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, string(out))
+	hostFilePath, err := createHostFile([]e2ef.WindowsVM{vm})
+	if err != nil {
+		return "", false, err
+	}
 
-	// Ansible will copy files to a temporary directory with a path such as:
-	// C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.z5wa1pc5.vhn\\
-	initialSplit := strings.Split(string(out), "C:\\\\Users\\\\Administrator\\\\AppData\\\\Local\\\\Temp\\\\ansible.")
-	require.True(t, len(initialSplit) > 1, "Could not find Windows temp dir: %s", out)
-	ansibleTempDir = "C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible." + strings.Split(initialSplit[1], "\"")[0]
+	// Run the WSU against the VM
+	if vmNum == pinnedWMCBVM {
+		usedPinned = true
+		ansibleCmd = exec.Command("ansible-playbook", "-v", "-e", pinnedWMCBOption, "-i",
+			hostFilePath, playbookPath)
+	} else {
+		ansibleCmd = exec.Command("ansible-playbook", "-v", "-i", hostFilePath, playbookPath)
+	}
+
+	// Run the playbook
+	wsuOut, err := ansibleCmd.CombinedOutput()
+	return string(wsuOut), usedPinned, err
+}
+
+// testVM runs the WSU against the given VM and runs the e2e test suite against that VM as well
+func runTest(t *testing.T, pinnedWMCB bool, vm e2ef.WindowsVM, wsuOut string, wmcbURL string) {
+	// Run the test suite
+	runE2ETestSuite(t, pinnedWMCB, wmcbURL, vm, wsuOut)
+
+	//Run the test suite again, to ensure that the WSU can be run multiple times against the same VM
+	t.Run("Run the WSU against the same VM again", func(t *testing.T) {
+		runE2ETestSuite(t, pinnedWMCB, wmcbURL, vm, wsuOut)
+	})
+}
+
+// getAnsibleTempDirPath returns the path of the ansible temp directory on the remote VM
+func getAnsibleTempDirPath(ansibleOutput string) (string, error) {
+	// Debug line looks like:
+	// "msg": "Windows temporary directory: C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.to4wamvh.yzk"
+	debugStatementSplit := strings.Split(ansibleOutput, "Windows temporary directory: ")
+	if len(debugStatementSplit) != 2 {
+		return "", fmt.Errorf("expected one temporary directory debug statement, but found multiple: %s", ansibleOutput)
+	}
+	tempDirSplit := strings.Split(debugStatementSplit[1], "\"")
+	if len(tempDirSplit) < 2 {
+		return "", fmt.Errorf("unexpected split format %s", ansibleOutput)
+	}
+
+	return tempDirSplit[0], nil
+}
+
+// runE2ETestSuite runs the WSU test suite against a VM
+func runE2ETestSuite(t *testing.T, pinnedWMCB bool, wmcbURL string, vm e2ef.WindowsVM, ansibleOutput string) {
+	tempDirPath, err := getAnsibleTempDirPath(ansibleOutput)
+	require.NoError(t, err, "Could not get path of Ansible temp directory")
+
+	if pinnedWMCB {
+		t.Run("Using pinned version of WMCB", func(t *testing.T) {
+			testPinnedWMCB(t, ansibleOutput, wmcbURL)
+		})
+	} else {
+		t.Run("Built WMCB", func(t *testing.T) {
+			testBuiltWMCB(t, ansibleOutput)
+		})
+	}
+
+	node, err := framework.GetNode(vm.GetCredentials().GetIPAddress())
+	require.NoError(t, err, "Could not get Windows node object")
 
 	t.Run("Files copied to Windows node", func(t *testing.T) {
-		testFilesCopied(t, vm)
+		testFilesCopied(t, vm, tempDirPath)
 	})
-	t.Run("Pending CSRs were approved", testNoPendingCSRs)
 	t.Run("Node is in ready state", func(t *testing.T) {
-		testNodeReady(t, vm.GetCredentials())
+		testNodeReady(t, node)
 	})
-	// test if the Windows node has proper worker label.
-	t.Run("Check if worker label has been applied to the Windows node", testWorkerLabelsArePresent)
-	t.Run("Network annotations were applied to node", testHybridOverlayAnnotations)
+	t.Run("Check if worker label has been applied to the Windows node", func(t *testing.T) {
+		testWorkerLabelsArePresent(t, node)
+	})
+	t.Run("Network annotations were applied to node", func(t *testing.T) {
+		testHybridOverlayAnnotations(t, node)
+	})
 	t.Run("HNS Networks were created", func(t *testing.T) {
 		testHNSNetworksCreated(t, vm)
 	})
 	t.Run("Check cni config generated on the Windows host", func(t *testing.T) {
-		testCNIConfig(t, vm)
+		testCNIConfig(t, node, vm, tempDirPath)
 	})
 	t.Run("East-west networking", func(t *testing.T) {
-		testEastWestNetworking(t, vm)
+		testEastWestNetworking(t, node, vm)
 	})
 	t.Run("North-south networking", func(t *testing.T) {
-		testNorthSouthNetworking(t, vm)
+		testNorthSouthNetworking(t, node, vm)
 	})
 }
 
 // testCNIConfig tests if the CNI config has required hostsubnet and servicenetwork CIDR
 // NOTE: split this into multiple tests when this grows
-func testCNIConfig(t *testing.T, vm e2ef.WindowsVM) {
+func testCNIConfig(t *testing.T, node *v1.Node, vm e2ef.WindowsVM, ansibleTempDir string) {
 	// Read the CNI config present on the Windows host
 	cniConfigFilePath := filepath.Join(ansibleTempDir, "cni", "config", "cni.conf")
 	cniConfigFileContents, err := readRemoteFile(cniConfigFilePath, vm)
 	require.NoError(t, err, "Could not get CNI config contents")
 
-	// Get the Windows node object
-	windowsNodes, err := framework.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: e2ef.WindowsLabel})
-	require.NoError(t, err, "Could not get a list of Windows nodes")
-	require.Equalf(t, len(windowsNodes.Items), vmCount, "Expected %d Windows node(s) to be present but found %v",
-		vmCount, len(windowsNodes.Items))
-
 	// By the time, we reach here the annotation should be present, so need to validate again
-	hostSubnet := windowsNodes.Items[0].Annotations[hybridOverlaySubnet]
+	hostSubnet := node.Annotations[hybridOverlaySubnet]
 	// Check if the host subnet matches our expected value
 	assert.Contains(t, cniConfigFileContents, hostSubnet, "CNI config does not contain host subnet")
 
@@ -157,7 +307,7 @@ func testCNIConfig(t *testing.T, vm e2ef.WindowsVM) {
 }
 
 // testFilesCopied tests that the files we attempted to copy to the Windows host, exist on the Windows host
-func testFilesCopied(t *testing.T, vm e2ef.WindowsVM) {
+func testFilesCopied(t *testing.T, vm e2ef.WindowsVM, ansibleTempDir string) {
 	expectedFileList := []string{"kubelet.exe", "worker.ign", "wmcb.exe", "hybrid-overlay.exe", "kube.tar.gz"}
 
 	// Check if each of the files we expect on the Windows host are there
@@ -186,26 +336,7 @@ func testFilesCopied(t *testing.T, vm e2ef.WindowsVM) {
 }
 
 // testNodeReady tests that the bootstrapped node was added to the cluster and is in the ready state
-func testNodeReady(t *testing.T, vmCredentials *types.Credentials) {
-	var createdNode *v1.Node
-	nodes, err := framework.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{})
-	require.NoError(t, err, "Could not get list of nodes")
-	require.NotZero(t, len(nodes.Items), "No nodes found")
-
-	// Find the node that we spun up
-	for _, node := range nodes.Items {
-		for _, address := range node.Status.Addresses {
-			if address.Type == "ExternalIP" && address.Address == vmCredentials.GetIPAddress() {
-				createdNode = &node
-				break
-			}
-		}
-		if createdNode != nil {
-			break
-		}
-	}
-	require.NotNil(t, createdNode, "Created node not found through Kubernetes API")
-
+func testNodeReady(t *testing.T, createdNode *v1.Node) {
 	// Make sure the node is in a ready state
 	foundReady := false
 	for _, condition := range createdNode.Status.Conditions {
@@ -235,13 +366,8 @@ func testNoPendingCSRs(t *testing.T) {
 }
 
 // testWorkerLabelsArePresent tests if the worker labels are present on the Windows Node.
-func testWorkerLabelsArePresent(t *testing.T) {
-	// Check if the Windows node has the required label needed.
-	windowsNodes, err := framework.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: e2ef.WindowsLabel})
-	require.NoErrorf(t, err, "error while getting Windows node: %v", err)
-	assert.Equalf(t, len(windowsNodes.Items), vmCount, "expected %d Windows node(s) to be present but found %v",
-		vmCount, len(windowsNodes.Items))
-	assert.Contains(t, windowsNodes.Items[0].Labels, workerLabel,
+func testWorkerLabelsArePresent(t *testing.T, node *v1.Node) {
+	assert.Contains(t, node.Labels, workerLabel,
 		"expected worker label to be present on the Windows node but did not find any")
 }
 
@@ -255,13 +381,9 @@ func readRemoteFile(fileName string, vm e2ef.WindowsVM) (string, error) {
 }
 
 // testHybridOverlayAnnotations tests that the correct annotations have been added to the bootstrapped node
-func testHybridOverlayAnnotations(t *testing.T) {
-	windowsNodes, err := framework.K8sclientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: e2ef.WindowsLabel})
-	require.NoError(t, err, "Could not get list of Windows nodes")
-	assert.Equalf(t, len(windowsNodes.Items), vmCount, "expected %d Windows node(s) to be present but found %v",
-		vmCount, len(windowsNodes.Items))
-	assert.Contains(t, windowsNodes.Items[0].Annotations, hybridOverlaySubnet)
-	assert.Contains(t, windowsNodes.Items[0].Annotations, hybridOverlayMac)
+func testHybridOverlayAnnotations(t *testing.T, node *v1.Node) {
+	assert.Contains(t, node.Annotations, hybridOverlaySubnet)
+	assert.Contains(t, node.Annotations, hybridOverlayMac)
 }
 
 // testHNSNetworksCreated tests that the required HNS Networks have been created on the bootstrapped node
@@ -274,10 +396,51 @@ func testHNSNetworksCreated(t *testing.T, vm e2ef.WindowsVM) {
 		"Could not find OpenShiftNetwork in list of HNS Networks")
 }
 
+// getAffinityForNode returns an affinity which matches the associated node's name
+func getAffinityForNode(node *v1.Node) (*v1.Affinity, error) {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "metadata.name",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{node.Name},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// getPodEvents gets all events for any pod with the input in its name. Used for debugging purposes
+func getPodEvents(name string) ([]v1.Event, error) {
+	eventList, err := framework.K8sclientset.CoreV1().Events(v1.NamespaceDefault).List(metav1.ListOptions{
+		FieldSelector: "involvedObject.kind=Pod"})
+	if err != nil {
+		return []v1.Event{}, err
+	}
+	podEvents := []v1.Event{}
+	for _, event := range eventList.Items {
+		if strings.Contains(event.InvolvedObject.Name, name) {
+			podEvents = append(podEvents, event)
+		}
+	}
+	return podEvents, nil
+
+}
+
 // testEastWestNetworking deploys Windows and Linux pods, and tests that the pods can communicate
-func testEastWestNetworking(t *testing.T, vm e2ef.WindowsVM) {
+func testEastWestNetworking(t *testing.T, node *v1.Node, vm e2ef.WindowsVM) {
+	affinity, err := getAffinityForNode(node)
+	require.NoError(t, err, "Could not get affinity for node")
+
 	// Deploy a webserver pod on the new node
-	winServerDeployment, err := deployWindowsWebServer(vm)
+	winServerDeployment, err := deployWindowsWebServer("win-webserver-"+vm.GetCredentials().GetInstanceId(), vm, affinity)
 	require.NoError(t, err, "Could not create Windows Server deployment")
 	defer deleteDeployment(winServerDeployment.Name)
 
@@ -288,7 +451,7 @@ func testEastWestNetworking(t *testing.T, vm e2ef.WindowsVM) {
 	// test Windows <-> Linux
 	// This will install curl and then curl the windows server.
 	linuxCurlerCommand := []string{"bash", "-c", "yum update; yum install curl -y; curl " + winServerIP}
-	linuxCurlerJob, err := createLinuxJob("linux-curler", linuxCurlerCommand)
+	linuxCurlerJob, err := createLinuxJob("linux-curler-"+vm.GetCredentials().GetInstanceId(), linuxCurlerCommand)
 	require.NoError(t, err, "Could not create Linux job")
 	defer deleteJob(linuxCurlerJob.Name)
 	err = waitUntilJobSucceeds(linuxCurlerJob.Name)
@@ -301,7 +464,7 @@ func testEastWestNetworking(t *testing.T, vm e2ef.WindowsVM) {
 		"$response = Invoke-Webrequest -UseBasicParsing -Uri " + winServerIP +
 		"; $code = $response.StatusCode; echo \"GET returned code $code\";" +
 		"If ($code -eq 200) {exit 0}; Start-Sleep -s 10;}; exit 1" + winServerIP}
-	winCurlerJob, err := createWindowsServerJob("win-curler", winCurlerCommand)
+	winCurlerJob, err := createWindowsServerJob("win-curler-"+vm.GetCredentials().GetInstanceId(), winCurlerCommand)
 	require.NoError(t, err, "Could not create Windows job")
 	defer deleteJob(winCurlerJob.Name)
 	err = waitUntilJobSucceeds(winCurlerJob.Name)
@@ -311,7 +474,7 @@ func testEastWestNetworking(t *testing.T, vm e2ef.WindowsVM) {
 }
 
 // deployWindowsWebServer creates a deployment with a single Windows Server pod, listening on port 80
-func deployWindowsWebServer(vm e2ef.WindowsVM) (*appsv1.Deployment, error) {
+func deployWindowsWebServer(name string, vm e2ef.WindowsVM, affinity *v1.Affinity) (*appsv1.Deployment, error) {
 	// Preload the image that will be used on the Windows node, to prevent download timeouts
 	// and separate possible failure conditions into multiple operations
 	err := pullDockerImage(windowsServerImage, vm)
@@ -326,7 +489,7 @@ func deployWindowsWebServer(vm e2ef.WindowsVM) (*appsv1.Deployment, error) {
 			"$content='<html><body><H1>Windows Container Web Server</H1></body></html>'; " +
 			"$buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; " +
 			"$response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };"}
-	winServerDeployment, err := createWindowsServerDeployment("win-server", winServerCommand)
+	winServerDeployment, err := createWindowsServerDeployment(name, winServerCommand, affinity)
 	if err != nil {
 		return nil, fmt.Errorf("could not create Windows deployment: %s", err)
 	}
@@ -352,11 +515,13 @@ func waitUntilJobSucceeds(name string) error {
 			return nil
 		}
 		if job.Status.Failed > 0 {
-			return fmt.Errorf("job %v failed", job)
+			events, _ := getPodEvents(name)
+			return fmt.Errorf("job %v failed: %v", job, events)
 		}
 		time.Sleep(e2ef.RetryInterval)
 	}
-	return fmt.Errorf("job %v timed out", job)
+	events, _ := getPodEvents(name)
+	return fmt.Errorf("job %v timed out: %v", job, events)
 }
 
 // waitUntilDeploymentScaled will return nil if the deployment reaches the amount of replicas specified in its spec
@@ -374,7 +539,8 @@ func waitUntilDeploymentScaled(name string) error {
 		}
 		time.Sleep(e2ef.RetryInterval)
 	}
-	return fmt.Errorf("timed out waiting for deployment %v to scale", deployment)
+	events, _ := getPodEvents(name)
+	return fmt.Errorf("timed out waiting for deployment %v to scale: %v", deployment, events)
 }
 
 // getPodIP returns the IP of the pod that matches the label selector. If more than one pod match the
@@ -447,7 +613,7 @@ func deleteJob(name string) error {
 }
 
 // createWindowsServerDeployment creates a deployment with a Windows Server 2019 container
-func createWindowsServerDeployment(name string, command []string) (*appsv1.Deployment, error) {
+func createWindowsServerDeployment(name string, command []string, affinity *v1.Affinity) (*appsv1.Deployment, error) {
 	deploymentsClient := framework.K8sclientset.AppsV1().Deployments(v1.NamespaceDefault)
 	replicaCount := int32(1)
 	deployment := &appsv1.Deployment{
@@ -468,6 +634,7 @@ func createWindowsServerDeployment(name string, command []string) (*appsv1.Deplo
 					},
 				},
 				Spec: v1.PodSpec{
+					Affinity: affinity,
 					Tolerations: []v1.Toleration{
 						{
 							Key:    "os",
@@ -521,14 +688,17 @@ func pullDockerImage(name string, vm e2ef.WindowsVM) error {
 }
 
 // testNorthSouthNetworking deploys a Windows Server pod, and tests that we can network with it from outside the cluster
-func testNorthSouthNetworking(t *testing.T, vm e2ef.WindowsVM) {
+func testNorthSouthNetworking(t *testing.T, node *v1.Node, vm e2ef.WindowsVM) {
+	affinity, err := getAffinityForNode(node)
+	require.NoError(t, err, "Could not get affinity for node")
+
 	// Deploy a webserver pod on the new node
-	winServerDeployment, err := deployWindowsWebServer(vm)
+	winServerDeployment, err := deployWindowsWebServer("win-webserver-"+vm.GetCredentials().GetInstanceId(), vm, affinity)
 	require.NoError(t, err, "Could not create Windows Server deployment")
 	defer deleteDeployment(winServerDeployment.Name)
 
 	// Create a load balancer svc to expose the webserver
-	loadBalancer, err := createLoadBalancer("win-server", *winServerDeployment.Spec.Selector)
+	loadBalancer, err := createLoadBalancer("win-webserver-"+vm.GetCredentials().GetInstanceId(), *winServerDeployment.Spec.Selector)
 	require.NoError(t, err, "Could not create load balancer for Windows Server")
 	defer deleteService(loadBalancer.Name)
 	loadBalancer, err = waitForLoadBalancerIngress(loadBalancer.Name)

--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -49,6 +49,11 @@ Run the WSU playbook:
 $ ansible-playbook -i hosts tasks/wsu/main.yaml -v
 ```
 
+A specific WMCB version can be used by specifying its URL when running the playbook
+```
+$ ansible-playbook -i hosts tasks/wsu/main.yaml -v -e wmcb_url=<location_of_wmcb>
+```
+
 ### End to end testing
 The following environment variables need to be set for running the end to end tests of the playbook:
 - ARTIFACT_DIR
@@ -77,3 +82,4 @@ The hack script can be given the following options:
   ```shell script
   $ hack/run-wsu-ci-e2e-test.sh -v"aws-instance-id,1.2.34.23,password" -s
   ```
+

--- a/tools/ansible/tasks/wsu/main.yaml
+++ b/tools/ansible/tasks/wsu/main.yaml
@@ -6,14 +6,14 @@
     wmcb_exe: "wmcb.exe"
 
   tasks:
-    - name: Gather required files
+    - name: Create directory to store files to be used later
+      tempfile:
+        state: directory
+      register: tmp_dir
+
+    - name: Build WMCB
+      when: wmcb_url is undefined
       block:
-
-        - name: Create directory to store files to be used later
-          tempfile:
-            state: directory
-          register: tmp_dir
-
         - name: Build WMCB
           make:
             target: build
@@ -21,6 +21,14 @@
 
         - name: Move WMCB to temporary directory
           command: mv "{{ project_root }}/{{ wmcb_exe }}" "{{ tmp_dir.path }}/{{ wmcb_exe }}"
+
+    - name: Gather required files
+      block:
+        - name: Download WMCB
+          when: wmcb_url is defined
+          get_url:
+            url: "{{ wmcb_url }}"
+            dest: "{{ tmp_dir.path }}/wmcb.exe"
 
         - name: Download Windows node kubelet
           get_url:
@@ -64,6 +72,10 @@
       win_tempfile:
         state: directory
       register: win_temp_dir
+
+    - name: Display Windows temporary directory
+      debug:
+        msg: "Windows temporary directory: {{ win_temp_dir.path }}"
 
     - name: Copy required files to Windows host
       win_copy:


### PR DESCRIPTION
This commit adds the option to use a released WMCB version, by setting
the wmcb_url variable when running the WSU playbook.

I also had to restructure the tests to allow the test suite to tests
against multiple VMs at the same time. This resulted in the concept of
tests against a VM and tests against the cluster to be implemented.