### PR TITLE
[ci] Add local dev flags to e2e script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
 export CLUSTER_ADDR=<cluster_name, eg: ravig211.devcluster.openshift.com>
 export KUBE_SSH_KEY_PATH=<path to ssh key>
 ```
-- Update the sshKeyPair mentioned in [create_test.go](https://github.com/openshift/windows-machine-config-operator/blob/master/test/e2e/create_test.go) to match with what 
-is being used in KUBE_SSH_KEY_PATH. Please note that we're using libra as keypair
-for our CI purposes.
 - Ensure that /payload directory exists and is accessible by the user account. The directory needs to be populated with the following files. Please see the [Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/build/Dockerfile) for figuring where to download and build these binaries. It is up to the user to keep these files up to date.
 ```
 /payload/
@@ -42,9 +39,21 @@ for our CI purposes.
 ```
 Once the above variables are set and the /payload directory has been populated, run the following script:
 ```shell script
-hack/run-ci-e2e-test.sh
+hack/run-ci-e2e-test.sh -k "openshift-dev"
 ```
+We assume that the developer uses `openshift-dev` as the key pair in the aws cloud
 
+Additional flags that can be passed to `hack/run-ci-e2e-test.sh` are
+- `-s` to skip the deletion of Windows nodes that are created as part of test suite run
+- `-n` to represent the number of Windows nodes to be created for test run
+- `-k` to represent the AWS specific key pair that will be used during e2e run and it should map to the private key
+       that we have in `KUBE_SSH_KEY_PATH`. The default value points to `libra` which we use in our CI
+       
+Example command to spin up 2 Windows nodes and retain them after test run:
+```
+hack/run-ci-e2e-test.sh -s -k "openshift-dev" -n 2      
+```
+        
 ## Bundling the Windows Machine Config Operator
 This directory contains resources related to installing the WMCO onto a cluster using OLM.
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -7,21 +7,61 @@ set -o pipefail
 # TODO: This needs to be removed as part of https://issues.redhat.com/browse/WINC-351
 oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
 
+NODE_COUNT=""
+SKIP_NODE_DELETION=""
+KEY_PAIR_NAME=""
+
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 export CGO_ENABLED=0
 export CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 
+while getopts ":n:k:s" opt; do
+  case ${opt} in
+    n ) # process option for the node count
+      NODE_COUNT=$OPTARG
+      ;;
+    k ) # process option for the keypair to be used by AWS cloud provider
+      KEY_PAIR_NAME=$OPTARG
+      ;;
+    s ) # process option for skipping deleting Windows VMs created by test suite
+      SKIP_NODE_DELETION="-skip-node-deletion"
+      ;;
+    \? )
+      echo "Usage: $0 [-n] [-k] [-s]"
+      exit 0
+      ;;
+  esac
+done
+
 # Copy the cloud credentials and KUBESSH key path so that they can be used by operator
 cp $AWS_SHARED_CREDENTIALS_FILE /etc/cloud/credentials
 cp $KUBE_SSH_KEY_PATH /etc/private-key/private-key.pem
 
-# Get operator-sdk binary.
-# TODO: Make this to download the same version we have in go dependencies in gomod
-wget -O /tmp/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.15.2/operator-sdk-v0.15.2-x86_64-linux-gnu && chmod +x /tmp/operator-sdk
+# Download the operator-sdk binary only if it is not already available
+# We do not validate the version of operator-sdk if it is available already
+if ! type operator-sdk > /dev/null; then
+  # TODO: Make this download the same version we have in go dependencies in gomod
+  wget -O /tmp/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.15.2/operator-sdk-v0.15.2-x86_64-linux-gnu && chmod +x /tmp/operator-sdk
+  # To expand alias. We'll add an alias for operator-sdk to be in `/tmp/operator-sdk`
+  shopt -s expand_aliases
+  alias operator-sdk=/tmp/operator-sdk
+fi
+
+# Set default values for the flags. Without this operator-sdk flags are getting
+# polluted. For example, if KEY_PAIR_NAME is not passed or passed as empty value
+# the value is literally taken as "" instead of empty-string so default values we
+# specified in main_test.go has literally no effect. Not sure, if this is because of
+# the way operator-sdk testing is done using `go test []string{}
+NODE_COUNT=${NODE_COUNT:-1}
+SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"-skip-node-deletion=false"}
+KEY_PAIR_NAME=${KEY_PAIR_NAME:-"libra"}
+
 cd $WMCO_ROOT
-oc create -f deploy/namespace.yaml 
-/tmp/operator-sdk test local ./test/e2e --up-local --namespace=windows-machine-config-operator --go-test-flags "-v -timeout 60m"
+oc create -f deploy/namespace.yaml
+# The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
+# -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
+operator-sdk test local ./test/e2e --up-local --namespace=windows-machine-config-operator --go-test-flags "-v -timeout=60m -node-count=$NODE_COUNT $SKIP_NODE_DELETION -ssh-key-pair=$KEY_PAIR_NAME"
 oc delete -f deploy/namespace.yaml 
 
 exit 0

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -20,7 +20,6 @@ import (
 const (
 	instanceType        = "m5a.large"
 	credentialAccountID = "default"
-	SSHKeyPair          = "libra"
 	wmcCRName           = "instance"
 )
 
@@ -53,7 +52,7 @@ func testWindowsNodeCreation(t *testing.T) {
 		},
 		Spec: operator.WindowsMachineConfigSpec{
 			InstanceType: instanceType,
-			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: SSHKeyPair},
+			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: gc.sshKeyPair},
 			Replicas:     gc.numberOfNodes,
 		},
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"flag"
 	"testing"
 	"time"
 
@@ -15,10 +16,14 @@ import (
 
 var (
 	// numberOfNodes represent the number of nodes to be dealt with in the test suite.
-	// Expose this as a flag.
-	numberOfNodes = 1
+	numberOfNodes int
+	// skipNodeDeletion allows the Windows nodes to hang around after the test suite has been run. This skips the deletion
+	// test suite.
+	skipNodeDeletion bool
+	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
+	sshKeyPair string
 	// gc is the global context across the test suites.
-	gc = globalContext{numberOfNodes: numberOfNodes}
+	gc = globalContext{}
 )
 
 // testVM encapsulates a VM created by the test
@@ -38,6 +43,10 @@ type globalContext struct {
 	nodes []v1.Node
 	// windowsVMs is used to interact with the Windows VMs created by the test suite
 	windowsVMs []testVM
+	// skipNodeDeletion allows the Windows nodes to hang around after the test suite has been run.
+	skipNodeDeletion bool
+	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
+	sshKeyPair string
 }
 
 // testContext holds the information related to the individual test suite. This data structure
@@ -81,5 +90,11 @@ func (tc *testContext) cleanup() {
 }
 
 func TestMain(m *testing.M) {
+	flag.IntVar(&numberOfNodes, "node-count", 1, "number of nodes to be created for testing")
+	flag.BoolVar(&skipNodeDeletion, "skip-node-deletion", false,
+		"Option to disable deletion of the VMs")
+	// We're using libra as default value to be used in CI
+	flag.StringVar(&sshKeyPair, "ssh-key-pair", "libra", "SSH Key Pair to be used for decrypting "+
+		"the Windows Node password")
 	framework.MainEntry(m)
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -267,7 +267,7 @@ func createWindowsMachineConfig(namespace string, isReplicasFieldRequired bool, 
 		},
 		Spec: operator.WindowsMachineConfigSpec{
 			InstanceType: instanceType,
-			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: SSHKeyPair},
+			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: gc.sshKeyPair},
 		},
 	}
 	if isReplicasFieldRequired {

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -22,12 +22,19 @@ func TestWMCO(t *testing.T) {
 	if err := setupWMCOResources(); err != nil {
 		t.Fatalf("%v", err)
 	}
-	// TODO: In future, we'd like to skip the teardown for each test. As of now, since we just have deletion it should
-	// 		be ok to call destroy directly.
-	//		Jira Story: https://issues.redhat.com/browse/WINC-283
+
+	// We've to update the global context struct here as the operator-sdk's framework has coupled flag
+	// parsing along with test suite execution.
+	// Reference:
+	// https://github.com/operator-framework/operator-sdk/blob/b448429687fd7cb2343d022814ed70c9d264612b/pkg/test/main_entry.go#L51
+	gc.numberOfNodes = numberOfNodes
+	gc.skipNodeDeletion = skipNodeDeletion
+	gc.sshKeyPair = sshKeyPair
 	t.Run("WMC CR validation", testWMCValidation)
 	t.Run("create", creationTestSuite)
-	t.Run("destroy", deletionTestSuite)
+	if !gc.skipNodeDeletion {
+		t.Run("destroy", deletionTestSuite)
+	}
 }
 
 // setupWMCO setups the resources needed to run WMCO tests


### PR DESCRIPTION
As of now, after the test suite has been run, the
Windows nodes would be deleted as well. This commit
ensures that
- We have a flag which retains the Windows node
 created as part of test suite. Please note that
 we're skipping the part where the delete
 suite is being called in case this flag has been
 set.
- We have flag to specify the number of number of
  Windows nodes to be created as part of test run
- We won't download operator-sdk if it's already
  available in the PATH

Example command to spin up 2 Windows nodes and retain them after test run:

```
hack/run-ci-e2e-test.sh -s -k "openshift-dev" -n 2"
```