### PR TITLE
[wmco]Add cluster configuration checks

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"testing"
 
+	fakeconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 )
 
 // TestCheckIfRequiredFilesExist tests if checkIfRequiredFilesExist function is throwing appropriate error when some
@@ -22,4 +25,36 @@ func TestCheckIfRequiredFilesExist(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not stat /payload/file-2: stat /payload/file-2: no such file or directory",
 		"Expected error message is absent")
 
+}
+
+// TestIsValidKubernetesVersion tests if validateK8sVersion function throws error if K8s version is not a supported k8s version
+func TestIsValidKubernetesVersion(t *testing.T) {
+	fakeConfigClient := fakeconfigclient.NewSimpleClientset()
+	var tests = []struct {
+		name         string
+		version      string
+		errorMessage string
+	}{
+		{"cluster version lower than supported version ", "v1.17.1", "Unsupported server version: v1.17.1. Supported version is v1.18.x"},
+		{"cluster version equals supported version", "v1.18.3", ""},
+		{"cluster version greater than supported version", "v1.19.0", "Unsupported server version: v1.19.0. Supported version is v1.18.x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// specify version to be tested
+			fakeConfigClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+				GitVersion: tt.version,
+			}
+			clusterconfig := clusterConfig{oclient: fakeConfigClient}
+			err := clusterconfig.validateK8sVersion()
+			if tt.errorMessage == "" {
+				require.Nil(t, err, "Successful check for valid network type")
+			} else {
+				require.Error(t, err, "Function getK8sVersion did not throw an error "+
+					"when it was expected to")
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			}
+		})
+	}
 }

--- a/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
@@ -54,6 +54,7 @@ spec:
           - config.openshift.io
           resources:
           - infrastructures
+          - networks
           verbs:
           - get
         - apiGroups:
@@ -65,6 +66,12 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - networks
+          verbs:
+          - get
         serviceAccountName: windows-machine-config-operator
       deployments:
       - name: windows-machine-config-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -89,6 +89,7 @@ rules:
    - "config.openshift.io"
    resources:
    - infrastructures
+   - networks
    verbs:
    - get
  - apiGroups:
@@ -100,3 +101,9 @@ rules:
    - get
    - list
    - update
+ - apiGroups:
+     - operator.openshift.io
+   resources:
+     - networks
+   verbs:
+     - get

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -13,6 +13,6 @@ if [[ "$goflags" == *"-mod=vendor"* ]]; then
   unset GOFLAGS
 fi
 
-go test -v ./cmd/...
-
+# Run tests from all packages excluding e2e package, as it consists of e2e tests.
+go test -v ./cmd/... ./pkg/... -count=1
 exit 0

--- a/pkg/clusternetwork/config.go
+++ b/pkg/clusternetwork/config.go
@@ -1,0 +1,79 @@
+package clusternetwork
+
+import (
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	operatorv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const ovnKubernetesNetwork = "OVNKubernetes"
+
+// ClusterNetworkConfig interface contains methods to validate network configuration of a cluster
+type ClusterNetworkConfig interface {
+	Validate() error
+}
+
+// networkType information for a required network type
+type networkType struct {
+	// name describes value of the Network Type
+	name string
+	// oclient is the OpenShift config client, we will use to interact with the OpenShift API
+	oclient configclient.Interface
+	// operatorClient is the OpenShift operator client, we will use to interact with OpenShift operator objects
+	operatorClient operatorv1.OperatorV1Interface
+}
+
+// ovnKubernetes contains information specific to network type OVNKubernetes
+type ovnKubernetes struct {
+	networkType
+}
+
+// NetworkConfigurationFactory is a factory method that returns information specific to network type
+func NetworkConfigurationFactory(oclient configclient.Interface, operatorClient operatorv1.OperatorV1Interface) (ClusterNetworkConfig, error) {
+	network, err := getNetworkType(oclient)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting cluster network type")
+	}
+	switch network {
+	case ovnKubernetesNetwork:
+		return &ovnKubernetes{
+			networkType{
+				name:           network,
+				oclient:        oclient,
+				operatorClient: operatorClient,
+			},
+		}, nil
+	default:
+		return nil, errors.Errorf("%s : network type not supported", network)
+	}
+}
+
+// Validate for OVN Kubernetes checks for network type and hybrid overlay.
+func (ovn *ovnKubernetes) Validate() error {
+	//check if hybrid overlay is enabled for the cluster
+	networkCR, err := ovn.operatorClient.Networks().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error getting cluster network.operator object")
+	}
+
+	defaultNetwork := networkCR.Spec.DefaultNetwork
+	if defaultNetwork.OVNKubernetesConfig == nil || defaultNetwork.OVNKubernetesConfig.HybridOverlayConfig == nil {
+		return errors.New("cluster is not configured for OVN hybrid networking")
+	}
+
+	if len(networkCR.Spec.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig.HybridClusterNetwork) == 0 {
+		return errors.New("invalid OVN hybrid networking configuration")
+	}
+	return nil
+}
+
+// getNetworkType returns network type of the cluster
+func getNetworkType(oclient configclient.Interface) (string, error) {
+	// Get the cluster network object so that we can find the network type
+	networkCR, err := oclient.ConfigV1().Networks().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrap(err, "error getting cluster network object")
+	}
+	return networkCR.Spec.NetworkType, nil
+}

--- a/pkg/clusternetwork/config_test.go
+++ b/pkg/clusternetwork/config_test.go
@@ -1,0 +1,105 @@
+package clusternetwork
+
+import (
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	fakeconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
+	fakeoperatorclient "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	operatorclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// TestNetworkConfigurationFactory tests if NetworkConfigurationFactory function throws appropriate errors
+func TestNetworkConfigurationFactory(t *testing.T) {
+	var tests = []struct {
+		name         string
+		networkType  string
+		errorMessage string
+	}{
+		{"invalid network type", "OpenShiftSDN", "OpenShiftSDN : network type not supported"},
+		{"valid network type", "OVNKubernetes", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeConfigClient, fakeOperatorClient := createFakeClients(tt.networkType)
+
+			_, err := NetworkConfigurationFactory(fakeConfigClient, fakeOperatorClient)
+			if tt.errorMessage == "" {
+				require.Nil(t, err, "Successful check for valid network type")
+			} else {
+				require.Error(t, err, "Function networkConfigurationFactory did not throw an error "+
+					"when it was expected to")
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			}
+		})
+	}
+}
+
+// TestNetworkConfigurationValidate tests if validate() method throws error when network is of required type, but network configuration
+//cannot be validated
+func TestNetworkConfigurationValidate(t *testing.T) {
+	var tests = []struct {
+		name         string
+		networkType  string
+		networkPatch []byte
+		errorMessage string
+	}{
+		{"ovnKubernetesConfig not defined", "OVNKubernetes", nil, "cluster is not configured for OVN hybrid networking"},
+		{"hybridOverlayConfig not defined", "OVNKubernetes", []byte(`{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{} }}}`), "cluster is not configured for OVN hybrid networking"},
+		{"invalid OVN hybrid networking configuration", "OVNKubernetes", []byte(`{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":` +
+			`{"hybridClusterNetwork":[]}}}}}`), "invalid OVN hybrid networking configuration"},
+		{"valid OVN hybrid networking configuration", "OVNKubernetes", []byte(`{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":` +
+			`{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}`), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeConfigClient, fakeOperatorClient := createFakeClients(tt.networkType)
+			if tt.networkPatch != nil {
+				_, err := fakeOperatorClient.Networks().Patch("cluster", k8stypes.MergePatchType, tt.networkPatch)
+				require.Nil(t, err, "network patch should not throw error")
+			}
+
+			network, err := NetworkConfigurationFactory(fakeConfigClient, fakeOperatorClient)
+			require.Nil(t, err, "networkConfigurationFactory should not throw error")
+			err = network.Validate()
+
+			if tt.errorMessage == "" {
+				require.Nil(t, err, "Successful check for valid network type")
+			} else {
+				require.Error(t, err, "Function networkConfigurationFactory did not throw an error "+
+					"when it was expected to")
+				assert.Equal(t, err.Error(), tt.errorMessage)
+			}
+		})
+	}
+}
+
+// CreateFakeClients is a helper function to create fake OpenShift API config and operator clients
+func createFakeClients(networkType string) (configclient.Interface, operatorclient.OperatorV1Interface) {
+	fakeOperatorClient := fakeoperatorclient.NewSimpleClientset().OperatorV1()
+	fakeConfigClient := fakeconfigclient.NewSimpleClientset()
+
+	testNetworkConfig := &v1.Network{}
+	testNetworkConfig.Name = "cluster"
+	testNetworkConfig.Spec.NetworkType = networkType
+
+	testNetworkOperator := &operatorv1.Network{}
+	testNetworkOperator.Name = "cluster"
+
+	_, err := fakeConfigClient.ConfigV1().Networks().Create(testNetworkConfig)
+	if err != nil {
+		return nil, nil
+	}
+	_, err = fakeOperatorClient.Networks().Create(testNetworkOperator)
+	if err != nil {
+		return nil, nil
+	}
+	return fakeConfigClient, fakeOperatorClient
+}


### PR DESCRIPTION
This PR ensures that the cluster has required configurations before starting
the controller. The cluster configuration checks include : 

- checking the K8s version
- checking that cluster uses OVN kubernetes
- checking hybrid overlay is enabled.

[WINC-326](https://issues.redhat.com/browse/WINC-326)