### PR TITLE
[ci] Fix skipVMSetup command line option

### DIFF
--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -12,7 +12,7 @@ while getopts ":v:s" opt; do
       VM_CREDS=$OPTARG
       ;;
     s ) # process option for skipping setup in VMs
-      SKIP_VM_SETUP="-skipSetup"
+      SKIP_VM_SETUP="-skipVMSetup"
       ;;
     \? )
       echo "Usage: $0 [-v] [-s]"

--- a/hack/run-wsu-ci-e2e-test.sh
+++ b/hack/run-wsu-ci-e2e-test.sh
@@ -13,7 +13,7 @@ while getopts ":v:s" opt; do
       VM_CREDS=$OPTARG
       ;;
     s ) # process option for skipping setup in VMs
-      SKIP_VM_SETUP="-skipSetup"
+      SKIP_VM_SETUP="-skipVMSetup"
       ;;
     \? )
       echo "Usage: $0 [-v] [-s]"


### PR DESCRIPTION
`skipVMSetup` was incorrectly referenced as `skipSetup` in the bash scripts. This PR fixes that.