### PR TITLE
[ci] Enable running of WMCB CNI e2e tests

### DIFF
--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -11,6 +11,7 @@ replace (
 require (
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/google/go-github/v29 v29.0.2
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.0 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/internal/test/go.sum
+++ b/internal/test/go.sum
@@ -75,6 +75,10 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
+github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -188,6 +192,7 @@ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,6 @@
+package test
+
+const (
+	// hybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
+	HybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"
+)

--- a/internal/test/wmcb/templates/cni.template
+++ b/internal/test/wmcb/templates/cni.template
@@ -1,0 +1,31 @@
+{
+    "cniVersion":"0.2.0",
+    "name":"OpenShiftNetwork",
+        "type":"win-overlay",
+ "capabilities": {
+        "dns": true
+    },
+    "ipam": {
+        "type": "host-local",
+        "subnet": "{{ .OvnHostSubnet }}"
+    },
+        "policies":[
+            {
+                "name":"EndpointPolicy",
+                "value":{
+                    "Type":"OutBoundNAT",
+                    "ExceptionList":[
+                        "{{ .ServiceNetworkCIDR }}"
+                    ]
+                }
+            },
+            {
+                "name":"EndpointPolicy",
+                "value":{
+                    "Type":"ROUTE",
+                    "DestinationPrefix":"{{ .ServiceNetworkCIDR }}",
+                    "NeedEncap":true
+                }
+            }
+        ]
+}

--- a/internal/test/wmcb/wmcb_test.go
+++ b/internal/test/wmcb/wmcb_test.go
@@ -3,11 +3,18 @@ package wmcb
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
+	"github.com/openshift/windows-machine-config-operator/internal/test"
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,17 +29,24 @@ const (
 	remoteDir = "C:\\Temp\\"
 	// winTemp is the default Windows temporary directory
 	winTemp = "C:\\Windows\\Temp\\"
+	// winCNIDir is the directory where the CNI files are placed
+	winCNIDir = winTemp + "\\cni\\"
+	// winCNIConfigPath is the CNI configuration file path on the Windows VM
+	winCNIConfigPath = "C:\\Windows\\Temp\\cni\\config\\"
+	// logDir is the remote kubernetes log director
+	kLog = "C:\\k\\log\\"
+	// cniConfigTemplate is the location of the cni.conf template file
+	cniConfigTemplate = "templates/cni.template"
 	// wgetIgnoreCertCmd is the remote location of the wget-ignore-cert.ps1 script
 	wgetIgnoreCertCmd = remoteDir + "wget-ignore-cert.ps1"
 	// e2eExecutable is the remote location of the WMCB e2e test binary
 	e2eExecutable = remoteDir + "wmcb_e2e_test.exe"
 	// unitExecutable is the remote location of the WMCB unit test binary
 	unitExecutable = remoteDir + "wmcb_unit_test.exe"
-	// kubePackageURL is the kubernetes node package URL
-	kubePackageURL = "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz"
-	// kubePackageSHA is the SHA512 of node package from
-	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#node-binaries-3
-	kubePackageSHA = "a88e7a1c6f72ea6073dbb4ddfe2e7c8bd37c9a56d94a33823f531e303a9915e7a844ac5880097724e44dfa7f4a9659d14b79cc46e2067f6b13e6df3f3f1b0f64"
+	// hybridOverlayName is the name of the hybrid overlay executable
+	hybridOverlayName = "hybrid-overlay.exe"
+	// hybridOverExecutable is the remote location of the hybrid overlay binary
+	hybridOverlayExecutable = remoteDir + hybridOverlayName
 )
 
 var (
@@ -45,11 +59,33 @@ var (
 	// filesToBeTransferred holds the list of files that needs to be transferred to the Windows VM
 	filesToBeTransferred = flag.String("filesToBeTransferred", "",
 		"Comma separated list of files to be transferred")
+	// kubeNode contains the information about  the kubernetes node package for Windows
+	kubeNode = pkgInfo{
+		url:     "https://dl.k8s.io/v1.16.2/kubernetes-node-windows-amd64.tar.gz",
+		sha:     "a88e7a1c6f72ea6073dbb4ddfe2e7c8bd37c9a56d94a33823f531e303a9915e7a844ac5880097724e44dfa7f4a9659d14b79cc46e2067f6b13e6df3f3f1b0f64",
+		shaType: "sha512",
+	}
+	// cniPlugins contains information about the CNI plugin package
+	cniPlugins = pkgInfo{
+		url:     "https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz",
+		sha:     "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0",
+		shaType: "sha512",
+	}
 )
 
 // wmcbVM is a wrapper for the WindowsVM interface that associates it with WMCB specific testing
 type wmcbVM struct {
 	e2ef.WindowsVM
+}
+
+// pkg encapsulates information about a package
+type pkgInfo struct {
+	// url is the URL of the package
+	url string
+	// sha is the SHA hash of the package
+	sha string
+	// shaType is the type of SHA used, example: 256 or 512
+	shaType string
 }
 
 // TestWMCB runs the unit and e2e tests for WMCB on the remote VMs
@@ -79,6 +115,8 @@ func (vm *wmcbVM) runE2ETestSuite(t *testing.T) {
 	// Handle the bootstrap and node CSRs
 	err := handleCSRs()
 	require.NoError(t, err, "error handling CSRs")
+
+	vm.runTestConfigureCNI(t)
 }
 
 // runTest runs the testCmd in the given VM
@@ -113,16 +151,36 @@ func (vm *wmcbVM) runTestBootstrapper(t *testing.T) {
 	require.NoError(t, err, "TestBootstrapper failed")
 }
 
+// runTestConfigureCNI performs the required setup and runs the configure-cni tests
+func (vm *wmcbVM) runTestConfigureCNI(t *testing.T) {
+	err := vm.initializeHybridOverlayBinary()
+	require.NoError(t, err, "error initializing files required for TestConfigureCNI")
+
+	node, err := framework.GetNode(vm.GetCredentials().GetIPAddress())
+	require.NoError(t, err, "unable to get node object for VM")
+
+	err = vm.handleHybridOverlay(node.GetName())
+	require.NoError(t, err, "unable to handle hybrid-overlay")
+
+	// It is guaranteed that the hybrid overlay annotations are present as we have already checked for it
+	hybridOverlayAnnotation := node.GetAnnotations()[test.HybridOverlaySubnet]
+	err = vm.initializeTestConfigureCNIFiles(hybridOverlayAnnotation)
+	require.NoError(t, err, "error initializing files required for TestConfigureCNI")
+
+	err = vm.runTest(e2eExecutable + " --test.run TestConfigureCNI --test.v")
+	require.NoError(t, err, "TestConfigureCNI failed")
+}
+
 // initializeTestBootstrapperFiles initializes the files required for initialize-kubelet
 func (vm *wmcbVM) initializeTestBootstrapperFiles() error {
 	// Create the temp directory
-	_, _, err := vm.Run("if not exist "+remoteDir+" mkdir "+remoteDir, false)
+	_, _, err := vm.Run(mkdirCmd(remoteDir), false)
 	if err != nil {
 		return fmt.Errorf("unable to create remote directory %s: %v", remoteDir, err)
 	}
 
 	// Download and extract the kube package on the VM
-	err = vm.remoteDownloadExtract(kubePackageURL, kubePackageSHA, remoteDir+"kube.tar.gz", remoteDir)
+	err = vm.remoteDownloadExtract(kubeNode, remoteDir+"kube.tar.gz", remoteDir)
 	if err != nil {
 		return fmt.Errorf("unable to download kube package: %v", err)
 	}
@@ -142,23 +200,24 @@ func (vm *wmcbVM) initializeTestBootstrapperFiles() error {
 	return nil
 }
 
-// remoteDownloadExtract downloads the tar file in url to the remoteDownloadFile location and checks if the SHA matches
-func (vm *wmcbVM) remoteDownload(url, sha, remoteDownloadFile string) error {
-	_, stderr, err := vm.Run("if (!(Test-Path "+remoteDownloadFile+")) { wget "+url+" -o "+remoteDownloadFile+" }", true)
+// remoteDownload downloads the tar file in url to the remoteDownloadFile location and checks if the SHA matches
+func (vm *wmcbVM) remoteDownload(pkg pkgInfo, remoteDownloadFile string) error {
+	_, stderr, err := vm.Run("if (!(Test-Path "+remoteDownloadFile+")) { wget "+pkg.url+" -o "+remoteDownloadFile+" }",
+		true)
 	if err != nil {
-		return fmt.Errorf("unable to download %s: %v\n%s", url, err, stderr)
+		return fmt.Errorf("unable to download %s: %v\n%s", pkg.url, err, stderr)
 	}
 
-	if sha == "" {
+	if pkg.sha == "" {
 		return nil
 	}
 
 	// Perform a checksum check
-	stdout, _, err := vm.Run("certutil -hashfile "+remoteDownloadFile+" sha512", true)
+	stdout, _, err := vm.Run("certutil -hashfile "+remoteDownloadFile+" "+pkg.shaType, true)
 	if err != nil {
 		return fmt.Errorf("unable to check SHA of %s: %v", remoteDownloadFile, err)
 	}
-	if !strings.Contains(stdout, sha) {
+	if !strings.Contains(stdout, pkg.sha) {
 		return fmt.Errorf("package %s SHA does not match: %v\n%s", remoteDownloadFile, err, stdout)
 	}
 
@@ -167,11 +226,11 @@ func (vm *wmcbVM) remoteDownload(url, sha, remoteDownloadFile string) error {
 
 // remoteDownloadExtract downloads the tar file in url to the remoteDownloadFile location, checks if the SHA matches and
 //  extracts the files to the remoteExtractDir directory
-func (vm *wmcbVM) remoteDownloadExtract(url, sha, remoteDownloadFile, remoteExtractDir string) error {
+func (vm *wmcbVM) remoteDownloadExtract(pkg pkgInfo, remoteDownloadFile, remoteExtractDir string) error {
 	// Download the file from the URL
-	err := vm.remoteDownload(url, sha, remoteDownloadFile)
+	err := vm.remoteDownload(pkg, remoteDownloadFile)
 	if err != nil {
-		return fmt.Errorf("unable to download %s: %v", url, err)
+		return fmt.Errorf("unable to download %s: %v", pkg.url, err)
 	}
 
 	// Extract files from the archive
@@ -180,6 +239,147 @@ func (vm *wmcbVM) remoteDownloadExtract(url, sha, remoteDownloadFile, remoteExtr
 		return fmt.Errorf("unable to extract %s: %v\n%s", remoteDownloadFile, err, stderr)
 	}
 	return nil
+}
+
+// initializeTestConfigureCNIFiles initializes the files required for configure-cni
+func (vm *wmcbVM) initializeTestConfigureCNIFiles(ovnHostSubnet string) error {
+	// Create the CNI directory C:\Windows\Temp\cni on the Windows VM
+	_, stderr, err := vm.Run(mkdirCmd(winCNIDir), false)
+	if err != nil {
+		return fmt.Errorf("unable to create remote directory %s: %v\n%s", remoteDir, err, stderr)
+	}
+
+	cniUrl, err := url.Parse(cniPlugins.url)
+	if err != nil {
+		return fmt.Errorf("error parsing %s: %v", cniPlugins.url, err)
+	}
+
+	// Download and extract the CNI binaries on the Windows VM
+	err = vm.remoteDownloadExtract(cniPlugins, remoteDir+path.Base(cniUrl.Path), winCNIDir)
+	if err != nil {
+		return fmt.Errorf("unable to download CNI package: %v", err)
+	}
+
+	// Create the CNI config file locally
+	cniConfigPath, err := createCNIConf(ovnHostSubnet)
+	if err != nil {
+		return fmt.Errorf("error creating local cni.conf: %v", err)
+	}
+
+	// Copy the created config to C:\Window\Temp\cni\config\cni.conf on the Windows VM
+	err = vm.CopyFile(cniConfigPath, winCNIConfigPath)
+	if err != nil {
+		return fmt.Errorf("error copying %s --> VM %s: %v", cniConfigPath, winCNIConfigPath, err)
+	}
+	return nil
+}
+
+// initializeHybridOverlayBinary creates the files on the Windows node needed for running "configure-cni"
+func (vm *wmcbVM) initializeHybridOverlayBinary() error {
+	hybridOverlayURL, err := framework.GetReleaseArtifactURL(hybridOverlayName)
+	if err != nil {
+		return fmt.Errorf("unable to get %s URL: %v", hybridOverlayName, err)
+	}
+
+	hybridOverlaySHA, err := framework.GetReleaseArtifactSHA(hybridOverlayName)
+	if err != nil {
+		return fmt.Errorf("unable to get %s SHA: %v", hybridOverlayName, err)
+	}
+
+	hybridOverlay := pkgInfo{
+		url:     hybridOverlayURL,
+		sha:     hybridOverlaySHA,
+		shaType: "sha256",
+	}
+
+	err = vm.remoteDownload(hybridOverlay, hybridOverlayExecutable)
+	if err != nil {
+		return fmt.Errorf("unable to download %s on VM: %s", hybridOverlayURL, err)
+	}
+	return nil
+}
+
+// handleHybridOverlay ensures that the hybrid overlay is running on the node
+func (vm *wmcbVM) handleHybridOverlay(nodeName string) error {
+	// Check if the hybrid-overlay is running
+	_, stderr, err := vm.Run("Get-Process -Name \"hybrid-overlay\"", true)
+
+	// stderr being empty implies that an hybrid-overlay was running. This is to help with local development.
+	if err == nil || stderr == "" {
+		return nil
+	}
+
+	// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
+	// start
+	if err = waitForHybridOverlayAnnotation(nodeName); err != nil {
+		return fmt.Errorf("error waiting for hybrid overlay node annotation: %v", err)
+	}
+
+	_, stderr, err = vm.Run(mkdirCmd(kLog), false)
+	if err != nil {
+		return fmt.Errorf("unable to create remote directory %s: %v\n%s", kLog, err, stderr)
+	}
+
+	// Start the hybrid-overlay in the background over ssh. We cannot use vm.Run() and by extension WinRM.Run() here as
+	// we observed WinRM.Run() returning before the commands completes execution. The reason for that is unclear and
+	// requires further investigation.
+	go vm.RunOverSSH(hybridOverlayExecutable+" --node "+nodeName+
+		" --k8s-kubeconfig c:\\k\\kubeconfig > "+kLog+"hybrid-overlay.log 2>&1", false)
+
+	err = vm.waitForHybridOverlayToRun()
+	if err != nil {
+		return fmt.Errorf("error running %s: %v", hybridOverlayName, err)
+	}
+
+	err = vm.waitForOpenShiftHNSNetworks()
+	if err != nil {
+		return fmt.Errorf("error waiting for OpenShift HNS networks to be created: %v", err)
+	}
+
+	// Running the hybrid-overlay causes network reconfiguration in the Windows VM which results in the ssh connection
+	// being closed and the client is not smart enough to reconnect. We have observed that the WinRM connection does not
+	// get closed and does not need reinitialization.
+	err = vm.Reinitialize()
+
+	return nil
+}
+
+// waitForOpenShiftHSNNetworks waits for the OpenShift HNS networks to be created until the timeout is reached
+func (vm *wmcbVM) waitForOpenShiftHNSNetworks() error {
+	var stdout string
+	var err error
+	for retries := 0; retries < e2ef.RetryCount; retries++ {
+		stdout, _, err = vm.Run("Get-HnsNetwork", true)
+		if err != nil {
+			// retry
+			continue
+		}
+
+		if strings.Contains(stdout, "BaseOpenShiftNetwork") &&
+			strings.Contains(stdout, "OpenShiftNetwork") {
+			return nil
+		}
+		time.Sleep(e2ef.RetryInterval)
+	}
+
+	// OpenShift HNS networks were not found
+	log.Printf("Get-HnsNetwork:\n%s", stdout)
+	return fmt.Errorf("timeout waiting for OpenShift HNS networks: %v", err)
+}
+
+// waitForHybridOverlayToRun waits for the hybrid-overlay.exe to run until the timeout is reached
+func (vm *wmcbVM) waitForHybridOverlayToRun() error {
+	var err error
+	for retries := 0; retries < e2ef.RetryCount; retries++ {
+		_, _, err = vm.Run("Get-Process -Name \"hybrid-overlay\"", true)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(e2ef.RetryInterval)
+	}
+
+	// hybrid-overlay never started running
+	return fmt.Errorf("timeout waiting for hybrid-overlay: %v", err)
 }
 
 // approve approves the given CSR if it has not already been approved
@@ -288,6 +488,105 @@ func handleCSRs() error {
 	}
 
 	return nil
+}
+
+// mkdirCmd returns the Windows command to create a directory if it does not exists
+func mkdirCmd(dirName string) string {
+	return "if not exist " + dirName + " mkdir " + dirName
+}
+
+// createCNIConf create the local cni.conf and returns its path
+func createCNIConf(ovnHostSubnet string) (string, error) {
+	serviceNetworkCIDR, err := getServiceNetworkCIDR()
+	if err != nil {
+		return "", fmt.Errorf("unable to get service network CIDR: %v", err)
+	}
+
+	cniConfigPath, err := generateCNIConf(ovnHostSubnet, serviceNetworkCIDR)
+	if err != nil {
+		return "", fmt.Errorf("unable to generate CNI configuration: %v", err)
+	}
+
+	return cniConfigPath, nil
+}
+
+// getServiceNetworkCIDR returns the service network CIDR from the cluster network object
+func getServiceNetworkCIDR() (string, error) {
+	// Get the cluster network object so that we can find the service network CIDR
+	networkCR, err := framework.OSConfigClient.ConfigV1().Networks().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting cluster network object: %v", err)
+	}
+
+	if len(networkCR.Spec.ServiceNetwork) != 1 {
+		return "", fmt.Errorf("expected one service network but got %d", len(networkCR.Spec.ServiceNetwork))
+	}
+
+	return networkCR.Spec.ServiceNetwork[0], nil
+}
+
+// generateCNIConf generates the cni.conf file, based on the input OVN host subnet and service network CIDR, and
+// returns the its path
+func generateCNIConf(ovnHostSubnet, serviceNetworkCIDR string) (string, error) {
+	// cniConf is used in replacing the template values in templates/cni.template
+	type cniConf struct {
+		OvnHostSubnet      string
+		ServiceNetworkCIDR string
+	}
+	confData := cniConf{ovnHostSubnet, serviceNetworkCIDR}
+
+	// Read the contents of the template file
+	content, err := ioutil.ReadFile(cniConfigTemplate)
+	if err != nil {
+		return "", fmt.Errorf("error reading CNI config template: %v", err)
+	}
+
+	cniConfTmpl := template.New("CNI")
+
+	// Parse the template
+	cniConfTmpl, err = cniConfTmpl.Parse(string(content))
+	if err != nil {
+		return "", fmt.Errorf("error parsing CNI config template: %v", err)
+	}
+
+	// Create a temp file to hold the config
+	tmpCniDir, err := ioutil.TempDir("", "cni")
+	if err != nil {
+		return "", fmt.Errorf("error creating local temp CNI directory: %v", err)
+	}
+
+	cniConfigPath, err := os.Create(filepath.Join(tmpCniDir, "cni.conf"))
+	if err != nil {
+		return "", fmt.Errorf("error creating local cni.conf: %v", err)
+	}
+
+	// Take the data values, replace it in the template and write the result out to a file
+	if err = cniConfTmpl.Execute(cniConfigPath, confData); err != nil {
+		return "", fmt.Errorf("error applying data to CNI config template: %v", err)
+	}
+
+	if err = cniConfigPath.Close(); err != nil {
+		return "", fmt.Errorf("error closing %s: %v", cniConfigPath.Name(), err)
+	}
+
+	return cniConfigPath.Name(), nil
+}
+
+// waitForHybridOverlayAnnotation waits for the hybrid overlay subnet annotation to be present on the node until the
+// timeout is reached
+func waitForHybridOverlayAnnotation(nodeName string) error {
+	for retries := 0; retries < e2ef.RetryCount; retries++ {
+		node, err := framework.K8sclientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting node %s: %v", nodeName, err)
+		}
+		_, found := node.Annotations[test.HybridOverlaySubnet]
+		if found {
+			return nil
+		}
+		time.Sleep(e2ef.RetryInterval)
+	}
+	return fmt.Errorf("timeout waiting for %s node annotation", test.HybridOverlaySubnet)
 }
 
 // hasWindowsTaint returns true if the given Windows node has the Windows taint

--- a/internal/test/wsu/wsu_test.go
+++ b/internal/test/wsu/wsu_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/windows-machine-config-operator/internal/test"
 	e2ef "github.com/openshift/windows-machine-config-operator/internal/test/framework"
 	"github.com/openshift/windows-machine-config-operator/tools/windows-node-installer/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -36,11 +37,8 @@ var (
 		"a9659d14b79cc46e2067f6b13e6df3f3f1b0f64"
 	// workerLabel is the worker label that needs to be applied to the Windows node
 	workerLabel = "node-role.kubernetes.io/worker"
-	// hybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
-	hybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"
 	// hybridOverlayMac is an annotation applied by the hybrid overlay
 	hybridOverlayMac = "k8s.ovn.org/hybrid-overlay-distributed-router-gateway-mac"
-
 	// windowsServerImage is the name/location of the Windows Server 2019 image we will use to test pod deployment
 	windowsServerImage = "mcr.microsoft.com/windows/servercore:ltsc2019"
 	// ubi8Image is the name/location of the linux image we will use for testing
@@ -141,7 +139,7 @@ func testCNIConfig(t *testing.T, vm e2ef.WindowsVM) {
 		vmCount, len(windowsNodes.Items))
 
 	// By the time, we reach here the annotation should be present, so need to validate again
-	hostSubnet := windowsNodes.Items[0].Annotations[hybridOverlaySubnet]
+	hostSubnet := windowsNodes.Items[0].Annotations[test.HybridOverlaySubnet]
 	// Check if the host subnet matches our expected value
 	assert.Contains(t, cniConfigFileContents, hostSubnet, "CNI config does not contain host subnet")
 
@@ -260,7 +258,7 @@ func testHybridOverlayAnnotations(t *testing.T) {
 	require.NoError(t, err, "Could not get list of Windows nodes")
 	assert.Equalf(t, len(windowsNodes.Items), vmCount, "expected %d Windows node(s) to be present but found %v",
 		vmCount, len(windowsNodes.Items))
-	assert.Contains(t, windowsNodes.Items[0].Annotations, hybridOverlaySubnet)
+	assert.Contains(t, windowsNodes.Items[0].Annotations, test.HybridOverlaySubnet)
 	assert.Contains(t, windowsNodes.Items[0].Annotations, hybridOverlayMac)
 }
 


### PR DESCRIPTION
This PR enables remotely running WMCB configure-cni tests on the test Windows VM. The following changes were added to achieve this: 
- [ci] Add RunOverSsh and Reinitialize to WindowsVM
- [ci] Add functions that pull release information
- [ci][wmcb] Enable running of CNI tests
