### PR TITLE
Bug 1817186: [wmco]  Fix log panic and correct formatting of log messages

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,10 +40,9 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info("operator", "version", version.Version)
+	log.Info("go", "version", runtime.Version(), "os", runtime.GOOS, "arch", runtime.GOARCH)
+	log.Info("operator-sdk", "version", sdkVersion.Version)
 }
 
 func main() {
@@ -71,7 +70,7 @@ func main() {
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
+		log.Error(err, "failed to get watch namespace")
 		os.Exit(1)
 	}
 
@@ -100,7 +99,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Registering Components.")
+	log.Info("registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
@@ -120,11 +119,11 @@ func main() {
 	// Add the Metrics Service
 	addMetrics(ctx, cfg, namespace)
 
-	log.Info("Starting the Cmd.")
+	log.Info("starting the Cmd.")
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "Manager exited non-zero")
+		log.Error(err, "manager exited non-zero")
 		os.Exit(1)
 	}
 }
@@ -134,10 +133,10 @@ func main() {
 func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
 	if err := serveCRMetrics(cfg); err != nil {
 		if errors.Is(err, k8sutil.ErrRunLocal) {
-			log.Info("Skipping CR metrics server creation; not running in a cluster.")
+			log.Info("skipping CR metrics server creation; not running in a cluster.")
 			return
 		}
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+		log.Info("could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
 	// Add to the below struct any other metrics ports you want to expose.
@@ -149,7 +148,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service", "error", err.Error())
+		log.Info("could not create metrics Service", "error", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
@@ -157,11 +156,11 @@ func addMetrics(ctx context.Context, cfg *rest.Config, namespace string) {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
+		log.Info("could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
 		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+			log.Info("install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
 		}
 	}
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -77,7 +77,7 @@ func main() {
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Error(err, "")
+		log.Error(err, "failed to get the config for talking to a Kubernetes API server")
 		os.Exit(1)
 	}
 
@@ -85,7 +85,7 @@ func main() {
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "windows-machine-config-operator-lock")
 	if err != nil {
-		log.Error(err, "")
+		log.Error(err, "failed to become a leader within current namespace")
 		os.Exit(1)
 	}
 
@@ -95,7 +95,7 @@ func main() {
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {
-		log.Error(err, "")
+		log.Error(err, "failed to create a new Manager")
 		os.Exit(1)
 	}
 
@@ -103,13 +103,13 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "")
+		log.Error(err, "failed to add all Resources to the Scheme")
 		os.Exit(1)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Error(err, "")
+		log.Error(err, "failed to add all Controllers to the Manager")
 		os.Exit(1)
 	}
 

--- a/pkg/controller/windowsmachineconfig/tracker/tracker.go
+++ b/pkg/controller/windowsmachineconfig/tracker/tracker.go
@@ -160,12 +160,12 @@ func (t *Tracker) syncNodeRecords() {
 		}
 		if credentials.GetInstanceId() == "" || credentials.GetIPAddress() == "" || credentials.GetPassword() == "" ||
 			credentials.GetUserName() == "" {
-			log.Info("ignoring VM with incomplete credentials: %v", credentials)
+			log.Info("ignoring VM with incomplete credentials", "credentials", credentials)
 			continue
 		}
 		if t.nodeRecords != nil {
 			if _, ok := t.nodeRecords[credentials.GetInstanceId()]; ok {
-				log.Info("Node records already exist for the given Windows VM")
+				log.Info("node records already exist for the given Windows VM")
 				continue
 			}
 		}

--- a/pkg/controller/windowsmachineconfig/windows/windows.go
+++ b/pkg/controller/windowsmachineconfig/windows/windows.go
@@ -59,7 +59,7 @@ func (vm *Windows) runBootstrapper() error {
 		return errors.Wrap(err, "error running bootstrapper")
 	}
 	if len(stderr) > 0 {
-		log.Info(stderr, "err", "bootstrapper initialization failed")
+		log.Info("bootstrapper initialization failed", "stderr", stderr)
 	}
 	log.V(5).Info("stdout from wmcb", "stdout", stdout)
 	return nil
@@ -84,7 +84,7 @@ func (vm *Windows) initializeBootstrapperFiles() error {
 
 	log.V(5).Info("stderr associated with the ignition file download", "stderr", stderr)
 	if len(stderr) > 0 {
-		log.Info(stderr, "err", "error while downloading the ignition file from cluster")
+		log.Info("error while downloading the ignition file from cluster", "stderr", stderr)
 	}
 	log.V(5).Info("stdout associated with the ignition file download", "stdout", stdout)
 	return nil

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -273,7 +273,7 @@ func (r *ReconcileWindowsMachineConfig) createWindowsWorkerNodes(count int) bool
 		if err := nc.Configure(); err != nil {
 			// TODO: Unwrap to extract correct error
 			errs = append(errs, errors.Wrap(err, "configuring Windows VM failed"))
-			log.Error(err, "configuring Windows VM failed", err)
+			log.Error(err, "configuring Windows VM failed")
 		}
 
 		// update the windowsVMs slice

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -111,7 +111,7 @@ type ReconcileWindowsMachineConfig struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileWindowsMachineConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling WindowsMachineConfig")
+	reqLogger.Info("reconciling WindowsMachineConfig")
 
 	// Fetch the WindowsMachineConfig instance
 	instance := &wmcapi.WindowsMachineConfig{}
@@ -237,9 +237,9 @@ func (r *ReconcileWindowsMachineConfig) deleteWindowsVMs(count int) bool {
 		}
 
 		// Delete the Windows VM from cloud provider
-		log.Info(fmt.Sprintf("deleting the Windows VM: %s", instancedID))
+		log.Info("deleting the Windows VM", "instance", instancedID)
 		if err := r.cloudProvider.DestroyWindowsVM(instancedID); err != nil {
-			log.Error(err, "error while deleting windows VM: %s", instancedID)
+			log.Error(err, "error while deleting windows VM", "instance", instancedID)
 			errs = append(errs, errors.Wrap(err, "One of the VM deletions failed, will reconcile"))
 		}
 		delete(r.windowsVMs, vmTobeDeleted)
@@ -265,8 +265,8 @@ func (r *ReconcileWindowsMachineConfig) createWindowsWorkerNodes(count int) bool
 			errs = append(errs, errors.Wrap(err, "error creating windows VM"))
 			log.Error(err, "error creating windows VM")
 		}
-		log.V(5).Info(fmt.Sprintf("created the Windows VM: %s",
-			createdVM.GetCredentials().GetInstanceId()))
+		log.V(1).Info("created the Windows VM", "instance",
+			createdVM.GetCredentials().GetInstanceId())
 
 		// Make the Windows VM a Windows worker node.
 		nc := nodeconfig.NewNodeConfig(r.k8sclientset, createdVM)


### PR DESCRIPTION
This PR introduces a fix for the log panic caused due to a log entry with odd number of arguments for the logger. 
BZ: [https://bugzilla.redhat.com/show_bug.cgi?id=1817186](https://bugzilla.redhat.com/show_bug.cgi?id=1817186)

It also introduces changes for formatting the log info and error messages in a structured log format that follows the msg, key, value pair format as recommended by logr. 

This follows guidelines mentioned in :[https://godoc.org/github.com/go-logr/logr](https://godoc.org/github.com/go-logr/logr) and [https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md](https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md)