### PR TITLE
[ci] Update Windows VM ami

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -96,9 +96,9 @@ func (f *TestFramework) Setup(vmCount int, credentials []*types.Credentials, ski
 	}
 	// Use Windows 2019 server image with containers in us-east1 zone for CI testing.
 	// TODO: Move to environment variable that can be fetched from the cloud provider
-	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
+	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0105f663dc99752af for
 	// Microsoft Windows Server 2019 Base with Containers.
-	imageID := "ami-0b8d82dea356226d3"
+	imageID := "ami-0105f663dc99752af"
 	// Using an AMD instance type, as the Windows hybrid overlay currently does not work on on machines using
 	// the Intel 82599 network driver
 	instanceType := "m5a.large"

--- a/tools/windows-node-installer/test/e2e/aws_test.go
+++ b/tools/windows-node-installer/test/e2e/aws_test.go
@@ -21,9 +21,9 @@ var (
 	dir            = os.Getenv("ARTIFACT_DIR")
 	privateKeyPath = os.Getenv("KUBE_SSH_KEY_PATH")
 
-	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0b8d82dea356226d3 for
+	// The CI-operator uses AWS region `us-east-1` which has the corresponding image ID: ami-0105f663dc99752af for
 	// Microsoft Windows Server 2019 Base with Containers.
-	imageID      = "ami-0b8d82dea356226d3"
+	imageID      = "ami-0105f663dc99752af"
 	instanceType = "m4.large"
 	sshKey       = "libra"
 


### PR DESCRIPTION
This commit updates the ami that we use for spinning up a Windows VM in
our wsu and wni e2e tests. The previous ami was removed, so this is a
short term fix to get e2e tests working. A longer term solution would be
finding the latest ami to use, but that will be featured in a future
commit.