### PR TITLE
[wmco] Ensure files required by WMCO are present

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/pkg/apis"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller"
+	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
 	"github.com/openshift/windows-machine-config-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -69,6 +71,25 @@ func main() {
 
 	printVersion()
 
+	// Checking if required files exist before starting the operator
+	requiredFiles := []string{
+		wkl.FlannelCNIPluginPath,
+		wkl.HostLocalCNIPlugin,
+		wkl.WinBridgeCNIPlugin,
+		wkl.WinOverlayCNIPlugin,
+		wkl.HybridOverlayPath,
+		wkl.KubeletPath,
+		wkl.KubeProxyPath,
+		wkl.IgnoreWgetPowerShellPath,
+		wkl.WmcbPath,
+		wkl.CloudCredentialsPath,
+		wkl.PrivateKeyPath,
+	}
+	if err := checkIfRequiredFilesExist(requiredFiles); err != nil {
+		log.Error(err, "could not start the operator")
+		os.Exit(1)
+	}
+
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		log.Error(err, "Failed to get watch namespace")
@@ -113,9 +134,6 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-
-	// TODO: Add checks for the existence of well known paths likes
-	// 		/payload/bin/, /etc/cloud/credentials etc.
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg, namespace)
@@ -186,6 +204,25 @@ func serveCRMetrics(cfg *rest.Config) error {
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// checkIfRequiredFilesExist checks for the existence of required files and binaries before starting WMCO
+// sample error message: errors encountered with required files: could not stat /payload/hybrid-overlay.exe:
+// stat /payload/hybrid-overlay.exe: no such file or directory, could not stat /payload/wmcb.exe: stat /payload/wmcb.exe:
+// no such file or directory
+func checkIfRequiredFilesExist(requiredFiles []string) error {
+	var errorMessages []string
+	// Iterating through file paths and checking if they are present
+	for _, file := range requiredFiles {
+		if _, err := os.Stat(file); err != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("could not stat %s: %v", file, err))
+		}
+	}
+
+	if len(errorMessages) > 0 {
+		return fmt.Errorf("errors encountered with required files: %s", strings.Join(errorMessages, ", "))
 	}
 	return nil
 }

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckIfRequiredFilesExist tests if checkIfRequiredFilesExist function is throwing appropriate error when some
+// of the files required by WMCO are missing
+func TestCheckIfRequiredFilesExist(t *testing.T) {
+	// required files of WMCO that are missing
+	var missingRequiredFiles = []string{
+		"/payload/file-1",
+		"/payload/file-2",
+	}
+	err := checkIfRequiredFilesExist(missingRequiredFiles)
+	require.Error(t, err, "Function checkIfRequiredFilesExist did not throw an error when it was expected to")
+	assert.Contains(t, err.Error(), "could not stat /payload/file-1: stat /payload/file-1: no such file or directory",
+		"Expected error message is absent")
+	assert.Contains(t, err.Error(), "could not stat /payload/file-2: stat /payload/file-2: no such file or directory",
+		"Expected error message is absent")
+
+}

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -2,5 +2,17 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${WMCO_ROOT}"
+
+# Account for environments where GOFLAGS is not set by setting goflags to an empty string if GOFLAGS is not set
+goflags=${GOFLAGS:-}
+
+# The golang 1.13 image used in CI enforces vendoring. Workaround that by unsetting it.
+if [[ "$goflags" == *"-mod=vendor"* ]]; then
+  unset GOFLAGS
+fi
+
+go test -v ./cmd/...
 
 exit 0

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -13,7 +13,25 @@ const (
 	WmcbPath = "/payload/wmcb.exe"
 	// KubeletPath contains the path of the kubelet binary. The container image should already have this binary mounted
 	KubeletPath = "/payload/kube-node/kubelet.exe"
+	// KubeProxyPath contains the path of the kube-proxy binary. The container image should already have this binary
+	// mounted
+	KubeProxyPath = "/payload/kube-node/kube-proxy.exe"
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
 	IgnoreWgetPowerShellPath = "/payload/powershell/wget-ignore-cert.ps1"
+	// FlannelCNIPluginPath is the path of the flannel CNI plugin binary. The container image should already have this
+	// binary mounted
+	FlannelCNIPluginPath = "/payload/cni-plugins/flannel.exe"
+	// HostLocalCNIPluginPath is the path of the host-local CNI plugin binary. The container image should already have
+	// this binary mounted
+	HostLocalCNIPlugin = "/payload/cni-plugins/host-local.exe"
+	// WinBridgeCNIPluginPath is the path of the win-bridge CNI plugin binary. The container image should already have
+	// this binary mounted
+	WinBridgeCNIPlugin = "/payload/cni-plugins/win-bridge.exe"
+	// WinOverlayCNIPluginPath is the path of the win-overlay CNI Plugin binary. The container image should already have
+	// this binary mounted
+	WinOverlayCNIPlugin = "/payload/cni-plugins/win-overlay.exe"
+	// HybridOverlayPath contains the path of the hybrid overlay binary. The container image should already have this
+	// binary mounted
+	HybridOverlayPath = "/payload/hybrid-overlay.exe"
 )


### PR DESCRIPTION
This PR introduces a guard that ensures that required files for WMCO exist
before the operator starts. The operator fails when the required files are
absent. Also, the golang 1.13 image used in CI enforces vendoring, unseting it
before running the unit tests.