### PR TITLE
[build] Use golang 1.13 for builder

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,16 @@
 # build stage for building binaries
-FROM registry.access.redhat.com/ubi8/go-toolset:1.12.8-32 as build
+FROM golang:1.13.8 as build
 LABEL stage=build
 
 # Build WMCB
-# WORKDIR is not resulting in creating this directory, so we are forcing it to happen. The image does not allow us to
-# create /build/, forcing us to use $HOME which is /opt/app-root/src/
-RUN mkdir $HOME/build/
-WORKDIR $HOME/build/
+RUN mkdir /build/
+WORKDIR /build/
 RUN git clone https://github.com/openshift/windows-machine-config-bootstrapper.git
 WORKDIR windows-machine-config-bootstrapper
 RUN make build
 
 # Build hybrid-overlay
-WORKDIR $HOME/build/
+WORKDIR /build/
 RUN git clone https://github.com/openshift/ovn-kubernetes/
 WORKDIR ovn-kubernetes/go-controller/
 RUN make windows
@@ -56,10 +54,10 @@ LABEL stage=operator
 
 # Copy wmcb.exe
 WORKDIR /payload/
-COPY --from=build /opt/app-root/src/build/windows-machine-config-bootstrapper/wmcb.exe .
+COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 
 # Copy hybrid-overlay.exe
-COPY --from=build /opt/app-root/src/build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
+COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
 
 # Copy kubelet.exe and kube-proxy.exe
 WORKDIR /payload/kube-node/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -4,21 +4,19 @@
 # NOTE: RUN mkdir <dir> is being used in cases where a directory needs to be created as CI image builds does not seem to
 # be creating the directory as a result of the WORKDIR directive. 
 # build stage for building binaries
-FROM registry.access.redhat.com/ubi8/go-toolset:1.12.8-32 as build
+FROM golang:1.13.8 as build
 LABEL stage=build
 
 # Build WMCB
-# WORKDIR is not resulting in creating this directory, so we are forcing it to happen. The image does not allow us to
-# create /build/, forcing us to use $HOME which is /opt/app-root/src/
-RUN mkdir $HOME/build/
-WORKDIR $HOME/build/
+RUN mkdir /build/
+WORKDIR /build/
 # Pin this to a release branch once branching has ocurred and master is no longer fast forwarded.
 RUN git clone https://github.com/openshift/windows-machine-config-bootstrapper.git
 WORKDIR windows-machine-config-bootstrapper
 RUN make build
 
 # Build hybrid-overlay
-WORKDIR $HOME/build/
+WORKDIR /build/
 RUN git clone https://github.com/openshift/ovn-kubernetes/
 WORKDIR ovn-kubernetes/go-controller/
 RUN make windows
@@ -70,10 +68,10 @@ LABEL stage=operator
 # Copy wmcb.exe
 RUN mkdir /payload/
 WORKDIR /payload/
-COPY --from=build /opt/app-root/src/build/windows-machine-config-bootstrapper/wmcb.exe .
+COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 
 # Copy hybrid-overlay.exe
-COPY --from=build /opt/app-root/src/build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
+COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
 
 # Copy kubelet.exe and kube-proxy.exe
 RUN mkdir /payload/kube-node/


### PR DESCRIPTION
The operator requires golang 1.13 for building. Remove the hack that required us to $HOME/build/ as we are changing build images. Though to be accurate, the issue had nothing to do with the image but with containers/buildah#2189.