### PR TITLE
[ci] Enable running of bootstrapper tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,44 +53,33 @@ network configuration to something other than CNI after the initial setup.
 ### Windows Machine Config Bootstrapper
 
 #### End to end testing
+The following environment variables need to be set for running the end to end tests:
+- ARTIFACT_DIR
+  - This can be set to any directory
+- AWS_SHARED_CREDENTIALS_FILE
+  - Set this to point to your AWS credentials file
+- KUBE_SSH_KEY_PATH
+  - The ssh key used to bring up the VM
+- KUBECONFIG
+  - The kubeconfig of the OpenShift cluster
 
-On an existing Windows instance which is ready to join the cluster, copy the worker ignition file to C:\Windows\Temp\worker.ign, and the kubelet to C:\Windows\Temp\kubelet.exe
+Once the above variables are set, you can run the unit and end to end tests by executing:
+```shell script
+$ hack/run-wmcb-ci-e2e-test.sh
+```
 
-On your Linux development machine, build the e2e test binary:
-```
-make build-wmcb-e2e-test
-```
-This will build a binary called `wmcb_e2e_test.exe`. Copy this binary to the Windows node and execute it. The expected
-output should be as follows:
-```
-PS C:\wmcb> .\wmcb_e2e_test.exe
-PASS
-```
-If the test passes run the following on your Linux development machine that has access to the cluster where the Windows
-node is present:
-```
-oc get csr
-```
-Approve the most recent csr by `system:serviceaccount:openshift-machine-config-operator:node-bootstrapper`
-```
-oc adm certificate approve $CSR_NAME
-```
-Repeat the above steps for the `system:node:$NODE_NAME` csr which will appear shortly. 
+The hack script can be given the following options:
+- `-v` option takes a list of VM credentials in the order of `instance-id,ip-address,password`. The username defaults
+   to `Administrator`. This allows you to run the tests against existing set of VMs.
+   ```shell script
+   $ hack/run-wmcb-ci-e2e-test.sh -v"aws-instance-id-1,3.135.234.23,password,aws-instance-id-2,3.135.234.23,password"
+   ```
 
-You can now do `oc get nodes`, and see the Windows node has joined the cluster.
-
-#### Unit testing
-
-On your Linux development machine, build the unit test binary:
-```
-make build-wmcb-unit-test
-```
-This will build a binary called `wmcb_unit_test.exe`. Copy this binary to a Windows node and execute it. The expected
-output should be as follows:
-```
-PS C:\wmcb> .\wmcb_test.exe
-PASS
-```
+- `-s` option allows you to skip the framework setup. The assumption here is that the framework setup has already been
+  run on the VM.
+  ```shell script
+  $ hack/run-wmcb-ci-e2e-test.sh -v"aws-instance-id,1.2.34.23,password" -s
+  ```
 
 ### Ansible
 

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -28,9 +28,15 @@ WMCB_TEST_DIR=$WMCO_ROOT/internal/test/wmcb
 # Build the unit test binary
 cd "${WMCO_ROOT}"
 make build-wmcb-unit-test
+make build-wmcb-e2e-test
 
-# The WMCB e2e tests requires the cluster address, we parse that here using oc
+
+# Set up hybrid networking on the cluster, a requirement of OVNKubernetes on Windows
+oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
+
+# The WMCB E2E tests requires the cluster address, we parse that here using oc
 CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 
-# Transfer the binary and run the unit tests
-CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .
+cd "${WMCB_TEST_DIR}"
+# Transfer the files and run the unit and e2e tests
+CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR go test -v -run=TestWMCB -filesToBeTransferred="../../../wmcb_unit_test.exe,../../../wmcb_e2e_test.exe,powershell/wget-ignore-cert.ps1" -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .

--- a/hack/run-wmcb-ci-e2e-test.sh
+++ b/hack/run-wmcb-ci-e2e-test.sh
@@ -29,6 +29,8 @@ WMCB_TEST_DIR=$WMCO_ROOT/internal/test/wmcb
 cd "${WMCO_ROOT}"
 make build-wmcb-unit-test
 
+# The WMCB e2e tests requires the cluster address, we parse that here using oc
+CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
+
 # Transfer the binary and run the unit tests
-cd "${WMCB_TEST_DIR}"
-CGO_ENABLED=0 GO111MODULE=on go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .
+CGO_ENABLED=0 GO111MODULE=on CLUSTER_ADDR=$CLUSTER_ADDR go test -v -run=TestWMCBUnit -binaryToBeTransferred=../../../wmcb_unit_test.exe -vmCreds="$VM_CREDS" $SKIP_VM_SETUP -timeout=30m .

--- a/internal/test/framework/framework.go
+++ b/internal/test/framework/framework.go
@@ -5,11 +5,21 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// RetryCount is the amount of times we will retry an api operation
+	RetryCount = 20
+	// RetryInterval is the interval of time until we retry after a failure
+	RetryInterval = 5 * time.Second
+	// WindowsLabel represents the node label that need to be applied to the Windows node created
+	WindowsLabel = "node.openshift.io/os_id=Windows"
 )
 
 var (
@@ -21,6 +31,9 @@ var (
 	artifactDir string
 	// privateKeyPath is the path to the key that will be used to retrieve the password of each Windows VM
 	privateKeyPath string
+	// clusterAddress is the address of the OpenShift cluster e.g. "foo.fah.com".
+	// This should not include "https://api-" or a port
+	ClusterAddress string
 )
 
 // TestFramework holds the info to run the test suite.
@@ -80,6 +93,10 @@ func initCIvars() error {
 	privateKeyPath = os.Getenv("KUBE_SSH_KEY_PATH")
 	if privateKeyPath == "" {
 		return fmt.Errorf("KUBE_SSH_KEY_PATH environment variable not set")
+	}
+	ClusterAddress = os.Getenv("CLUSTER_ADDR")
+	if ClusterAddress == "" {
+		return fmt.Errorf("CLUSTER_ADDR environment variable not set")
 	}
 	return nil
 }

--- a/internal/test/wmcb/powershell/wget-ignore-cert.ps1
+++ b/internal/test/wmcb/powershell/wget-ignore-cert.ps1
@@ -1,0 +1,26 @@
+# Script that downloads a file from the server to the output location ignoring the server certificate
+param (
+    [Parameter(Mandatory=$true)][string]$server,
+    [Parameter(Mandatory=$true)][string]$output
+)
+
+if (-not("dummy" -as [type])) {
+    add-type -TypeDefinition @"
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+public static class Dummy {
+    public static bool ReturnTrue(object sender,
+        X509Certificate certificate,
+        X509Chain chain,
+        SslPolicyErrors sslPolicyErrors) { return true; }
+    public static RemoteCertificateValidationCallback GetDelegate() {
+        return new RemoteCertificateValidationCallback(Dummy.ReturnTrue);
+    }
+}
+"@
+}
+[System.Net.ServicePointManager]::ServerCertificateValidationCallback = [dummy]::GetDelegate()
+
+wget $server -o $output

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -13,11 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// nodeLabels represents the node label that need to be applied to the Windows node created
-	nodeLabel = "node.openshift.io/os_id=Windows"
-)
-
 var (
 	// windowsTaint is the taint that needs to be applied to the Windows node
 	windowsTaint = v1.Taint{
@@ -76,7 +71,7 @@ func TestWMCBCluster(t *testing.T) {
 	winNodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "kubernetes.io/os=windows"})
 	require.NoErrorf(t, err, "error while getting Windows node: %v", err)
 	assert.Equal(t, hasWindowsTaint(winNodes.Items), true, "expected Windows Taint to be present on the Windows Node")
-	winNodes, err = client.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: nodeLabel})
+	winNodes, err = client.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: e2ef.WindowsLabel})
 	require.NoErrorf(t, err, "error while getting Windows node: %v", err)
 	assert.Lenf(t, winNodes.Items, 1, "expected one node to have node label but found: %v", len(winNodes.Items))
 }

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -2,15 +2,37 @@ package wmcb
 
 import (
 	"flag"
+	"fmt"
 	"log"
-	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	certificates "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	// remoteDir is the remote temporary directory that the e2e test uses
+	remoteDir = "C:\\Temp\\"
+	// winTemp is the default Windows temporary directory
+	winTemp = "C:\\Windows\\Temp\\"
+	// wgetIgnoreCertCmd is the remote location of the wget-ignore-cert.ps1 script
+	wgetIgnoreCertCmd = remoteDir + "wget-ignore-cert.ps1"
+	// e2eExecutable is the remote location of the WMCB e2e test binary
+	e2eExecutable = remoteDir + "wmcb_e2e_test.exe"
+	// unitExecutable is the remote location of the WMCB unit test binary
+	unitExecutable = remoteDir + "wmcb_unit_test.exe"
+	// kubePackageURL is the kubernetes node package URL
+	kubePackageURL = "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz"
+	// kubePackageSHA is the SHA512 of node package from
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#node-binaries-3
+	kubePackageSHA = "a88e7a1c6f72ea6073dbb4ddfe2e7c8bd37c9a56d94a33823f531e303a9915e7a844ac5880097724e44dfa7f4a9659d14b79cc46e2067f6b13e6df3f3f1b0f64"
 )
 
 var (
@@ -20,31 +42,252 @@ var (
 		Value:  "Windows",
 		Effect: v1.TaintEffectNoSchedule,
 	}
-	// binaryToBeTransferred holds the binary that needs to be transferred to the Windows VM
-	// TODO: Make this an array later with a comma separated values for more binaries to be transferred
-	binaryToBeTransferred = flag.String("binaryToBeTransferred", "",
-		"Absolute path of the binary to be transferred")
+	// filesToBeTransferred holds the list of files that needs to be transferred to the Windows VM
+	filesToBeTransferred = flag.String("filesToBeTransferred", "",
+		"Comma separated list of files to be transferred")
 )
 
-// TestWMCBUnit runs the unit tests for WMCB
-func TestWMCBUnit(t *testing.T) {
+// wmcbVM is a wrapper for the WindowsVM interface that associates it with WMCB specific testing
+type wmcbVM struct {
+	e2ef.WindowsVM
+}
+
+// TestWMCB runs the unit and e2e tests for WMCB on the remote VMs
+func TestWMCB(t *testing.T) {
+	remoteDir := "C:\\Temp"
 	for _, vm := range framework.WinVMs {
-		runWMCBUnitTestSuite(t, vm)
+		wVM := &wmcbVM{vm}
+		files := strings.Split(*filesToBeTransferred, ",")
+		for _, file := range files {
+			err := wVM.CopyFile(file, remoteDir)
+			require.NoError(t, err, "error copying %s to the Windows VM", file)
+		}
+		t.Run("Unit", func(t *testing.T) {
+			assert.NoError(t, wVM.runTest(unitExecutable+" --test.v"), "WMCB unit test failed")
+		})
+		t.Run("E2E", func(t *testing.T) {
+			wVM.runE2ETestSuite(t)
+		})
+		t.Run("WMCB cluster tests", testWMCBCluster)
 	}
 }
 
-// runWMCBUnitTestSuite runs the unit test suite on the VM
-func runWMCBUnitTestSuite(t *testing.T, vm e2ef.WindowsVM) {
-	remoteDir := "C:\\Temp"
-	err := vm.CopyFile(*binaryToBeTransferred, remoteDir)
-	require.NoError(t, err, "error copying binary to the Windows VM")
+// runE2ETestSuite runs the WmCB e2e tests suite on the VM
+func (vm *wmcbVM) runE2ETestSuite(t *testing.T) {
+	vm.runTestBootstrapper(t)
 
-	stdout, stderr, err := vm.Run(remoteDir+"\\"+filepath.Base(*binaryToBeTransferred)+" --test.v", true)
-	assert.NoError(t, err, "error running WMCB unit test suite")
+	// Handle the bootstrap and node CSRs
+	err := handleCSRs()
+	require.NoError(t, err, "error handling CSRs")
+}
+
+// runTest runs the testCmd in the given VM
+func (vm *wmcbVM) runTest(testCmd string) error {
+	stdout, stderr, err := vm.Run(testCmd, true)
+
+	// Logging the output so that it is visible on the CI page
 	log.Printf("\n%s\n", stdout)
-	assert.Equal(t, "", stderr, "WMCB unit test returned error output")
-	assert.NotContains(t, stdout, "FAIL", "WMCB unit test failed")
-	assert.NotContains(t, stdout, "panic", "WMCB unit test panic")
+	log.Printf("\n%s\n", stderr)
+
+	if err != nil {
+		return fmt.Errorf("error running test: %v", err)
+	}
+	if stderr != "" {
+		return fmt.Errorf("test returned stderr output")
+	}
+	if strings.Contains(stdout, "FAIL") {
+		return fmt.Errorf("test output showed a failure")
+	}
+	if strings.Contains(stdout, "panic") {
+		return fmt.Errorf("test output showed panic")
+	}
+	return nil
+}
+
+// runTestBootstrapper runs the initialize-kubelet tests
+func (vm *wmcbVM) runTestBootstrapper(t *testing.T) {
+	err := vm.initializeTestBootstrapperFiles()
+	require.NoError(t, err, "error initializing files required for TestBootstrapper")
+
+	err = vm.runTest(e2eExecutable + " --test.run TestBootstrapper --test.v")
+	require.NoError(t, err, "TestBootstrapper failed")
+}
+
+// initializeTestBootstrapperFiles initializes the files required for initialize-kubelet
+func (vm *wmcbVM) initializeTestBootstrapperFiles() error {
+	// Create the temp directory
+	_, _, err := vm.Run("if not exist "+remoteDir+" mkdir "+remoteDir, false)
+	if err != nil {
+		return fmt.Errorf("unable to create remote directory %s: %v", remoteDir, err)
+	}
+
+	// Download and extract the kube package on the VM
+	err = vm.remoteDownloadExtract(kubePackageURL, kubePackageSHA, remoteDir+"kube.tar.gz", remoteDir)
+	if err != nil {
+		return fmt.Errorf("unable to download kube package: %v", err)
+	}
+
+	// Copy kubelet.exe to C:\Windows\Temp\
+	_, _, err = vm.Run("cp "+remoteDir+"kubernetes\\node\\bin\\kubelet.exe "+winTemp, true)
+	if err != nil {
+		return fmt.Errorf("unable to copy kubelet.exe to %s", winTemp)
+	}
+
+	// Download the worker ignition to C:\Windows\Tenp\ using the script that ignores the server cert
+	_, _, err = vm.Run(wgetIgnoreCertCmd+" -server https://api-int."+e2ef.ClusterAddress+":22623/config/worker"+" -output "+winTemp+"worker.ign", true)
+	if err != nil {
+		return fmt.Errorf("unable to download worker.ign: %v", err)
+	}
+
+	return nil
+}
+
+// remoteDownloadExtract downloads the tar file in url to the remoteDownloadFile location and checks if the SHA matches
+func (vm *wmcbVM) remoteDownload(url, sha, remoteDownloadFile string) error {
+	_, stderr, err := vm.Run("if (!(Test-Path "+remoteDownloadFile+")) { wget "+url+" -o "+remoteDownloadFile+" }", true)
+	if err != nil {
+		return fmt.Errorf("unable to download %s: %v\n%s", url, err, stderr)
+	}
+
+	if sha == "" {
+		return nil
+	}
+
+	// Perform a checksum check
+	stdout, _, err := vm.Run("certutil -hashfile "+remoteDownloadFile+" sha512", true)
+	if err != nil {
+		return fmt.Errorf("unable to check SHA of %s: %v", remoteDownloadFile, err)
+	}
+	if !strings.Contains(stdout, sha) {
+		return fmt.Errorf("package %s SHA does not match: %v\n%s", remoteDownloadFile, err, stdout)
+	}
+
+	return nil
+}
+
+// remoteDownloadExtract downloads the tar file in url to the remoteDownloadFile location, checks if the SHA matches and
+//  extracts the files to the remoteExtractDir directory
+func (vm *wmcbVM) remoteDownloadExtract(url, sha, remoteDownloadFile, remoteExtractDir string) error {
+	// Download the file from the URL
+	err := vm.remoteDownload(url, sha, remoteDownloadFile)
+	if err != nil {
+		return fmt.Errorf("unable to download %s: %v", url, err)
+	}
+
+	// Extract files from the archive
+	_, stderr, err := vm.Run("tar -xf "+remoteDownloadFile+" -C "+remoteExtractDir, true)
+	if err != nil {
+		return fmt.Errorf("unable to extract %s: %v\n%s", remoteDownloadFile, err, stderr)
+	}
+	return nil
+}
+
+// approve approves the given CSR if it has not already been approved
+// Based on https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/certificates/certificates.go#L237
+func approve(csr *certificates.CertificateSigningRequest) error {
+	// Check if the certificate has already been approved
+	for _, c := range csr.Status.Conditions {
+		if c.Type == certificates.CertificateApproved {
+			return nil
+		}
+	}
+
+	// Approve the CSR
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Ensure we get the current version
+		csr, err := framework.K8sclientset.CertificatesV1beta1().CertificateSigningRequests().Get(
+			csr.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Add the approval status condition
+		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+			Type:           certificates.CertificateApproved,
+			Reason:         "WMCBe2eTestRunnerApprove",
+			Message:        "This CSR was approved by WMCB e2e test runner",
+			LastUpdateTime: metav1.Now(),
+		})
+
+		_, err = framework.K8sclientset.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+		return err
+	})
+}
+
+//findCSR finds the CSR that matches the requestor filter
+func findCSR(requestor string) (*certificates.CertificateSigningRequest, error) {
+	var foundCSR *certificates.CertificateSigningRequest
+	// Find the CSR
+	for retries := 0; retries < e2ef.RetryCount; retries++ {
+		csrs, err := framework.K8sclientset.CertificatesV1beta1().CertificateSigningRequests().List(metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to get CSR list: %v", err)
+		}
+		if csrs == nil {
+			time.Sleep(e2ef.RetryInterval)
+			continue
+		}
+
+		for _, csr := range csrs.Items {
+			if !strings.Contains(csr.Spec.Username, requestor) {
+				continue
+			}
+			var handledCSR bool
+			for _, c := range csr.Status.Conditions {
+				if c.Type == certificates.CertificateApproved || c.Type == certificates.CertificateDenied {
+					handledCSR = true
+					break
+				}
+			}
+			if handledCSR {
+				continue
+			}
+			foundCSR = &csr
+			break
+		}
+
+		if foundCSR != nil {
+			break
+		}
+		time.Sleep(e2ef.RetryInterval)
+	}
+
+	if foundCSR == nil {
+		return nil, fmt.Errorf("unable to find CSR with requestor %s", requestor)
+	}
+	return foundCSR, nil
+}
+
+// handleCSR finds the CSR based on the requestor filter and approves it
+func handleCSR(requestorFilter string) error {
+	csr, err := findCSR(requestorFilter)
+	if err != nil {
+		return fmt.Errorf("error finding CSR for %s: %v", requestorFilter, err)
+	}
+
+	if err = approve(csr); err != nil {
+		return fmt.Errorf("error approving CSR for %s: %v", requestorFilter, err)
+	}
+
+	return nil
+}
+
+// handleCSRs handles the approval of bootstrap and node CSRs
+func handleCSRs() error {
+	// Handle the bootstrap CSR
+	err := handleCSR("system:serviceaccount:openshift-machine-config-operator:node-bootstrapper")
+	if err != nil {
+		return fmt.Errorf("unable to handle bootstrap CSR: %v", err)
+	}
+
+	// Handle the node CSR
+	// Note: for the product we want to get the node name from the instance information
+	err = handleCSR("system:node:")
+	if err != nil {
+		return fmt.Errorf("unable to handle node CSR: %v", err)
+	}
+
+	return nil
 }
 
 // hasWindowsTaint returns true if the given Windows node has the Windows taint
@@ -61,12 +304,9 @@ func hasWindowsTaint(winNodes []v1.Node) bool {
 	return false
 }
 
-// TestWMCBCluster runs the cluster tests for the nodes
-func TestWMCBCluster(t *testing.T) {
-	//TODO: Transfer the WMCB binary to the Windows node and approve CSR for the Windows node.
-	// I want this to be moved to another test. We've another card for this, so let's come back
-	// to that later(WINC-82). As of now, this test is limited to check if the taint has been
-	// applied to the Windows node and skipped for now.
+// testWMCBCluster runs the cluster tests for the nodes
+func testWMCBCluster(t *testing.T) {
+	// TODO: Fix this test for multiple VMs
 	client := framework.K8sclientset
 	winNodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "kubernetes.io/os=windows"})
 	require.NoErrorf(t, err, "error while getting Windows node: %v", err)

--- a/test/e2e/bootstrapper_test.go
+++ b/test/e2e/bootstrapper_test.go
@@ -71,23 +71,8 @@ func TestBootstrapper(t *testing.T) {
 			t.Skip("Skipping as kubelet was already running before the test")
 		}
 		// Wait for kubelet log to be populated
-		time.Sleep(5 * time.Second)
+		time.Sleep(30 * time.Second)
 		assert.True(t, isKubeletRunning(t, kubeletLogPath))
-	})
-
-	// Run it again, to ensure it maintains state if the bootstrapper is already started
-	time.Sleep(5 * time.Second)
-	wmcb, err = bootstrapper.NewWinNodeBootstrapper(installDir, ignitionFilePath, kubeletPath, "", "")
-	require.NoErrorf(t, err, "Could not create WinNodeBootstrapper: %s", err)
-	err = wmcb.InitializeKubelet()
-	assert.NoErrorf(t, err, "Could not run bootstrapper: %s", err)
-	err = wmcb.Disconnect()
-	assert.NoErrorf(t, err, "Could not disconnect from windows svc API: %s", err)
-
-	t.Run("Kubelet Windows service starts after bootstrapper is run a second time", func(t *testing.T) {
-		// Wait for the service to start
-		time.Sleep(2 * time.Second)
-		assert.Truef(t, svcRunning(t, bootstrapper.KubeletServiceName), "The kubelet service is not running")
 	})
 
 	// Kubelet arguments with paths that are set by bootstrapper


### PR DESCRIPTION
- [ci] Move common entities to the framework
  Move ClusterAddress and intializing it into the framework. Do the same for RetryCount, RetryInterval and WindowsLabel into the framework as  they will be required by both WSU and WMCB test suites.
- [wmcb] Fix e2e tests
  - TestBootstrapper ends up calling initialize-kubelet twice resulting in two bootstrap CSRs being issued. This is problematic when running this in CI as the test runner needs approve all CSRs. Rather    than doing that this test needs to be split up or called twice from the runner.
  - testConfigureCNIWithoutKubeletSvc assumes the presence of the CNI dir and config when it is run. This test is called from TestBootstrapper at which points the required files are not created. Fix the test to create a temp CNI dir and config.
  - Increase the wait time before the kubelet logs are checked for success.
- [ci][wmcb] Enable running of bootstrapper tests
  Copy wmcb_e2e_test.exe to the Windows VM and execute the bootstrapper test. To allow this to succeed, perform all the pre-requisite steps as defined by the test namely:
  - Copy the kube package and extract it
  - wget the worker ignition from the cluster
  - This required a PowerShell script as embedding the script was fraught with peril
  - Approve the CSRs generated by running the tests
  - Enable running of against the cluster tests

Running of the configure-cni test will be done in a follow up PR.