### PR TITLE
[wmco] Relax CRD field validation

### DIFF
--- a/deploy/crds/wmc.openshift.io_v1alpha1_windowsmachineconfig_cr.yaml
+++ b/deploy/crds/wmc.openshift.io_v1alpha1_windowsmachineconfig_cr.yaml
@@ -1,7 +1,11 @@
 apiVersion: wmc.openshift.io/v1alpha1
 kind: WindowsMachineConfig
 metadata:
-  name: example-windowsmachineconfig
+  name: instance
 spec:
   # Add fields here
-  size: 3
+  replicas: 1
+  instanceType: "m5a.large"
+  aws:
+    credentialAccountId: "default"
+    sshKeyPair: "openshift-dev"

--- a/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -33,7 +33,7 @@ spec:
           description: WindowsMachineConfigSpec defines the desired state of WindowsMachineConfig
           properties:
             aws:
-              description: AWS holds AWS specific cloud provider information.
+              description: AWS holds AWS specific cloud provider information
               properties:
                 credentialAccountId:
                   description: CredentialAccountID is account id associated with AWS
@@ -44,22 +44,13 @@ spec:
                     AWS asks a keypair to be present for encrypting the Windows VM
                     password
                   type: string
-                sshPrivateKey:
-                  description: SSHPrivateKey is the name of the secret which contains
-                    ssh key to decrypt the password
-                  type: string
               required:
               - credentialAccountId
               - sshKeyPair
-              - sshPrivateKey
               type: object
             azure:
               description: Azure holds Azure specific cloud provider information
               type: object
-            cloudProviderCredentials:
-              description: CloudProviderCredentials is the name of the secret which
-                contains the credentials of the cloud provider
-              type: string
             instanceType:
               description: InstanceType represents the flavor of instance to be used
                 while creating the virtual machines. Please note that this is common
@@ -70,8 +61,8 @@ spec:
                 the OpenShift cluster
               type: integer
           required:
-          - aws
-          - azure
+          - instanceType
+          - replicas
           type: object
         status:
           description: WindowsMachineConfigStatus defines the observed state of WindowsMachineConfig

--- a/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
+++ b/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
@@ -11,18 +11,17 @@ import (
 type WindowsMachineConfigSpec struct {
 	// Replicas represent how many Windows nodes to be added to the
 	// OpenShift cluster
-	Replicas int `json:"replicas,omitempty"`
+	Replicas int `json:"replicas"`
 	// InstanceType represents the flavor of instance to be used while
 	// creating the virtual machines. Please note that this is common
 	// across all the Windows nodes in the cluster
-	InstanceType string `json:"instanceType,omitempty"`
-	// AWS holds AWS specific cloud provider information.
-	AWS *AWS `json:"aws"`
+	InstanceType string `json:"instanceType"`
+	// AWS holds AWS specific cloud provider information
+	// +optional
+	AWS *AWS `json:"aws,omitempty"`
 	// Azure holds Azure specific cloud provider information
-	Azure *Azure `json:"azure"`
-	// CloudProviderCredentials is the name of the secret which contains the
-	// credentials of the cloud provider
-	CloudProviderCredentials string `json:"cloudProviderCredentials,omitempty"`
+	// +optional
+	Azure *Azure `json:"azure,omitempty"`
 }
 
 // AWS holds the information related to AWS cloud provider
@@ -30,9 +29,6 @@ type AWS struct {
 	// SSHKeyPair is the sshKeyPair associated with cloudprovider. AWS
 	// asks a keypair to be present for encrypting the Windows VM password
 	SSHKeyPair string `json:"sshKeyPair"`
-	// SSHPrivateKey is the name of the secret which contains ssh key
-	// to decrypt the password
-	SSHPrivateKey string `json:"sshPrivateKey"`
 	// CredentialAccountID is account id associated with AWS provider
 	CredentialAccountID string `json:"credentialAccountId"`
 }

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -6,6 +6,7 @@ const (
 	CloudCredentialsPath = "/etc/cloud/credentials"
 	// PrivateKeyPath contains the path to the private key which is used in decrypting password in case of AWS
 	// cloud provider. This would have been mounted as a secret by user
+	// TODO: Jira story for validation: https://issues.redhat.com/browse/WINC-316
 	PrivateKeyPath = "/etc/private-key/private-key.pem"
 	// WmcbPath contains the path of the Windows Machine Config Bootstrapper binary. The container image should already
 	// have this binary mounted


### PR DESCRIPTION
As of now, the e2es are failing as some CRD fields
are made mandatory. This commit relaxes
the restriction and removes certain fields that are
not mandatory anymore

cc @aravindhp @openshift/openshift-team-windows-containers 