### PR TITLE
[wni][aws][azure] Capture windows user in credentials

### DIFF
--- a/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/aws/ec2.go
@@ -50,6 +50,8 @@ var log = logger.Log.WithName("aws-ec2")
 const (
 	// Winrm port for https request
 	WINRM_PORT = 5986
+	// winUser is the user used to login into the instance
+	winUser = "Administrator"
 )
 
 // awsProvider is a provider specific struct which contains clients for EC2, IAM, and the existing OpenShift
@@ -185,7 +187,7 @@ func (a *AwsProvider) CreateWindowsVM() (credentials *types.Credentials, rerr er
 	// Build new credentials structure to be used by other actors. The actor is responsible for checking if
 	// the credentials are being generated properly. This method won't guarantee the existence of credentials
 	// if the VM is spun up
-	credentials = types.NewCredentials(instanceID, publicIPAddress, decryptedPassword)
+	credentials = types.NewCredentials(instanceID, publicIPAddress, decryptedPassword, winUser)
 	err = resource.AppendInstallerInfo([]string{instanceID}, []string{}, a.resourceTrackerDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to record instance ID to file at '%s',instance will not be able to be deleted, "+

--- a/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
+++ b/tools/windows-node-installer/pkg/cloudprovider/azure/vm.go
@@ -48,6 +48,8 @@ const (
 	vnetRulePriority = 602
 	// vnetRuleName is the security group rule name for vnet traffic within the cluster
 	vnetRuleName = "vnet_traffic"
+	// winUser is the user used to login into the instance.
+	winUser = "core"
 )
 
 var log = logger.Log.WithName("azure-vm")
@@ -786,7 +788,7 @@ func (az *AzureProvider) CreateWindowsVM() (*types.Credentials, error) {
 		log.Info(fmt.Sprintf("Please Check for file %s in %s directory on how to access the node",
 			instanceName, az.resourceTrackerDir))
 	}
-	credentials := types.NewCredentials(instanceName, *ipAddress, adminPassword)
+	credentials := types.NewCredentials(instanceName, *ipAddress, adminPassword, winUser)
 	return credentials, nil
 }
 

--- a/tools/windows-node-installer/pkg/types/types.go
+++ b/tools/windows-node-installer/pkg/types/types.go
@@ -12,12 +12,14 @@ type Credentials struct {
 	ipAddress string
 	// password to access the instance created
 	password string
+	// user used for accessing the  instance created
+	user string
 }
 
 // NewCredentials takes the instanceID, ip address and password of the Windows instance created and returns the
 // Credentials structure
-func NewCredentials(instanceID, ipAddress, password string) *Credentials {
-	return &Credentials{instanceID: instanceID, ipAddress: ipAddress, password: password}
+func NewCredentials(instanceID, ipAddress, password, user string) *Credentials {
+	return &Credentials{instanceID: instanceID, ipAddress: ipAddress, password: password, user: user}
 }
 
 // GetIPAddress returns the ip address of the given node
@@ -33,4 +35,9 @@ func (cred *Credentials) GetPassword() string {
 // GetInstanceID returns the instanceId associated with the given node
 func (cred *Credentials) GetInstanceId() string {
 	return cred.instanceID
+}
+
+// GetUserName returns the user name associated with the given node
+func (cred *Credentials) GetUserName() string {
+	return cred.user
 }


### PR DESCRIPTION
This commit ensures that we capture the user information that is used to
access the windows instance. This can be useful when working on the e2e
test cases, especially when interacting with windows VM via winrm client.
Username also varies with cloudprovider, so it would be good to include it
in the credential object.