### PR TITLE
Bug 1813508: Update dockerfile to address buildah COPY bug

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -70,7 +70,10 @@ COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
 
 # Copy CNI plugin binaries
 WORKDIR /payload/cni-plugins/
-COPY --from=download /download/cni-plugins/* .
+COPY --from=download /download/cni-plugins/flannel.exe .
+COPY --from=download /download/cni-plugins/host-local.exe .
+COPY --from=download /download/cni-plugins/win-bridge.exe .
+COPY --from=download /download/cni-plugins/win-overlay.exe .
 
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -87,7 +87,10 @@ COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
 # Copy CNI plugin binaries
 RUN mkdir /payload/cni-plugins/
 WORKDIR /payload/cni-plugins/
-COPY --from=download /download/cni-plugins/* .
+COPY --from=download /download/cni-plugins/flannel.exe .
+COPY --from=download /download/cni-plugins/host-local.exe .
+COPY --from=download /download/cni-plugins/win-bridge.exe .
+COPY --from=download /download/cni-plugins/win-overlay.exe .
 
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/


### PR DESCRIPTION
Docker has a longstanding bug using globs
in COPY directives (i.e. COPY foo/dir/* /tmp/dir/ ).
If the source files matched by the glob include
subdirectories, these subdirectories are
not present in the destination. While this is not
a problem for WMCO Dockerfiles, we are doing it
just to be on safe side.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1813508