### PR TITLE
[build] Add workaround for CI enforcing vendoring

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,4 +11,10 @@ BIN_DIR="${OUTPUT_DIR}/bin"
 
 echo "building ${BIN_NAME}..."
 mkdir -p "${BIN_DIR}"
+
+# The golang 1.13 image used in CI enforces vendoring. Workaround that by
+# unsetting it.
+if [[ "$GOFLAGS" == *"-mod=vendor"* ]]; then
+  unset GOFLAGS
+fi
 CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -o ${BIN_DIR}/${BIN_NAME} ${MAIN_PACKAGE}


### PR DESCRIPTION
The golang image used for building in CI enforces vendoring by setting "-mod=vendor" in GOFLAGS. Add a workaround that detects that and unsets it.