### PR TITLE
[build] Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all: lint build
+
+.PHONY: build
+build:
+	build/build.sh
+
+.PHONY: lint
+lint:
+	hack/lint-gofmt.sh
+
+.PHONY: run-ci-e2e-test
+run-ci-e2e-test:
+	hack/run-ci-e2e-test.sh
+
+.PHONY: clean
+clean:
+	rm -rf ${OUTPUT_DIR}

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PACKAGE="github.com/openshift/windows-machine-config-operator"
+MAIN_PACKAGE="${PACKAGE}/cmd/manager"
+BIN_NAME="windows-machine-config-operator"
+OUTPUT_DIR="build/_output"
+BIN_DIR="${OUTPUT_DIR}/bin"
+
+echo "building ${BIN_NAME}..."
+mkdir -p "${BIN_DIR}"
+CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -o ${BIN_DIR}/${BIN_NAME} ${MAIN_PACKAGE}

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+GO_VERSION=($(go version))
+
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.13') ]]; then
+  echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
+  exit 1
+fi
+cd "${WMCO_ROOT}"
+
+# find_files identifies all the go files excluding some directories and
+# binaries created as part of build
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './build' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename './.git' \
+        -o -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+GOFMT="gofmt -s" 
+bad_files=$(find_files | xargs $GOFMT -l)
+if [[ -n "${bad_files}" ]]; then
+  echo "!!! '$GOFMT' needs to be run on the following files: "
+  echo "${bad_files}"
+  exit 1
+fi

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+exit 0


### PR DESCRIPTION
Add a Makefile with the following targets:
- build
  This will be used in CI to ensure there are not compilation failures. We cannot use `operator-sdk build` as that will result in building the operator image which is not supported in the test pods.
- lint
  Runs gofmt against the code base. It will be connected to a CI job.
- run-ci-e2e-test
  This is a placeholder for running the e2e tests. It will be connected to a CI job.
- clean
  Deletes the built operator binary.