### PR TITLE
Added worker label and windows taint for windows node

### DIFF
--- a/pkg/controller/windowsmachineconfig/windows/windows.go
+++ b/pkg/controller/windowsmachineconfig/windows/windows.go
@@ -51,6 +51,20 @@ func (vm *Windows) Configure() error {
 	return vm.runBootstrapper()
 }
 
+// validate the WindowsVM node object
+func (vm *Windows) Validate() error {
+	if vm.GetCredentials() == nil {
+		return fmt.Errorf("nil credentials for VM")
+	}
+	if vm.GetCredentials().GetIPAddress() == "" {
+		return fmt.Errorf("empty IP for VM: %v", vm.GetCredentials())
+	}
+	if vm.GetCredentials().GetInstanceId() == "" {
+		return fmt.Errorf("empty instance id for VM: %v", vm.GetCredentials())
+	}
+	return nil
+}
+
 // runBootstrapper copies the bootstrapper and runs the code on the remote Windows VM
 func (vm *Windows) runBootstrapper() error {
 	if err := vm.CopyFile(wkl.WmcbPath, remoteDir); err != nil {

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -26,11 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const (
-	// windowsOSLabel is the label that is applied by WMCB to identify the Windows nodes bootstrapped via WMCB
-	WindowsOSLabel = "node.openshift.io/os_id=Windows"
-)
-
 var log = logf.Log.WithName("controller_windowsmachineconfig")
 
 /**
@@ -161,7 +156,7 @@ func (r *ReconcileWindowsMachineConfig) Reconcile(request reconcile.Request) (re
 	// Get the current number of Windows VMs created by WMCO.
 	// TODO: Get all the running Windows nodes in the cluster
 	//		jira story: https://issues.redhat.com/browse/WINC-280
-	windowsNodes, err := r.k8sclientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: WindowsOSLabel})
+	windowsNodes, err := r.k8sclientset.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: nodeconfig.WindowsOSLabel})
 	if err != nil {
 		return reconcile.Result{}, nil
 	}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -35,6 +35,7 @@ func creationTestSuite(t *testing.T) {
 	t.Run("Secrets validation", func(t *testing.T) { testValidateSecrets(t) })
 	t.Run("Network validation", testNetwork)
 	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
+	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })
 }
 
 // testWindowsNodeCreation tests the Windows node creation in the cluster

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -34,6 +34,7 @@ func creationTestSuite(t *testing.T) {
 	t.Run("ConfigMap validation", func(t *testing.T) { testConfigMapValidation(t) })
 	t.Run("Secrets validation", func(t *testing.T) { testValidateSecrets(t) })
 	t.Run("Network validation", testNetwork)
+	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
 }
 
 // testWindowsNodeCreation tests the Windows node creation in the cluster

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
-	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/nodeconfig"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
@@ -77,7 +76,7 @@ func (tc *testContext) waitForWindowsNode() error {
 	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
 	// side, let's make it as 20 minutes per node. The value comes from nodeCreationTime variable
 	err := wait.Poll(nodeRetryInterval, time.Duration(gc.numberOfNodes)*nodeCreationTime, func() (done bool, err error) {
-		nodes, err = tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
+		nodes, err = tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: nodeconfig.WindowsOSLabel})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Printf("waiting for %d Windows nodes", gc.numberOfNodes)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -284,3 +284,25 @@ func testWorkerLabel(t *testing.T) {
 		assert.Contains(t, node.Labels, nc.WorkerLabel, "expected node label %s was not present on %s", nc.WorkerLabel, node.GetName())
 	}
 }
+
+// testNodeTaint tests if the Windows node has the Windows taint
+func testNodeTaint(t *testing.T) {
+	// windowsTaint is the taint that needs to be applied to the Windows node
+	windowsTaint := corev1.Taint{
+		Key:    "os",
+		Value:  "Windows",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	for _, node := range gc.nodes {
+		hasTaint := func() bool {
+			for _, taint := range node.Spec.Taints {
+				if taint.Key == windowsTaint.Key && taint.Value == windowsTaint.Value && taint.Effect == windowsTaint.Effect {
+					return true
+				}
+			}
+			return false
+		}()
+		assert.Equal(t, hasTaint, true, "expected Windows Taint to be present on the Node: %s", node.GetName())
+	}
+}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -275,3 +275,12 @@ func createWindowsMachineConfig(namespace string, isReplicasFieldRequired bool, 
 	}
 	return wmc
 }
+
+// testWorkerLabel tests if the worker label has been applied properly
+func testWorkerLabel(t *testing.T) {
+	testCtx := framework.NewTestCtx(t)
+	defer testCtx.Cleanup()
+	for _, node := range gc.nodes {
+		assert.Contains(t, node.Labels, nc.WorkerLabel, "expected node label %s was not present on %s", nc.WorkerLabel, node.GetName())
+	}
+}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
-	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
+	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
@@ -119,7 +119,7 @@ func (tc *testContext) validateConnectivity(windowsVM types.WindowsVM) error {
 
 // getInstanceIP gets the instance IP address associated with a node
 func (tc *testContext) getInstanceIP(instanceID string) (string, error) {
-	nodes, err := tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: wmc.WindowsOSLabel})
+	nodes, err := tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})
 	if err != nil {
 		return "", errors.Wrap(err, "error while querying for Windows nodes")
 	}


### PR DESCRIPTION
Refactor:
This PR refactors nodeConfig and adds node object to nodeConfig
struct. It also includes validation for windowsVM and node object.
Also, moved WindowsOSLabel to nodeconfig.go

WMCO:
This PR adds a worker label for windows node
and adds e2e test to check worker label on windows node

Also, adds e2e test to check presence of windows taint on windows node