### PR TITLE
[wmco] Hybrid overlay configuration

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -3,6 +3,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Set up hybrid networking on the cluster, a requirement for Windows support in OpenShift
+# TODO: This needs to be removed as part of https://issues.redhat.com/browse/WINC-351
+oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
+
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 export CGO_ENABLED=0

--- a/pkg/controller/retry/retry.go
+++ b/pkg/controller/retry/retry.go
@@ -1,0 +1,12 @@
+package retry
+
+import "time"
+
+const (
+	// Count is the number of times we will retry an API call
+	Count = 20
+	// Interval is the wait time between API calls on a failure
+	Interval = 15 * time.Second
+	// Timeout is the total time we will wait for an event to occur.
+	Timeout = time.Minute * 10
+)

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -8,30 +8,34 @@ const (
 	// cloud provider. This would have been mounted as a secret by user
 	// TODO: Jira story for validation: https://issues.redhat.com/browse/WINC-316
 	PrivateKeyPath = "/etc/private-key/private-key.pem"
+	// payloadDirectory is the directory in the operator image where are all the binaries live
+	payloadDirectory = "/payload/"
 	// WmcbPath contains the path of the Windows Machine Config Bootstrapper binary. The container image should already
 	// have this binary mounted
-	WmcbPath = "/payload/wmcb.exe"
+	WmcbPath = payloadDirectory + "wmcb.exe"
 	// KubeletPath contains the path of the kubelet binary. The container image should already have this binary mounted
-	KubeletPath = "/payload/kube-node/kubelet.exe"
+	KubeletPath = payloadDirectory + "/kube-node/kubelet.exe"
 	// KubeProxyPath contains the path of the kube-proxy binary. The container image should already have this binary
 	// mounted
-	KubeProxyPath = "/payload/kube-node/kube-proxy.exe"
+	KubeProxyPath = payloadDirectory + "/kube-node/kube-proxy.exe"
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
-	IgnoreWgetPowerShellPath = "/payload/powershell/wget-ignore-cert.ps1"
+	IgnoreWgetPowerShellPath = payloadDirectory + "/powershell/wget-ignore-cert.ps1"
 	// FlannelCNIPluginPath is the path of the flannel CNI plugin binary. The container image should already have this
 	// binary mounted
-	FlannelCNIPluginPath = "/payload/cni-plugins/flannel.exe"
+	FlannelCNIPluginPath = payloadDirectory + "/cni-plugins/flannel.exe"
 	// HostLocalCNIPluginPath is the path of the host-local CNI plugin binary. The container image should already have
 	// this binary mounted
-	HostLocalCNIPlugin = "/payload/cni-plugins/host-local.exe"
+	HostLocalCNIPlugin = payloadDirectory + "/cni-plugins/host-local.exe"
 	// WinBridgeCNIPluginPath is the path of the win-bridge CNI plugin binary. The container image should already have
 	// this binary mounted
-	WinBridgeCNIPlugin = "/payload/cni-plugins/win-bridge.exe"
+	WinBridgeCNIPlugin = payloadDirectory + "/cni-plugins/win-bridge.exe"
 	// WinOverlayCNIPluginPath is the path of the win-overlay CNI Plugin binary. The container image should already have
 	// this binary mounted
-	WinOverlayCNIPlugin = "/payload/cni-plugins/win-overlay.exe"
+	WinOverlayCNIPlugin = payloadDirectory + "/cni-plugins/win-overlay.exe"
+	// hybridOverlayName is the name of the hybrid overlay executable
+	HybridOverlayName = "hybrid-overlay.exe"
 	// HybridOverlayPath contains the path of the hybrid overlay binary. The container image should already have this
 	// binary mounted
-	HybridOverlayPath = "/payload/hybrid-overlay.exe"
+	HybridOverlayPath = payloadDirectory + HybridOverlayName
 )

--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
@@ -10,7 +10,9 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/windows"
 	"github.com/pkg/errors"
 	certificates "k8s.io/api/certificates/v1beta1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	kretry "k8s.io/client-go/util/retry"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,6 +21,10 @@ import (
 const (
 	// bootstrapCSR is the CSR name associated with a worker node that just got bootstrapped.
 	bootstrapCSR = "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper"
+	// HybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
+	HybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"
+	// HybridOverlayMac is an annotation applied by the hybrid-overlay
+	HybridOverlayMac = "k8s.ovn.org/hybrid-overlay-distributed-router-gateway-mac"
 )
 
 // nodeConfig holds the information to make the given VM a kubernetes node. As of now, it holds the information
@@ -45,6 +51,53 @@ func (nc *nodeConfig) Configure() error {
 	if err := nc.handleCSRs(); err != nil {
 		return errors.Wrap(err, "handling CSR for the given node failed")
 	}
+
+	// Now that basic kubelet configuration is complete, configure networking in the node
+	if err := nc.configureNetwork(); err != nil {
+		return errors.Wrap(err, "configuring node network failed")
+	}
+	log.Info("VM has been configured as a worker node", "VM ID", nc.GetCredentials().GetInstanceId())
+	return nil
+}
+
+// configureNetwork configures k8s networking in the node
+func (nc *nodeConfig) configureNetwork() error {
+	if nc.GetCredentials() == nil {
+		return fmt.Errorf("nil credentials for VM")
+	}
+
+	if nc.GetCredentials().GetIPAddress() == "" {
+		return fmt.Errorf("empty IP for VM: %v", nc.GetCredentials())
+	}
+
+	node, err := nc.getNode(nc.GetCredentials().GetIPAddress())
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error getting node object for VM %s",
+			nc.GetCredentials().GetInstanceId()))
+	}
+
+	// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
+	// start
+	if err = nc.waitForNodeAnnotation(node.GetName(), HybridOverlaySubnet); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error waiting for %s node annotation for %s", HybridOverlaySubnet,
+			node.GetName()))
+	}
+
+	// NOTE: Investigate if we need to introduce a interface wrt to the VM's networking configuration. This will
+	// become more clear with the outcome of https://issues.redhat.com/browse/WINC-343
+
+	// Configure the hybrid overlay in the Windows VM
+	if err = nc.Windows.ConfigureHybridOverlay(node.GetName()); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error configuring hybrid overlay for %s", node.GetName()))
+	}
+
+	// Wait until the node object has the hybrid overlay MAC annotation. This is required for the CNI configuration to
+	// start.
+	if err = nc.waitForNodeAnnotation(node.GetName(), HybridOverlayMac); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error waiting for %s node annotation for %s", HybridOverlayMac,
+			node.GetName()))
+	}
+
 	return nil
 }
 
@@ -153,5 +206,57 @@ func (nc *nodeConfig) handleCSR(requestorFilter string) error {
 		return errors.Wrapf(err, "error approving CSR for %s", requestorFilter)
 	}
 
+	return nil
+}
+
+// GetNode returns a pointer to the node object associated with the external IP provided
+func (nc *nodeConfig) getNode(externalIP string) (*v1.Node, error) {
+	var matchedNode *v1.Node
+
+	nodes, err := nc.k8sclientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get list of nodes")
+	}
+	if len(nodes.Items) == 0 {
+		return nil, fmt.Errorf("no nodes found")
+	}
+
+	// Find the node that has the given IP
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == "ExternalIP" && address.Address == externalIP {
+				matchedNode = &node
+				break
+			}
+		}
+		if matchedNode != nil {
+			break
+		}
+	}
+	if matchedNode == nil {
+		return nil, fmt.Errorf("could not find node with IP: %s", externalIP)
+	}
+	return matchedNode, nil
+}
+
+// waitForNodeAnnotation checks if the node object has the given annotation and waits for retry.Interval seconds and
+// returns an error if the annotation does not appear in that time frame.
+func (nc *nodeConfig) waitForNodeAnnotation(nodeName, annotation string) error {
+	var found bool
+	err := wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
+		node, err := nc.k8sclientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, errors.Wrap(err, fmt.Sprintf("error getting node %s", nodeName))
+		}
+		_, found := node.Annotations[annotation]
+		if found {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if !found {
+		return errors.Wrap(err, fmt.Sprintf("timeout waiting for %s node annotation", annotation))
+	}
 	return nil
 }

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -8,6 +8,7 @@ import (
 
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
 	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/nodeconfig"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
@@ -24,9 +25,16 @@ const (
 )
 
 func creationTestSuite(t *testing.T) {
+	// The order of tests here are important. testValidateSecrets is what populates the windowsVMs slice in the gc.
+	// testNetwork needs that to check if the HNS networks have been installed. Ideally we would like to run testNetwork
+	// before testValidateSecrets and testConfigMapValidation but we cannot as the source of truth for the credentials
+	// are the secrets but they are created only after the VMs have been fully configured.
+	// Any node object related tests should be run only after testNodeCreation as that initializes the node objects in
+	// the global context.
 	t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t) })
 	t.Run("ConfigMap validation", func(t *testing.T) { testConfigMapValidation(t) })
 	t.Run("Secrets validation", func(t *testing.T) { testValidateSecrets(t) })
+	t.Run("Network validation", testNetwork)
 }
 
 // testWindowsNodeCreation tests the Windows node creation in the cluster
@@ -58,33 +66,48 @@ func testWindowsNodeCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("windows node creation failed  with %v", err)
 	}
+	log.Printf("Created %d Windows worker nodes", len(gc.nodes))
 }
 
-// waitForWindowsNode waits for the Windows node to be created by the operator.
+// waitForWindowsNode waits for the Windows node with the correct set of annotations to be created by the operator.
 func (tc *testContext) waitForWindowsNode() error {
 	var nodes *v1.NodeList
+	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac}
+
 	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
 	// side, let's make it as 20 minutes per node. The value comes from nodeCreationTime variable
 	err := wait.Poll(nodeRetryInterval, time.Duration(gc.numberOfNodes)*nodeCreationTime, func() (done bool, err error) {
 		nodes, err = tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Printf("Waiting for availability of %d windows nodes\n", gc.numberOfNodes)
+				log.Printf("waiting for %d Windows nodes", gc.numberOfNodes)
 				return false, nil
 			}
 			return false, err
 		}
-		if len(nodes.Items) == gc.numberOfNodes {
-			log.Println("Created the required number of Windows worker nodes")
-			return true, nil
+		if len(nodes.Items) != gc.numberOfNodes {
+			log.Printf("waiting for %d/%d Windows nodes", len(nodes.Items), gc.numberOfNodes)
+			return false, nil
 		}
-		log.Printf("still waiting for %d number of Windows worker nodes to be available\n", gc.numberOfNodes)
-		return false, nil
+
+		// Wait for annotations to be present on the node objects in the scale up caseoc
+		if gc.numberOfNodes != 0 {
+			log.Printf("waiting for annotations to be present on %d Windows nodes", gc.numberOfNodes)
+		}
+		for _, node := range nodes.Items {
+			for _, annotation := range annotations {
+				_, found := node.Annotations[annotation]
+				if !found {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
 	})
 
-	for _, node := range nodes.Items {
-		tc.nodes = append(tc.nodes, node)
-	}
+	// Initialize/update nodes to avoid staleness
+	gc.nodes = nodes.Items
 
 	return err
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -20,6 +21,11 @@ var (
 	gc = globalContext{numberOfNodes: numberOfNodes}
 )
 
+// testVM encapsulates a VM created by the test
+type testVM struct {
+	types.WindowsVM
+}
+
 // globalContext holds the information that we want to use across the test suites.
 // If you want to move item here make sure that
 // 1.) It is needed across test suites
@@ -28,6 +34,10 @@ var (
 type globalContext struct {
 	// numberOfNodes to be used for the test suite.
 	numberOfNodes int
+	// nodes are the Windows nodes created by the operator
+	nodes []v1.Node
+	// windowsVMs is used to interact with the Windows VMs created by the test suite
+	windowsVMs []testVM
 }
 
 // testContext holds the information related to the individual test suite. This data structure
@@ -41,8 +51,6 @@ type testContext struct {
 	namespace string
 	// osdkTestCtx is the operator sdk framework's test Context
 	osdkTestCtx *framework.TestCtx
-	// nodes is the list of Windows nodes created by operator
-	nodes []v1.Node
 	// credentials to be used to access the Windows nodes
 	credentials []tracker.Credentials
 	// kubeclient is the kube client
@@ -64,8 +72,7 @@ func NewTestContext(t *testing.T) (*testContext, error) {
 	}
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{osdkTestCtx: fmwkTestContext, kubeclient: framework.Global.KubeClient,
-		timeout: retry.Timeout, retryInterval: retry.Interval, nodes: make([]v1.Node, 0, gc.numberOfNodes),
-		namespace: namespace}, nil
+		timeout: retry.Timeout, retryInterval: retry.Interval, namespace: namespace}, nil
 }
 
 // cleanup cleans up the test context

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
@@ -63,7 +64,7 @@ func NewTestContext(t *testing.T) (*testContext, error) {
 	}
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{osdkTestCtx: fmwkTestContext, kubeclient: framework.Global.KubeClient,
-		timeout: time.Minute * 15, retryInterval: time.Second * 5, nodes: make([]v1.Node, 0, gc.numberOfNodes),
+		timeout: retry.Timeout, retryInterval: retry.Interval, nodes: make([]v1.Node, 0, gc.numberOfNodes),
 		namespace: namespace}, nil
 }
 

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/windows"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testNetwork runs all the cluster and node network tests
+func testNetwork(t *testing.T) {
+	t.Run("Hybrid overlay running", testHybridOverlayRunning)
+	t.Run("OpenShift HNS networks", testHNSNetworksCreated)
+}
+
+// testHNSNetworksCreated tests that the required HNS Networks have been created on the bootstrapped nodes
+func testHNSNetworksCreated(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+	defer testCtx.cleanup()
+
+	for _, vm := range gc.windowsVMs {
+		// We don't need to retry as we are waiting long enough for the secrets to be created which implies that the
+		// network setup has succeeded.
+		stdout, _, err := vm.Run("Get-HnsNetwork", true)
+		require.NoError(t, err, "Could not run Get-HnsNetwork command")
+		assert.Contains(t, stdout, "BaseOpenShiftNetwork",
+			"Could not find BaseOpenShiftNetwork in %s", vm.GetCredentials().GetInstanceId())
+		assert.Contains(t, stdout, "OpenShiftNetwork",
+			"Could not find OpenShiftNetwork in %s", vm.GetCredentials().GetInstanceId())
+	}
+}
+
+// testHybridOverlayRunning checks if the hybrid-overlay process is running on all the bootstrapped nodes
+func testHybridOverlayRunning(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+	defer testCtx.cleanup()
+
+	for _, vm := range gc.windowsVMs {
+		_, stderr, err := vm.Run("Get-Process -Name \""+windows.HybridOverlayProcess+"\"", true)
+		require.NoError(t, err, "Could not run Get-Process command")
+		// stderr being empty implies that hybrid-overlay was running.
+		assert.Equal(t, "", stderr, "hybrid-overlay was not running in %s",
+			vm.GetCredentials().GetInstanceId())
+	}
+}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -3,12 +3,12 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
 	"log"
 	"strings"
 	"testing"
 
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
+	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
 	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -25,7 +25,7 @@ import (
 // waitForTrackerConfigMap waits for the Windows tracker configmap to be created with appropriate values
 func (tc *testContext) waitForTrackerConfigMap() error {
 	var trackerConfigMap *corev1.ConfigMap
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	err := wait.Poll(tc.retryInterval, tc.timeout, func() (done bool, err error) {
 		trackerConfigMap, err = tc.kubeclient.CoreV1().ConfigMaps(tc.namespace).Get(tracker.StoreName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -144,7 +144,7 @@ func (tc *testContext) getInstanceIP(instanceID string) (string, error) {
 // getCredsFromSecret gets the credentials associated with the instance.
 func (tc *testContext) getCredsFromSecret(instanceID string) (tracker.Credentials, error) {
 	var creds tracker.Credentials
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	err := wait.Poll(tc.retryInterval, tc.timeout, func() (done bool, err error) {
 		instanceSecret, err := tc.kubeclient.CoreV1().Secrets(tc.namespace).Get(instanceID, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
@@ -25,7 +26,9 @@ import (
 // waitForTrackerConfigMap waits for the Windows tracker configmap to be created with appropriate values
 func (tc *testContext) waitForTrackerConfigMap() error {
 	var trackerConfigMap *corev1.ConfigMap
-	err := wait.Poll(tc.retryInterval, tc.timeout, func() (done bool, err error) {
+	// timeout is a factor of the number of nodes we are dealing with as all nodes have to finish their full
+	// configuration before the ConfigMap is updated.
+	err := wait.Poll(tc.retryInterval, time.Duration(gc.numberOfNodes)*tc.timeout, func() (done bool, err error) {
 		trackerConfigMap, err = tc.kubeclient.CoreV1().ConfigMaps(tc.namespace).Get(tracker.StoreName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -56,17 +59,8 @@ func getInstanceID(providerID string) string {
 
 // getInstanceIDsOfNodes returns the instanceIDs of all the Windows nodes created
 func (tc *testContext) getInstanceIDsOfNodes() ([]string, error) {
-	nodes, err := tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
-	if err != nil {
-		return nil, errors.Wrap(err, "error while querying for Windows nodes")
-	}
-
-	for _, node := range nodes.Items {
-		tc.nodes = append(tc.nodes, node)
-	}
-
-	instanceIDs := make([]string, 0, len(tc.nodes))
-	for _, node := range tc.nodes {
+	instanceIDs := make([]string, 0, len(gc.nodes))
+	for _, node := range gc.nodes {
 		if len(node.Spec.ProviderID) > 0 {
 			instanceID := getInstanceID(node.Spec.ProviderID)
 			instanceIDs = append(instanceIDs, instanceID)
@@ -180,7 +174,11 @@ func (tc *testContext) validateInstanceSecret(instanceID string) error {
 		return err
 	}
 	err = tc.validateConnectivity(windowsVM)
-	return err
+	if err != nil {
+		return err
+	}
+	gc.windowsVMs = append(gc.windowsVMs, testVM{windowsVM})
+	return nil
 }
 
 // testValidateSecrets ensures we've valid secrets in place to be used by trackerConfigmap to construct node objects
@@ -192,6 +190,10 @@ func testValidateSecrets(t *testing.T) {
 	instanceIDs, err := testCtx.getInstanceIDsOfNodes()
 	require.NoError(t, err, "error while getting instance ids")
 	require.Equal(t, len(instanceIDs), gc.numberOfNodes, "mismatched node count")
+
+	// Reset the windowsVMs to avoid staleness
+	gc.windowsVMs = make([]testVM, 0, numberOfNodes)
+
 	for _, instanceID := range instanceIDs {
 		err := testCtx.validateInstanceSecret(instanceID)
 		assert.NoError(t, err, "error validating instance secret")

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	retryInterval        = time.Second * 5
-	timeout              = time.Minute * 60
+	nodeCreationTime     = time.Minute * 20
+	nodeRetryInterval    = time.Minute * 1
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )


### PR DESCRIPTION
- [ci] Normalize retry constants across the code
  - Move common retry constants to the main codebase so that they can be shared across the e2e tests
  - Normalize and use sane timeouts and waits for resources to be created
- [wmco] hybrid-overlay configuration
  - Update hack/run-ci-e2e-test.sh to enable hybrid OVN networking on the cluster
  - Add steps to run hybrid-overlay.exe in the Windows VM
  - Add a slice of Windows VM handles to the global context to allow for inside VM tests
  - Move nodes from test context to the global context as they are needed in multiple tests
  - Add e2e tests to check if the result of running the hybrid-overlay.exe is successful