### PR TITLE
[wmco] Add validation for fields in the CRD

### DIFF
--- a/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -59,6 +59,7 @@ spec:
             replicas:
               description: Replicas represent how many Windows nodes to be added to
                 the OpenShift cluster
+              minimum: 0
               type: integer
           required:
           - instanceType

--- a/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
+++ b/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
@@ -11,6 +11,7 @@ import (
 type WindowsMachineConfigSpec struct {
 	// Replicas represent how many Windows nodes to be added to the
 	// OpenShift cluster
+	// +kubebuilder:validation:Minimum=0
 	Replicas int `json:"replicas"`
 	// InstanceType represents the flavor of instance to be used while
 	// creating the virtual machines. Please note that this is common

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -25,6 +25,7 @@ func TestWMCO(t *testing.T) {
 	// TODO: In future, we'd like to skip the teardown for each test. As of now, since we just have deletion it should
 	// 		be ok to call destroy directly.
 	//		Jira Story: https://issues.redhat.com/browse/WINC-283
+	t.Run("WMC CR validation", testWMCValidation)
 	t.Run("create", creationTestSuite)
 	t.Run("destroy", deletionTestSuite)
 }


### PR DESCRIPTION
This PR updates the WMC CRD to set the minimum value of 'replicas' 
field to 0 by executing 'operator-sdk generate crds' command

It also adds validations for 'replicas' field in the CRD. Following are the
validations that are performed.

- 'replicas' field is a required field and should be present
- 'replicas' field cannot have value less than 0