### PR TITLE
[wni] Use latest Windows image

### DIFF
--- a/tools/windows-node-installer/README.md
+++ b/tools/windows-node-installer/README.md
@@ -28,7 +28,7 @@ make build-tools
 
 The `wni` requires the kubeconfig of the OpenShift cluster, a provider specific credentials file to create and 
 destroy a Windows instance on the selected provider. To create an instance, `wni` also 
-requires extra information such as image id and instance type. Some optional flags include directory path to 
+requires extra information such as the instance type. Some optional flags include directory path to
 windows-node-installer.json file and log level display. For more information please 
 visit `--help` for any commands or sub-commands.
 Available Commands:
@@ -41,7 +41,7 @@ Available Commands:
 
 ```bash
 ./wni aws create --kubeconfig <path to OpenShift cluster>/kubeconfig --credentials <path to aws>/credentials 
---credential-account default --image-id ami-06a4e829b8bbad61e --instance-type m5a.large --ssh-key <name of the 
+--credential-account default --instance-type m5a.large --ssh-key <name of the
 existing ssh keypair in aws> --private-key <private key to decrypt the aws instance password.>
 ```
 

--- a/tools/windows-node-installer/cmd/aws.go
+++ b/tools/windows-node-installer/cmd/aws.go
@@ -96,7 +96,7 @@ func createCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&awsInfo.imageID, "image-id", "",
 		"ami ID of a base image for the instance (i.e."+
-			": ami-06a4e829b8bbad61e for Microsoft Windows Server 2019 Base image on AWS) (required)")
+			": ami-06a4e829b8bbad61e for Microsoft Windows Server 2019 Base image on AWS)")
 	cmd.PersistentFlags().StringVar(&awsInfo.instanceType, "instance-type", "",
 		"name of a type of instance (i.e.: m4.large for AWS, etc) (required)")
 	cmd.PersistentFlags().StringVar(&awsInfo.sshKey, "ssh-key", "",
@@ -108,11 +108,7 @@ func createCmd() *cobra.Command {
 
 // validateCreateFlags defines required flags for createCmd.
 func validateCreateFlags(createCmd *cobra.Command) error {
-	err := createCmd.MarkPersistentFlagRequired("image-id")
-	if err != nil {
-		return err
-	}
-	err = createCmd.MarkPersistentFlagRequired("instance-type")
+	err := createCmd.MarkPersistentFlagRequired("instance-type")
 	if err != nil {
 		return err
 	}

--- a/tools/windows-node-installer/test/e2e/aws_test.go
+++ b/tools/windows-node-installer/test/e2e/aws_test.go
@@ -44,11 +44,24 @@ var (
 // TestAwsE2eSerial runs all e2e tests for the AWS implementation serially. It creates the Windows instance,
 // checks all properties of the instance and destroy the instance and check that resource are deleted.
 func TestAwsE2eSerial(t *testing.T) {
-	awsSetup(t)
+	err := awsSetup()
+	if err != nil {
+		tdErr := tearDownInstance()
+		if tdErr != nil {
+			t.Logf("error with test teardown: %s", tdErr)
+		}
+		t.Fatal(err)
+	}
 
 	t.Run("test create Windows Instance", testCreateWindowsInstance)
 
 	t.Run("test destroy Windows instance", testDestroyWindowsInstance)
+
+	// Make sure the instance is torn down in case the destroy fails
+	err = tearDownInstance()
+	if err != nil {
+		t.Logf("error with test teardown: %s", err)
+	}
 }
 
 // testCreateWindowsInstance tests the creation of a Windows instance and checks its properties and attached items.
@@ -70,66 +83,100 @@ func testDestroyWindowsInstance(t *testing.T) {
 	t.Run("test instance is terminated", destroyingWindowsInstance)
 	t.Run("test Windows security group is deleted", testSgIsDeleted)
 	t.Run("test installer json file is deleted", testInstallerJsonFileIsDeleted)
+
 }
 
 // awsSetup does the setup steps such as:
 // 1. Obtain the awsProvider object from the cloud factory implementation.
 // 2. Spin up the windows instance, to test properties on it.
-func awsSetup(t *testing.T) {
-	setupAWSCloudProvider(t)
-	setupWindowsInstanceWithResources(t)
+func awsSetup() error {
+	err := setupAWSCloudProvider()
+	if err != nil {
+		return err
+	}
+	err = setupWindowsInstanceWithResources()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // setupAWSCloudProvider creates provider ofr Cloud interface and asserts type into AWS provider.
 // This is the first step of the e2e test and fails the test upon error.
-func setupAWSCloudProvider(t *testing.T) {
+func setupAWSCloudProvider() error {
 	// The e2e test uses Microsoft Windows Server 2019 Base with Containers image, m4.large type, and libra ssh key.
 	cloud, err := cloudprovider.CloudProviderFactory(kubeconfig, awscredentials, "default", artifactDir,
 		imageID, instanceType, sshKey, privateKeyPath)
-	require.NoError(t, err, "Error obtaining aws interface object")
+	if err != nil {
+		return fmt.Errorf("error obtaining aws interface object: %s", err)
+	}
 
 	// Type assert to AWS so that we can test other functionality
 	provider, ok := cloud.(*awscp.AwsProvider)
-	assert.True(t, ok, "Error asserting cloudprovider to awsProvider")
+	if !ok {
+		return fmt.Errorf("error asserting cloudprovider to awsProvider")
+	}
 	awsProvider = provider
+	return nil
 }
 
 // setupWindowsInstanceWithResources creates a Windows instance and updates global information for infraID,
 // createdInstanceID, and createdSgID. All information updates are required to be successful or instance will be
 // teared down.
-func setupWindowsInstanceWithResources(t *testing.T) {
+func setupWindowsInstanceWithResources() error {
 	var err error
+	// Create the instance
 	credentials, err = awsProvider.CreateWindowsVM()
 	if err != nil {
-		tearDownInstance(t, "error creating Windows instance", err)
+		return fmt.Errorf("error creating Windows instance: %s", err)
 	}
-	require.NoError(t, err, "failed to create the windows instance")
+
+	// Ensure we have the login info for the instance
+	if credentials == nil {
+		return fmt.Errorf("returned credentials empty")
+	}
+	if credentials.GetPassword() == "" {
+		return fmt.Errorf("returned password empty")
+	}
+	if credentials.GetInstanceId() == "" {
+		return fmt.Errorf("returned instance id empty")
+	}
 
 	infraID, err = awsProvider.GetInfraID()
 	if err != nil {
-		tearDownInstance(t, "error while getting infrastructure ID for the OpenShift cluster", err)
+		return fmt.Errorf("error while getting infrastructure ID for the OpenShift cluster: %s", err)
 	}
-	require.NotEmpty(t, credentials, "Credentials returned are empty")
-	require.NotEmpty(t, credentials.GetPassword(), "Expected some password but got empty string")
-	require.NotEmpty(t, credentials.GetInstanceId(), "Expected instanceID to be present but got empty string")
 
 	// Check instance and security group information in windows-node-installer.json.
 	info, err := resource.ReadInstallerInfo(artifactDir + "/" + "windows-node-installer.json")
 	if err != nil {
-		tearDownInstance(t, "error reading from windows-node-installer.json file", err)
+		return fmt.Errorf("error reading from windows-node-installer.json file: %s", err)
 	}
 
-	if len(info.SecurityGroupIDs) > 0 && info.SecurityGroupIDs[0] != "" {
-		createdSgID = info.SecurityGroupIDs[0]
-	} else {
-		tearDownInstance(t, "security group ID information is empty", err)
+	// Set security group value
+	if len(info.SecurityGroupIDs) != 1 {
+		return fmt.Errorf("expected one security group but found %d", len(info.SecurityGroupIDs))
 	}
+	if info.SecurityGroupIDs[0] == "" {
+		return fmt.Errorf("found empty security group")
+	}
+	createdSgID = info.SecurityGroupIDs[0]
 
-	if len(info.SecurityGroupIDs) > 0 && info.SecurityGroupIDs[0] != "" {
-		createdInstanceID = info.InstanceIDs[0]
-	} else {
-		tearDownInstance(t, "instance ID information is empty", err)
+	// Set instanceID value
+	if len(info.InstanceIDs) != 1 {
+		return fmt.Errorf("expected one instance but found %d", len(info.InstanceIDs))
 	}
+	if info.InstanceIDs[0] == "" {
+		return fmt.Errorf("found empty instance id value")
+	}
+	createdInstanceID = info.InstanceIDs[0]
+
+	instance, err := getInstance(createdInstanceID)
+	if err != nil {
+		return fmt.Errorf("could not resolve instance id %s to instance: %s", createdInstanceID, err)
+	}
+	createdInstance = instance
+	return nil
 }
 
 // waitForStatusok waits for the instance to be okay.
@@ -206,34 +253,29 @@ func getInstance(instanceID string) (*ec2.Instance, error) {
 
 // tearDownInstance removes the lingering resources including instance and Windows security group when required steps of
 // the test fail.
-func tearDownInstance(t *testing.T, Msg string, terr error) {
-	t.Logf("%s, tearing down lingering resources", Msg)
-
+func tearDownInstance() error {
 	if createdInstanceID != "" {
 		err := awsProvider.TerminateInstance(createdInstanceID)
 		if err != nil {
-			t.Errorf("error terminating instance during teardown, %v", err)
+			return fmt.Errorf("error terminating instance during teardown, %v", err)
 		}
 	}
+	// Return the global variables to their original state to no longer reference the torn down instance
+	createdInstanceID = ""
+	createdInstance = &ec2.Instance{}
 
 	if createdSgID != "" {
 		err := awsProvider.DeleteSG(createdSgID)
 		if err != nil {
-			t.Errorf("error terminating instance during teardown, %v", err)
+			return fmt.Errorf("error deleting security group during teardown, %v", err)
 		}
 	}
-	assert.FailNow(t, terr.Error(), Msg)
+	return nil
 }
 
 // testInstanceProperties updates the createdInstance global object and asserts if an instance is in the running
 // state, has the right image id, instance type, and ssh key associated.
 func testInstanceProperties(t *testing.T) {
-	instance, err := getInstance(createdInstanceID)
-	if err != nil {
-		tearDownInstance(t, "error getting ec2 instance object after creation", err)
-	} else {
-		createdInstance = instance
-	}
 	assert.Equal(t, ec2.InstanceStateNameRunning, *createdInstance.State.Name,
 		"created instance is not in running state")
 
@@ -244,7 +286,7 @@ func testInstanceProperties(t *testing.T) {
 	assert.Equalf(t, sshKey, *createdInstance.KeyName, "created instance ssh key mismatch")
 }
 
-// testInstanceHasPublicSubnetAndIp asserts if the instance is associated with a public IP address and  subnet by
+// testInstanceHasPublicSubnetAndIp asserts if the instance is associated with a public IP address and subnet by
 // checking if the subnet routing table has internet gateway attached.
 func testInstanceHasPublicSubnetAndIp(t *testing.T) {
 	assert.NotEmpty(t, createdInstance.PublicIpAddress, "instance does not have a public IP address")
@@ -371,16 +413,10 @@ func testInstanceIsAssociatedWithClusterWorkerIAM(t *testing.T) {
 // destroyingWindowsInstance destroys Windows instance and updates the createdInstance global object.
 func destroyingWindowsInstance(t *testing.T) {
 	err := awsProvider.DestroyWindowsVMs()
-	if err != nil {
-		tearDownInstance(t, "error destroying Windows instance", err)
-	}
+	require.NoError(t, err, "Error destroying Windows VMs")
 
 	createdInstance, err = getInstance(createdInstanceID)
-	if err != nil {
-		tearDownInstance(t, "error getting ec2 instance object after termination", err)
-	} else {
-		createdInstanceID = ""
-	}
+	require.NoError(t, err, "Error retrieving Windows VM")
 
 	assert.Equal(t, ec2.InstanceStateNameTerminated, *createdInstance.State.Name,
 		"instance is not in the terminated state")


### PR DESCRIPTION
This commit makes it so that if an imageId is not provided to the WNI,
the latest Windows Server 2019 with Containers image will be used. This
is being done so that we can run outside the us-east-1 region, as
imageId's are region specific.