### PR TITLE
[docs] Fix link for SshKeyPair in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
 export CLUSTER_ADDR=<cluster_name, eg: ravig211.devcluster.openshift.com>
 export KUBE_SSH_KEY_PATH=<path to ssh key>
 ```
-- Update the keypair mentioned at [sshKeyPair](https://github.com/openshift/windows-machine-config-operator/blob/42593c5d2eb798b572c58b5debafc4c392d1f967/test/e2e/wmco_test.go#L59) to match with what 
+- Update the sshKeyPair mentioned in [create_test.go](https://github.com/openshift/windows-machine-config-operator/blob/master/test/e2e/create_test.go) to match with what 
 is being used in KUBE_SSH_KEY_PATH. Please note that we're using libra as keypair
 for our CI purposes.
 - Ensure that /payload directory exists and is accessible by the user account. The directory needs to be populated with the following files. Please see the [Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/build/Dockerfile) for figuring where to download and build these binaries. It is up to the user to keep these files up to date.


### PR DESCRIPTION
Updated Readme to point the correct link for updating shheyPair,
now mentioned in create_test.go file.