### PR TITLE
[build] Account for GOFLAGS not being set

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -12,9 +12,11 @@ BIN_DIR="${OUTPUT_DIR}/bin"
 echo "building ${BIN_NAME}..."
 mkdir -p "${BIN_DIR}"
 
-# The golang 1.13 image used in CI enforces vendoring. Workaround that by
-# unsetting it.
-if [[ "$GOFLAGS" == *"-mod=vendor"* ]]; then
+# Account for environments where GOFLAGS is not set by setting goflags to an empty string if GOFLAGS is not set
+goflags=${GOFLAGS:-}
+
+# The golang 1.13 image used in CI enforces vendoring. Workaround that by unsetting it.
+if [[ "$goflags" == *"-mod=vendor"* ]]; then
   unset GOFLAGS
 fi
 CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -o ${BIN_DIR}/${BIN_NAME} ${MAIN_PACKAGE}


### PR DESCRIPTION
`set -o nounset` results in errors on trying to access a variable which is not set. This is an issue with `GOFLAGS` as it is set in the CI build container and not in other places. Workaround this by using an intermediate variable that is set to an empty string if `GOFLAGS` is not set and use that variable to check for `-mod=vendor`.