### PR TITLE
[build] Fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: lint build
 
+OUTPUT_DIR="build/_output"
+
 .PHONY: build
 build:
-	build/build.sh
+	build/build.sh ${OUTPUT_DIR}
 
 .PHONY: lint
 lint:

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,10 +3,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OUTPUT_DIR=${1:-}
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "usage: $0 OUTPUT_DIR"
+    exit 1
+fi
+
 PACKAGE="github.com/openshift/windows-machine-config-operator"
 MAIN_PACKAGE="${PACKAGE}/cmd/manager"
 BIN_NAME="windows-machine-config-operator"
-OUTPUT_DIR="build/_output"
 BIN_DIR="${OUTPUT_DIR}/bin"
 
 echo "building ${BIN_NAME}..."


### PR DESCRIPTION
"make clean" was broken when $OUTPUT_DIR moved into build/build.sh. This PR fixes the issue by making OUTPUT_DIR a parameter you pass to build.sh.