### PR TITLE
[docs] Add testing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ To build the operator image, execute:
 ```shell script
 operator-sdk build quay.io/<insert username>/wmco:latest
 ```
+
+## Testing locally
+To run the e2e tests for WMCO locally against an OpenShift cluster set up on AWS, we need to setup the following environment variables.
+```shell script
+export KUBECONFIG=<path to kubeconfig>
+export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
+export CLUSTER_ADDR=<cluster_name, eg: ravig211.devcluster.openshift.com>
+export KUBE_SSH_KEY_PATH=<path to ssh key>
+```
+Once the above variables are set:
+```shell script
+hack/run-ci-e2e-test.sh
+```
+


### PR DESCRIPTION
 Update documentation on e2e testing. This ensures we can run e2e tests locally from our machine
/cc @aravindhp 