### PR TITLE
[wmco] Create tracker configmap for Windows VMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.15.2
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/controller/windowsmachineconfig/tracker/tracker.go
+++ b/pkg/controller/windowsmachineconfig/tracker/tracker.go
@@ -1,0 +1,248 @@
+package tracker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/pkg/errors"
+	"k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// StoreName is the name of the ConfigMap used to track Windows worker node information
+const StoreName = "wmco-node-tracker"
+
+var log = ctrllog.Log.WithName("tracker")
+
+// nodeRecord holds information about a single node in the cluster. This is the information that will be placed in the
+// ConfigMap with the node's cloud ID as the key to get the record.
+type nodeRecord struct {
+	// CredSecret holds the name of the secret for each Windows node managed by the WMCO
+	CredSecret string `json:"credSecret"`
+	// IPAddress of the Windows node managed by the WMCO
+	IPAddress string `json:"ipAddress"`
+	// Drain indicates if the Windows node has to be drained before removing the Windows VMs from cluster
+	Drain bool `json:"drain"`
+}
+
+// Tracker is used to track the instance information
+type Tracker struct {
+	// windowsVMs is a map of Windows VMs to be tracked by WMCO
+	windowsVMs map[types.WindowsVM]bool
+	// operatorNS is the name of namespace where the operator is running.
+	operatorNS string
+	//k8sclientset is the kubernetes client set
+	k8sclientset *kubernetes.Clientset
+	// nodeRecords is a map of instanceID as key and marshalled nodeRecord object
+	nodeRecords map[string][]byte
+}
+
+// NewTracker initializes and returns a tracker object
+func NewTracker(k8sclientset *kubernetes.Clientset, windowsVMs map[types.WindowsVM]bool) (*Tracker, error) {
+	if k8sclientset == nil {
+		return nil, fmt.Errorf("cannot instantiate tracker without k8s client")
+	}
+	if windowsVMs == nil {
+		return nil, fmt.Errorf("cannot instantiate tracker with a nil windowsVMs slice")
+	}
+
+	// Get the namespace the operator is currently deployed in.
+	operatorNS, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get operator namespace")
+	}
+
+	return &Tracker{
+		windowsVMs:   windowsVMs,
+		operatorNS:   operatorNS,
+		k8sclientset: k8sclientset,
+	}, nil
+}
+
+// WindowsVMs sets WindowsVMs to be tracked by WMCO
+func (t *Tracker) WindowsVMs(windowsVMs map[types.WindowsVM]bool) {
+	t.windowsVMs = windowsVMs
+}
+
+// newNodeRecord initializes and returns a nodeRecord object
+func newNodeRecord(ipAddress string, secretName string) nodeRecord {
+	return nodeRecord{
+		IPAddress:  ipAddress,
+		CredSecret: secretName,
+		Drain:      false,
+	}
+}
+
+// Reconcile ensures that the ConfigMap used by the tracker to store VM -> node information is present on the cluster
+// and is populated with nodeRecords.
+func (t *Tracker) Reconcile() error {
+	store, err := t.k8sclientset.CoreV1().ConfigMaps(t.operatorNS).Get(StoreName, metav1.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return errors.Wrap(err, fmt.Sprintf("unable to query %s/%s ConfigMap", t.operatorNS, StoreName))
+	}
+
+	// The ConfigMap does not exist, so we need to create it based on the WindowsVM slice
+	if err != nil && k8serrors.IsNotFound(err) {
+		if store, err = t.createStore(); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("unable to create %s/%s ConfigMap", t.operatorNS, StoreName))
+		}
+	}
+	// sync the node records
+	t.syncNodeRecords()
+	// sync the secrets
+	t.syncSecrets(store)
+	// sync the store
+	if err = t.updateStore(store); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("unable to update %s/%s ConfigMap", t.operatorNS, StoreName))
+	}
+	return nil
+}
+
+// createStoreConfigMap creates the store ConfigMap without any data
+func (t *Tracker) createStore() (*v1.ConfigMap, error) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      StoreName,
+			Namespace: t.operatorNS,
+		},
+	}
+	cm, err := t.k8sclientset.CoreV1().ConfigMaps(t.operatorNS).Create(cm)
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+// syncSecrets will syncSecrets associated with instances in the cloud provider
+func (t *Tracker) syncSecrets(cm *v1.ConfigMap) {
+	existingNodes := cm.BinaryData
+	// Since the secret is created with the instanceID as it's name, we can use the same key to identify secrets
+	// and delete the stale secrets associated with deleted instances.
+	for name := range existingNodes {
+		if _, ok := t.nodeRecords[name]; !ok {
+			deleteOptions := &metav1.DeleteOptions{}
+			if err := t.k8sclientset.CoreV1().Secrets(t.operatorNS).Delete(name, deleteOptions); err != nil {
+				log.Error(err, "while deleting secret associated with instance")
+			}
+		}
+	}
+}
+
+// updateStoreConfigMap updates the store ConfigMap with the nodeRecords
+func (t *Tracker) updateStore(cm *v1.ConfigMap) error {
+	cm.BinaryData = t.nodeRecords
+	cm, err := t.k8sclientset.CoreV1().ConfigMaps(t.operatorNS).Update(cm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// syncNodeRecords syncs the node records to be used by tracker. We construct the credentials struct
+// and marshall it so that nodeRecords are updated.
+func (t *Tracker) syncNodeRecords() {
+	nodeRecords := make(map[string][]byte, len(t.windowsVMs))
+	for windowsVM := range t.windowsVMs {
+		if windowsVM == nil {
+			log.Info("ignoring nil entry in windowsVMs")
+			continue
+		}
+		credentials := windowsVM.GetCredentials()
+		if credentials == nil {
+			log.Info("ignoring VM with nil credentials")
+			continue
+		}
+		if credentials.GetInstanceId() == "" || credentials.GetIPAddress() == "" || credentials.GetPassword() == "" ||
+			credentials.GetUserName() == "" {
+			log.Info("ignoring VM with incomplete credentials: %v", credentials)
+			continue
+		}
+		if t.nodeRecords != nil {
+			if _, ok := t.nodeRecords[credentials.GetInstanceId()]; ok {
+				log.Info("Node records already exist for the given Windows VM")
+				continue
+			}
+		}
+		// TODO: See if we can wrap the secret creation in the node record creation.
+		//		 This way, we'll just have sync node records which will delete the
+		//		 secrets associated with them.
+		// 		Jira Story: https://issues.redhat.com/browse/WINC-321
+		secretName, err := t.createSecret(credentials)
+		if err != nil {
+			log.Error(err, "unable to create secret for VM ", "instance",
+				credentials.GetInstanceId())
+			continue
+		}
+
+		nodeRecord, err := json.Marshal(newNodeRecord(credentials.GetIPAddress(), secretName))
+		if err != nil {
+			log.Error(err, "unable to marshall node record for VM ", "instance",
+				credentials.GetInstanceId())
+			continue
+		}
+		nodeRecords[credentials.GetInstanceId()] = nodeRecord
+	}
+	// We are overwriting the nodeRecords of tracker here. We'll always use configmap as source of truth
+	t.nodeRecords = nodeRecords
+}
+
+// createSecret creates the secret that stores the username and password from the credentials.
+func (t *Tracker) createSecret(credentials *types.Credentials) (string, error) {
+	creds := NewCredentials(credentials.GetUserName(), credentials.GetPassword())
+
+	reqBodyBytes := new(bytes.Buffer)
+	if err := json.NewEncoder(reqBodyBytes).Encode(creds); err != nil {
+		return "", errors.Wrap(err, "error encoding the credentials struct")
+	}
+
+	credValue := reqBodyBytes.Bytes()
+	credData := make(map[string][]byte, 1)
+	credData[credentials.GetInstanceId()] = credValue
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      credentials.GetInstanceId(),
+			Namespace: t.operatorNS,
+		},
+		Data: credData,
+		Type: v1.SecretTypeOpaque,
+	}
+
+	// Get and delete the secret if it already exists.
+	_, err := t.k8sclientset.CoreV1().Secrets(t.operatorNS).Get(credentials.GetInstanceId(), metav1.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		deleteOptions := &metav1.DeleteOptions{}
+		if err := t.k8sclientset.CoreV1().Secrets(t.operatorNS).Delete(credentials.GetInstanceId(), deleteOptions); err != nil {
+			return "", errors.Wrap(err, fmt.Sprintf("error deleting existing secret %s/%s", t.operatorNS,
+				credentials.GetInstanceId()))
+		}
+	}
+
+	secret, err = t.k8sclientset.CoreV1().Secrets(t.operatorNS).Create(secret)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("error creating secret %s/%s", t.operatorNS, credentials.GetInstanceId()))
+	}
+	return secret.GetName(), nil
+}
+
+// Credentials encapsulates the username and password of a VM. This to clearly differentiate between
+// the credentials we have in WNI. This ensures that we don't have to marshall the JSON to WNI's
+// Credentials struct which doesn't have JSON tags.
+type Credentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// NewCredentials returns a credentials object
+func NewCredentials(username, password string) Credentials {
+	return Credentials{
+		Username: username,
+		Password: password,
+	}
+}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
+	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	instanceType        = "m5a.large"
+	credentialAccountID = "default"
+	SSHKeyPair          = "libra"
+	wmcCRName           = "instance"
+)
+
+func creationTestSuite(t *testing.T) {
+	numOfNodesToBeCreated := 1
+	t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t, numOfNodesToBeCreated) })
+	t.Run("ConfigMap validation", func(t *testing.T) { testConfigMapValidation(t, numOfNodesToBeCreated) })
+	t.Run("Secrets validation", func(t *testing.T) { testValidateSecrets(t, numOfNodesToBeCreated) })
+}
+
+// testWindowsNodeCreation tests the Windows node creation in the cluster
+func testWindowsNodeCreation(t *testing.T, nodeCount int) {
+	testCtx := framework.NewTestCtx(t)
+	namespace, err := testCtx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// create WMCO custom resource
+	wmco := &operator.WindowsMachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "WindowsMachineConfig",
+			APIVersion: "wmc.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wmcCRName,
+			Namespace: namespace,
+		},
+		Spec: operator.WindowsMachineConfigSpec{
+			InstanceType: instanceType,
+			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: SSHKeyPair},
+			Replicas:     nodeCount,
+		},
+	}
+	if err = framework.Global.Client.Create(context.TODO(), wmco,
+		&framework.CleanupOptions{TestContext: testCtx,
+			Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval}); err != nil {
+		t.Fatalf("error creating wcmo custom resource  %v", err)
+	}
+	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
+	// side, let's make it as 60 minutes. The value comes from timeout variable
+	err = waitForWindowsNode(framework.Global.KubeClient, wmco.Spec.Replicas, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("windows node creation failed  with %v", err)
+	}
+
+}
+
+// waitForWindowsNode to be created waits for the Windows node to be created.
+func waitForWindowsNode(kubeclient kubernetes.Interface, expectedNodeCount int, retryInterval, timeout time.Duration) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		nodes, err := kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("Waiting for availability of %d windows nodes\n", expectedNodeCount)
+				return false, nil
+			}
+			return false, err
+		}
+		if len(nodes.Items) == expectedNodeCount {
+			log.Println("Created the required number of Windows worker nodes")
+			return true, nil
+		}
+		log.Printf("still waiting for %d number of Windows worker nodes to be available\n", expectedNodeCount)
+		return false, nil
+	})
+	return err
+}

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func deletionTestSuite(t *testing.T) {
+	nodeCount := 0
+	t.Run("Deletion", func(t *testing.T) { testWindowsNodeDeletion(t, nodeCount) })
+	t.Run("ConfigMap validation", func(t *testing.T) { testConfigMapValidation(t, nodeCount) })
+	t.Run("Secrets validation", func(t *testing.T) { testValidateSecrets(t, nodeCount) })
+}
+
+// testWindowsNodeDeletion tests the Windows node deletion from the cluster.
+func testWindowsNodeDeletion(t *testing.T, nodeCount int) {
+	testCtx := framework.NewTestCtx(t)
+	namespace, err := testCtx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get WMCO custom resource
+	wmco := &operator.WindowsMachineConfig{}
+	// Get the WMCO resource called instance
+	if err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: wmcCRName, Namespace: namespace}, wmco); err != nil {
+		t.Fatalf("error getting wcmo custom resource  %v", err)
+	}
+	// Delete the Windows VM that got created.
+	wmco.Spec.Replicas = nodeCount
+	if err := framework.Global.Client.Update(context.TODO(), wmco); err != nil {
+		t.Fatalf("error updating wcmo custom resource  %v", err)
+	}
+	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
+	// side, let's make it as 60 minutes.
+	err = waitForWindowsNode(framework.Global.KubeClient, wmco.Spec.Replicas, retryInterval, timeout)
+	if err != nil {
+		t.Fatalf("windows node deletion failed  with %v", err)
+	}
+	defer testCtx.Cleanup()
+}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -1,0 +1,198 @@
+package e2e
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
+	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// waitForTrackerConfigMap to be created waits for the Windows tracker configmap to be created with appropriate values
+func waitForTrackerConfigMap(kubeclient kubernetes.Interface, namespace string, expectedNodesToBeTracked int,
+	retryInterval, timeout time.Duration) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		trackerConfigMap, err := kubeclient.CoreV1().ConfigMaps(namespace).Get(tracker.StoreName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("Waiting for availability of tracker configmap to be created: %s\n", tracker.StoreName)
+				return false, nil
+			}
+			return false, err
+		}
+		if len(trackerConfigMap.BinaryData) == expectedNodesToBeTracked {
+			log.Println("Tracker configmap tracking required number of configmap")
+			return true, nil
+		}
+		log.Printf("still waiting for %d number of "+
+			"Windows worker nodes to be tracked but as of now we have %d\n", expectedNodesToBeTracked,
+			len(trackerConfigMap.BinaryData))
+		return false, nil
+	})
+	return err
+}
+
+// getInstanceID gets the instanceID of VM for a given cloud provider ID
+// Ex: aws:///us-east-1e/i-078285fdadccb2eaa. We always want the last entry which is the instanceID
+func getInstanceID(providerID string) string {
+	providerTokens := strings.Split(providerID, "/")
+	return providerTokens[len(providerTokens)-1]
+}
+
+// getInstanceIDsOfNode returns the instanceIDs of all the Windows nodes created
+func getInstanceIDsOfNode(kubeclient kubernetes.Interface) ([]string, error) {
+	nodes, err := kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
+	if err != nil {
+		return nil, errors.Wrap(err, "error while querying for Windows nodes")
+	}
+	instanceIDs := make([]string, 0, len(nodes.Items))
+	for _, node := range nodes.Items {
+		if len(node.Spec.ProviderID) > 0 {
+			instanceID := getInstanceID(node.Spec.ProviderID)
+			instanceIDs = append(instanceIDs, instanceID)
+		}
+	}
+	return instanceIDs, nil
+}
+
+// testConfigMapValidation ensures that the required configMap is created and is having appropriate
+// entries
+func testConfigMapValidation(t *testing.T, nodeCount int) {
+	testCtx := framework.NewTestCtx(t)
+	namespace, err := testCtx.GetNamespace()
+	require.NoError(t, err, "error while getting test namespace")
+
+	err = waitForTrackerConfigMap(framework.Global.KubeClient, namespace, nodeCount,
+		retryInterval, time.Minute*1)
+	require.NoError(t, err, "error waiting for tracker configmap")
+
+	// Get the instance id from the cloud provider for the windows Nodes created
+	instanceIDs, err := getInstanceIDsOfNode(framework.Global.KubeClient)
+	require.NoError(t, err, "error while getting provider specific instanceIDs")
+
+	// check if those instances are present in the configmap
+	trackerConfigMap, err := framework.Global.KubeClient.CoreV1().ConfigMaps(namespace).Get(tracker.StoreName, metav1.GetOptions{})
+	require.NoError(t, err, "error while getting the tracker configmap")
+	for _, instanceID := range instanceIDs {
+		assert.Contains(t, trackerConfigMap.BinaryData, instanceID)
+	}
+}
+
+// getWindowsVM returns a windowsVM interface to be used for running commands against
+func getWindowsVM(ipAddress, instanceID string, credentials tracker.Credentials) (types.WindowsVM, error) {
+	winVM := &types.Windows{}
+	windowsCredentials := types.NewCredentials(instanceID, ipAddress, credentials.Password, credentials.Username)
+	winVM.Credentials = windowsCredentials
+	// Set up Winrm client
+	err := winVM.SetupWinRMClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "error instantiating winrm client")
+	}
+	return winVM, nil
+}
+
+// validateConnectivity creates a Windows VM object and ensures that we have connectivity
+// for the Windows VM
+func validateConnectivity(ipAddress, instanceID string, credentials tracker.Credentials) error {
+	windowsVM, err := getWindowsVM(ipAddress, instanceID, credentials)
+	if err != nil {
+		return err
+	}
+	stdout, stderr, err := windowsVM.Run("dir", false)
+	if err != nil {
+		return errors.Wrap(err, "failed to run dir command on remote Windows VM")
+	}
+	if stderr != "" {
+		return errors.New("test returned stderr output")
+	}
+	if strings.Contains(stdout, "FAIL") {
+		return errors.New("test output showed a failure")
+	}
+	if strings.Contains(stdout, "panic") {
+		return errors.New("test output showed panic")
+	}
+	return nil
+}
+
+// getInstanceIP gets the instance IP address associated with a node
+func getInstanceIP(instanceID string, kubeclient kubernetes.Interface) (string, error) {
+	nodes, err := kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
+	if err != nil {
+		return "", errors.Wrap(err, "error while querying for Windows nodes")
+	}
+	for _, node := range nodes.Items {
+		if strings.Contains(node.Spec.ProviderID, instanceID) {
+			for _, address := range node.Status.Addresses {
+				if address.Type == corev1.NodeExternalIP {
+					return address.Address, nil
+				}
+			}
+		}
+	}
+	return "", errors.New("unable to find Windows Worker nodes")
+}
+
+// validateInstanceSecret validates the instance secret.
+func validateInstanceSecret(kubeclient kubernetes.Interface, namespace, instanceID string,
+	retryInterval, timeout time.Duration) error {
+	ipAddress, err := getInstanceIP(instanceID, kubeclient)
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		instanceSecret, err := kubeclient.CoreV1().Secrets(namespace).Get(instanceID, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("Waiting for instance secret to be created: %s\n", instanceSecret.Name)
+				return false, nil
+			}
+			return false, err
+		}
+		encodedCreds := instanceSecret.Data[instanceID]
+
+		var creds tracker.Credentials
+		if err := json.Unmarshal(encodedCreds, &creds); err != nil {
+			return false, errors.Wrap(err, "unmarshalling creds failed")
+		}
+
+		if err := validateConnectivity(ipAddress, instanceID, creds); err == nil {
+			log.Println("Successfully validated the SSH Connection")
+			return true, nil
+		}
+
+		log.Printf("failed with error for creds %v: %v", creds, err)
+		return false, nil
+	})
+	return err
+}
+
+// testValidateSecrets ensures we've valid secrets in place to be used by trackerConfigmap to construct node objects
+func testValidateSecrets(t *testing.T, nodeCount int) {
+	testCtx := framework.NewTestCtx(t)
+	namespace, err := testCtx.GetNamespace()
+
+	require.NoError(t, err, "error while getting namespace")
+
+	// Get the instance id from the cloud provider for the windows Nodes created
+	instanceIDs, err := getInstanceIDsOfNode(framework.Global.KubeClient)
+	require.NoError(t, err, "error while getting instance ids")
+	require.Equal(t, len(instanceIDs), nodeCount, "mismatched node count")
+	for _, instanceID := range instanceIDs {
+		err := validateInstanceSecret(framework.Global.KubeClient, namespace, instanceID,
+			retryInterval, timeout)
+		assert.NoError(t, err, "error validating instance secret")
+	}
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -1,21 +1,13 @@
 package e2e
 
 import (
-	"context"
-	"log"
 	"testing"
 	"time"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/apis"
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
-	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -33,66 +25,8 @@ func TestWMCO(t *testing.T) {
 	// TODO: In future, we'd like to skip the teardown for each test. As of now, since we just have deletion it should
 	// 		be ok to call destroy directly.
 	//		Jira Story: https://issues.redhat.com/browse/WINC-283
-	t.Run("create", testWindowsNodeCreation)
-	t.Run("destroy", testWindowsNodeDeletion)
-}
-
-// testWindowsNodeCreation tests the Windows node creation in the cluster
-func testWindowsNodeCreation(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	namespace, err := testCtx.GetNamespace()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// create WMCO custom resource
-	wmco := &operator.WindowsMachineConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "WindowsMachineConfig",
-			APIVersion: "wmc.openshift.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "instance",
-			Namespace: namespace,
-		},
-		Spec: operator.WindowsMachineConfigSpec{
-			InstanceType: "m4.large",
-			AWS:          &operator.AWS{CredentialAccountID: "default", SSHKeyPair: "libra"},
-			Replicas:     1,
-		},
-	}
-	if err = framework.Global.Client.Create(context.TODO(), wmco,
-		&framework.CleanupOptions{TestContext: testCtx,
-			Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval}); err != nil {
-		t.Fatalf("error creating wcmo custom resource  %v", err)
-	}
-	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
-	// side, let's make it as 60 minutes.
-	err = waitForWindowsNode(framework.Global.KubeClient, wmco.Spec.Replicas, retryInterval, timeout)
-	if err != nil {
-		t.Fatalf("windows node creation failed  with %v", err)
-	}
-
-}
-
-// waitForWindowsNode to be created waits for the Windows node to be created. As of now, we're waiting for 60 minutes
-func waitForWindowsNode(kubeclient kubernetes.Interface, expectedNodeCount int, retryInterval, timeout time.Duration) error {
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		nodes, err := kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				log.Printf("Waiting for availability of %d windows nodes\n", expectedNodeCount)
-				return false, nil
-			}
-			return false, err
-		}
-		if len(nodes.Items) == expectedNodeCount {
-			log.Println("Created the required number of Windows worker nodes")
-			return true, nil
-		}
-		log.Printf("still waiting for %d number of Windows worker nodes to be available\n", expectedNodeCount)
-		return false, nil
-	})
-	return err
+	t.Run("create", creationTestSuite)
+	t.Run("destroy", deletionTestSuite)
 }
 
 // setupWMCO setups the resources needed to run WMCO tests
@@ -103,31 +37,4 @@ func setupWMCOResources() error {
 		return errors.Wrap(err, "failed setting up test suite")
 	}
 	return nil
-}
-
-// testWindowsNodeDeletion tests the Windows node deletion from the cluster.
-func testWindowsNodeDeletion(t *testing.T) {
-	testCtx := framework.NewTestCtx(t)
-	namespace, err := testCtx.GetNamespace()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// get WMCO custom resource
-	wmco := &operator.WindowsMachineConfig{}
-	// Get the WMCO resource called instance
-	if err := framework.Global.Client.Get(context.TODO(), types.NamespacedName{Name: "instance", Namespace: namespace}, wmco); err != nil {
-		t.Fatalf("error getting wcmo custom resource  %v", err)
-	}
-	// Delete the Windows VM that got created.
-	wmco.Spec.Replicas = 0
-	if err := framework.Global.Client.Update(context.TODO(), wmco); err != nil {
-		t.Fatalf("error updating wcmo custom resource  %v", err)
-	}
-	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
-	// side, let's make it as 60 minutes.
-	err = waitForWindowsNode(framework.Global.KubeClient, wmco.Spec.Replicas, retryInterval, timeout)
-	if err != nil {
-		t.Fatalf("windows node deletion failed  with %v", err)
-	}
-	defer testCtx.Cleanup()
 }


### PR DESCRIPTION
The operator needs an internal tracking mechanism for Windows
nodes that it is managing that has some associated meta data.
This meta data will allow the Operator to sync the nodes on
cluster to what is expected as per the WMC CR. This commits
add the tracker configmap which can be used to identify the
nodes that are being added to the cluster.

/cc @openshift/openshift-team-windows-containers @aravindhp 