### PR TITLE
Bug 1817186: [wmco] Fix log panic

### DIFF
--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileWindowsMachineConfig) createWindowsWorkerNodes(count int) bool
 		if err := nc.Configure(); err != nil {
 			// TODO: Unwrap to extract correct error
 			errs = append(errs, errors.Wrap(err, "configuring Windows VM failed"))
-			log.Error(err, "configuring Windows VM failed", err)
+			log.Error(err, "configuring Windows VM failed")
 		}
 
 		// update the windowsVMs slice


### PR DESCRIPTION
As of now, we are panicking at the place, where we've
a log entry with odd number of arguments for the logger

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817186