### PR TITLE
[ci] Write WSU output to artifact dir

### DIFF
--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -2,8 +2,10 @@ package framework
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -174,4 +176,16 @@ func (f *TestFramework) TearDown() {
 			return
 		}
 	}
+}
+
+// WriteToArtifactDir will write contents to $ARTIFACT_DIR/subDirName/filename. If subDirName is empty, contents
+// will be written to $ARTIFACT_DIR/filename
+func (f *TestFramework) WriteToArtifactDir(contents []byte, subDirName, filename string) error {
+	path := filepath.Join(artifactDir, subDirName, filename)
+	dir, _ := filepath.Split(path)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not create %s: %s", dir, err)
+	}
+	return ioutil.WriteFile(path, contents, os.ModePerm)
 }

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -106,6 +106,10 @@ func runWSUTestSuite(t *testing.T, vm e2ef.WindowsVM) {
 	cmd := exec.Command("ansible-playbook", "-vvv", "-i", hostFilePath, playbookPath)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "WSU playbook returned error: %s, with output: %s", err, string(out))
+	logFileName := t.Name() + ".wsu.log"
+	if err = framework.WriteToArtifactDir(out, vm.GetCredentials().GetInstanceId(), logFileName); err != nil {
+		fmt.Printf("could not write %s to artifact dir: %s", logFileName, err)
+	}
 
 	// Ansible will copy files to a temporary directory with a path such as:
 	// C:\\Users\\Administrator\\AppData\\Local\\Temp\\ansible.z5wa1pc5.vhn\\


### PR DESCRIPTION
This commit writes the WSU output to the provided artifact dir, allowing
easier debugging of test failures.