### PR TITLE
[build] Fix operator-sdk image build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=download /download/cni-plugins/* .
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/
 WORKDIR /payload/powershell/
-COPY --from=build /build/windows-machine-config-operator/pkg/internal/wget-ignore-cert.ps1 .
+COPY pkg/internal/wget-ignore-cert.ps1 .
 
 WORKDIR /
 


### PR DESCRIPTION
`operator-sdk build` was broken in f46ddec9. This commit fixes the breakage.

Bug: [WINC-311](https://issues.redhat.com/browse/WINC-311)