### PR TITLE
Make operator deployable via OLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,122 @@ Once the above variables are set and the /payload directory has been populated, 
 hack/run-ci-e2e-test.sh
 ```
 
+## Bundling the Windows Machine Config Operator
+This directory contains resources related to installing the WMCO onto a cluster using OLM.
+
+### Pre-requisites
+[opm](https://github.com/operator-framework/operator-registry/) has been installed on the localhost.
+All previous [pre-requisites](#pre-requisites) must be satisfied as well.
+
+### Generating a new bundle
+This step should be done in the case that changes have been made to any of the yaml files in `deploy/`.
+
+If changes need to be made to the bundle spec, a new bundle can be generated with:
+```shell script
+operator-sdk generate csv --csv-channel alpha --csv-version $NEW_VERSION --default-channel --operator-name windows-machine-config-operator --update-crds --from-version $PREV_VERSION
+```
+
+You should replace `$NEW_VERSION` and `$PREV_VERSION` with the new semver and the previous semver respectively.
+This will create a new directory: `deploy/olm-catalog/windows-machine-config-operator/$NEW_VERSION`
+You should use this new directory when [creating the bundle image](#creating-a-bundle-image)
+
+### Creating a bundle image
+A bundle image can be created by editing the CSV in deploy/bundle/windows-machine-config-operator/manifests/
+and replacing `REPLACE_IMAGE` with the location of the WMCO operator image you wish to deploy.
+See [the build instructions](#build) for more information on building the image.
+
+You can then run the following command in the root of this git repository
+```shell script
+operator-sdk bundle create $BUNDLE_REPOSITORY:$VERSION_TAG -d deploy/olm-catalog/windows-machine-config-operator/0.0.0 \
+--channels alpha --default-channel alpha --image-builder podman
+```
+The variables in the command should be changed to match the container image repository you wish to store the bundle in.
+You can also change the channels based on the release status of the operator.
+
+You should then push the image to the remote repository
+```shell script
+podman push $BUNDLE_REPOSITORY:$BUNDLE_VERSION
+```
+
+You should verify that the new bundle is valid:
+```shell script
+operator-sdk bundle validate $BUNDLE_REPOSITORY:$BUNDLE_VERSION --image-builder podman
+```
+
+### Creating a new operator index
+An operator index is a collection of bundles. Creating one is required if you wish to deploy your operator on your own
+cluster.
+
+```shell script
+opm index add --bundles $BUNDLE_REPOSITORY:$VERSION_TAG --tag $INDEX_VERSION
+```
+
+#### Editing an existing operator index
+An existing operator index can have bundles added to it:
+```shell script
+opm index add --from-index $INDEX_VERSION
+```
+and removed from it:
+```shell script
+opm index rm --from-index $INDEX_VERSION
+```
+
+### Deploying the operator on a local cluster
+#### Openshift Console
+This deployment method is currently not supported. Please use the [CLI](#cli)
+
+#### CLI
+Change `deploy/olm-catalog/catalogsource.yaml` to point to the operator index created above. Now deploy it:
+```shell script
+oc apply -f deploy/olm-catalog/catalogsource.yaml
+```
+
+This will deploy a CatalogSource object in the `openshift-marketplace` namespace. You can check the status of it via:
+```shell script
+oc describe catalogsource wmco -n openshift-marketplace
+```
+
+Now wait 1-10 minutes for the catalogsource's `status.connectionState.lastObservedState` field to be set to READY.
+
+Create the windows-machine-config-operator namespace:
+```shell script
+oc apply -f deploy/namespace.yaml
+```
+
+Switch to the windows-machine-config-operator project:
+```shell script
+oc project windows-machine-config-operator
+```
+
+Create the OperatorGroup for the namespace:
+```shell script
+oc apply -f deploy/olm-catalog/operatorgroup.yaml
+```
+
+Create the cloud provider and cloud private key secrets. The cloud-private-key should match the keypair used in the
+Windows Machine Config CR you will use.
+```shell script
+# Change paths as necessary
+oc create secret generic cloud-credentials --from-file=credentials=/home/$user/.aws/credentials
+oc create secret generic cloud-private-key --from-file=private-key.pem=/home/$user/.ssh/$keyname
+```
+
+Put the kubeconfig you wish to use in a secret. In order to use the permissions of the windows-machine-config-operator
+service account the kubeconfig should be generated from the service account.
+```shell script
+# Change paths as necessary
+oc create secret generic kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
+```
+
+Put the cluster address in a secret:
+```shell script
+CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
+oc create secret generic cluster-address --from-literal=cluster-address=$CLUSTER_ADDR
+```
+
+Change `spec.startingCSV` in `deploy/olm-catalog/subscription.yaml` to match the version of the operator you wish to deploy.
+
+Now create the subscription which will deploy the operator.
+```shell script
+oc apply -f deploy/olm-catalog/subscription.yaml
+```

--- a/deploy/olm-catalog/catalogsource.yaml
+++ b/deploy/olm-catalog/catalogsource.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: wmco
+  # Deploying the openshift-marketplace namespace as it is the global catalog namespace
+  # a subscription in any namespace can refer to catalogsources in this namespace without error.
+  namespace: openshift-marketplace
+spec:
+  displayName: Windows Machine Config operators
+  sourceType: grpc
+  image: REPLACE_IMAGE
+  updateStrategy:
+    registryPoll:
+      interval: 5m

--- a/deploy/olm-catalog/operatorgroup.yaml
+++ b/deploy/olm-catalog/operatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: WindowsMachineConfig.v1alpha1.wmc.openshift.io
+  name: windows-machine-config-operator
+  namespace: windows-machine-config-operator
+spec:
+  targetNamespaces:
+  - windows-machine-config-operator

--- a/deploy/olm-catalog/subscription.yaml
+++ b/deploy/olm-catalog/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: windows-machine-config-operator
+  namespace: windows-machine-config-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: windows-machine-config-operator
+  source: wmco
+  sourceNamespace: openshift-marketplace
+  startingCSV: windows-machine-config-operator.v0.0.0

--- a/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
@@ -1,0 +1,210 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "wmc.openshift.io/v1alpha1",
+          "kind": "WindowsMachineConfig",
+          "metadata": {
+            "name": "instance"
+          },
+          "spec": {
+            "aws": {
+              "credentialAccountId": "default",
+              "sshKeyPair": "openshift-dev"
+            },
+            "instanceType": "m5a.large",
+            "replicas": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: windows-machine-config-operator
+    repository: https://github.com/openshift/windows-machine-config-operator
+  name: windows-machine-config-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: WindowsMachineConfig is the Schema for the windowsmachineconfigs
+        API
+      kind: WindowsMachineConfig
+      name: windowsmachineconfigs.wmc.openshift.io
+      version: v1alpha1
+  description: Placeholder description
+  displayName: Windows Machine Config Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          - certificatesigningrequests/approval
+          verbs:
+          - get
+          - list
+          - update
+        serviceAccountName: windows-machine-config-operator
+      deployments:
+      - name: windows-machine-config-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: windows-machine-config-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: windows-machine-config-operator
+            spec:
+              containers:
+              - command:
+                - windows-machine-config-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: windows-machine-config-operator
+                - name: KUBECONFIG
+                  value: /etc/kubeconfig/kubeconfig
+                - name: CLUSTER_ADDR
+                  valueFrom:
+                    secretKeyRef:
+                      key: cluster-address
+                      name: cluster-address
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: windows-machine-config-operator
+                resources: {}
+                volumeMounts:
+                - mountPath: /etc/cloud/
+                  name: cloud-credentials
+                  readOnly: true
+                - mountPath: /etc/private-key/
+                  name: cloud-private-key
+                  readOnly: true
+                - mountPath: /etc/kubeconfig/
+                  name: kubeconfig
+                  readOnly: true
+              serviceAccountName: windows-machine-config-operator
+              volumes:
+              - name: cloud-credentials
+                secret:
+                  secretName: cloud-credentials
+              - name: cloud-private-key
+                secret:
+                  secretName: cloud-private-key
+              - name: kubeconfig
+                secret:
+                  secretName: kubeconfig
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - windows-machine-config-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - wmc.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: windows-machine-config-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - windows
+  maintainers:
+  - {}
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 0.0.0

--- a/deploy/olm-catalog/windows-machine-config-operator/0.0.0/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/0.0.0/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -1,0 +1,76 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: windowsmachineconfigs.wmc.openshift.io
+spec:
+  group: wmc.openshift.io
+  names:
+    kind: WindowsMachineConfig
+    listKind: WindowsMachineConfigList
+    plural: windowsmachineconfigs
+    singular: windowsmachineconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: WindowsMachineConfig is the Schema for the windowsmachineconfigs
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: WindowsMachineConfigSpec defines the desired state of WindowsMachineConfig
+          properties:
+            aws:
+              description: AWS holds AWS specific cloud provider information
+              properties:
+                credentialAccountId:
+                  description: CredentialAccountID is account id associated with AWS
+                    provider
+                  type: string
+                sshKeyPair:
+                  description: SSHKeyPair is the sshKeyPair associated with cloudprovider.
+                    AWS asks a keypair to be present for encrypting the Windows VM
+                    password
+                  type: string
+              required:
+              - credentialAccountId
+              - sshKeyPair
+              type: object
+            azure:
+              description: Azure holds Azure specific cloud provider information
+              type: object
+            instanceType:
+              description: InstanceType represents the flavor of instance to be used
+                while creating the virtual machines. Please note that this is common
+                across all the Windows nodes in the cluster
+              type: string
+            replicas:
+              description: Replicas represent how many Windows nodes to be added to
+                the OpenShift cluster
+              minimum: 0
+              type: integer
+          required:
+          - instanceType
+          - replicas
+          type: object
+        status:
+          description: WindowsMachineConfigStatus defines the observed state of WindowsMachineConfig
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,19 @@ spec:
         name: windows-machine-config-operator
     spec:
       serviceAccountName: windows-machine-config-operator
+      volumes:
+      # TODO: Remove the cloud-credentials and cloud-private-key volumes as part of
+      # https://issues.redhat.com/browse/WINC-325
+      - name: cloud-credentials
+        secret:
+          secretName: cloud-credentials
+      - name: cloud-private-key
+        secret:
+          secretName: cloud-private-key
+      # TODO: Remove the kubeconfig volume as part of https://issues.redhat.com/browse/WINC-328
+      - name: kubeconfig
+        secret:
+          secretName: kubeconfig
       containers:
         - name: windows-machine-config-operator
           # Replace this with the built image name
@@ -31,3 +44,25 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "windows-machine-config-operator"
+            # TODO: Remove the KUBECONFIG environment variable as part of https://issues.redhat.com/browse/WINC-328
+            - name: KUBECONFIG
+              value: /etc/kubeconfig/kubeconfig
+            # TODO: Remove the CLUSTER_ADDR environment variable as part of https://issues.redhat.com/browse/WINC-274
+            - name: CLUSTER_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: cluster-address
+                  key: cluster-address
+          volumeMounts:
+          # TODO: Remove the cloud-credentials and cloud-private-key volumeMounts as part of
+          # https://issues.redhat.com/browse/WINC-325
+          - name: cloud-credentials
+            mountPath: "/etc/cloud/"
+            readOnly: true
+          - name: cloud-private-key
+            mountPath: "/etc/private-key/"
+            readOnly: true
+          # TODO: Remove the kubeconfig volumeMount as part of https://issues.redhat.com/browse/WINC-328
+          - name: kubeconfig
+            mountPath: "/etc/kubeconfig/"
+            readOnly: true

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -7,37 +7,30 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
   - secrets
   verbs:
   - create
   - delete
   - get
-  - list
-  - patch
-  - update
-  - watch
+# service permissions needed for the metrics server
 - apiGroups:
-  - apps
+  - ""
   resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
+  - services
+  - services/finalizers
   verbs:
   - create
   - delete
   - get
-  - list
-  - patch
   - update
-  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -45,6 +38,7 @@ rules:
   verbs:
   - get
   - create
+# deployment/finalizers permissions needed for the metrics server
 - apiGroups:
   - apps
   resourceNames:
@@ -53,12 +47,17 @@ rules:
   - deployments/finalizers
   verbs:
   - update
+# TODO: pods permissions needed as we are currently watching pods
+# remove as part of https://issues.redhat.com/browse/WINC-340
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
   - get
+  - list
+  - watch
+# These permissions needed for the metrics server
 - apiGroups:
   - apps
   resources:
@@ -71,10 +70,33 @@ rules:
   resources:
   - '*'
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: windows-machine-config-operator
+rules:
+ - apiGroups:
+   - ""
+   resources:
+   - nodes
+   verbs:
+   - "*"
+# The infrastructure endpoint is used within WNI
+ - apiGroups:
+   - "config.openshift.io"
+   resources:
+   - infrastructures
+   verbs:
+   - get
+ - apiGroups:
+   - certificates.k8s.io
+   resources:
+   - certificatesigningrequests
+   - certificatesigningrequests/approval
+   verbs:
+   - get
+   - list
+   - update

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,3 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: windows-machine-config-operator
+subjects:
+- kind: ServiceAccount
+  name: windows-machine-config-operator
+roleRef:
+  kind: ClusterRole
+  name: windows-machine-config-operator
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -144,7 +144,7 @@ func (r *ReconcileWindowsMachineConfig) Reconcile(request reconcile.Request) (re
 			// We assume the credential path is `/etc/aws/credentials` mounted as a secret.
 			wkl.CloudCredentialsPath,
 			instance.Spec.AWS.CredentialAccountID,
-			"", "", instance.Spec.InstanceType,
+			"/tmp", "", instance.Spec.InstanceType,
 			instance.Spec.AWS.SSHKeyPair, wkl.PrivateKeyPath)
 
 		if err != nil {


### PR DESCRIPTION
This PR consists of 3 commits which work towards making the WMCO deployable via OLM:
* Change the WNI resource tracking directory used so that the operator can be deployed outside of CI
* Change RBAC permissions so the SA used by the operator has the correct permissions
* Add the operator bundle and olm deployment yamls