### PR TITLE
Bug 1823579: [ci] React to hybrid overlay changes upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ for our CI purposes.
 │   ├── host-local.exe
 │   ├── win-bridge.exe
 │   └── win-overlay.exe
-├── hybrid-overlay.exe
+├── hybrid-overlay-node.exe
 ├── kube-node
 │   ├── kubelet.exe
 │   └── kube-proxy.exe

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -45,7 +45,7 @@ RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
 #│   ├── host-local.exe
 #│   ├── win-bridge.exe
 #│   └── win-overlay.exe
-#├── hybrid-overlay.exe
+#├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
 #│   └── kube-proxy.exe
@@ -60,8 +60,8 @@ LABEL stage=operator
 WORKDIR /payload/
 COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 
-# Copy hybrid-overlay.exe
-COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
+# Copy hybrid-overlay-node.exe
+COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
 
 # Copy kubelet.exe and kube-proxy.exe
 WORKDIR /payload/kube-node/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -59,7 +59,7 @@ RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
 #│   ├── host-local.exe
 #│   ├── win-bridge.exe
 #│   └── win-overlay.exe
-#├── hybrid-overlay.exe
+#├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
 #│   └── kube-proxy.exe
@@ -75,8 +75,8 @@ RUN mkdir /payload/
 WORKDIR /payload/
 COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 
-# Copy hybrid-overlay.exe
-COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay.exe .
+# Copy hybrid-overlay-node.exe
+COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
 
 # Copy kubelet.exe and kube-proxy.exe
 RUN mkdir /payload/kube-node/

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -208,8 +208,8 @@ func serveCRMetrics(cfg *rest.Config) error {
 }
 
 // checkIfRequiredFilesExist checks for the existence of required files and binaries before starting WMCO
-// sample error message: errors encountered with required files: could not stat /payload/hybrid-overlay.exe:
-// stat /payload/hybrid-overlay.exe: no such file or directory, could not stat /payload/wmcb.exe: stat /payload/wmcb.exe:
+// sample error message: errors encountered with required files: could not stat /payload/hybrid-overlay-node.exe:
+// stat /payload/hybrid-overlay-node.exe: no such file or directory, could not stat /payload/wmcb.exe: stat /payload/wmcb.exe:
 // no such file or directory
 func checkIfRequiredFilesExist(requiredFiles []string) error {
 	var errorMessages []string

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -34,7 +34,7 @@ const (
 	// this binary mounted
 	WinOverlayCNIPlugin = payloadDirectory + "/cni-plugins/win-overlay.exe"
 	// hybridOverlayName is the name of the hybrid overlay executable
-	HybridOverlayName = "hybrid-overlay.exe"
+	HybridOverlayName = "hybrid-overlay-node.exe"
 	// HybridOverlayPath contains the path of the hybrid overlay binary. The container image should already have this
 	// binary mounted
 	HybridOverlayPath = payloadDirectory + HybridOverlayName

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -25,10 +25,10 @@ func testHNSNetworksCreated(t *testing.T) {
 		// network setup has succeeded.
 		stdout, _, err := vm.Run("Get-HnsNetwork", true)
 		require.NoError(t, err, "Could not run Get-HnsNetwork command")
-		assert.Contains(t, stdout, "BaseOpenShiftNetwork",
-			"Could not find BaseOpenShiftNetwork in %s", vm.GetCredentials().GetInstanceId())
-		assert.Contains(t, stdout, "OpenShiftNetwork",
-			"Could not find OpenShiftNetwork in %s", vm.GetCredentials().GetInstanceId())
+		assert.Contains(t, stdout, windows.BaseOVNKubeOverlayNetwork,
+			"Could not find %s in %s", windows.BaseOVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
+		assert.Contains(t, stdout, windows.OVNKubeOverlayNetwork,
+			"Could not find %s in %s", windows.OVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
 	}
 }
 


### PR DESCRIPTION
Because of this [commit](openshift/ovn-kubernetes@2563e6b#diff-86eeef0b956d450bd2a787067b7443fdR26) in ovn-kubernetes repo, the hybrid-overlay binary is no longer called hybrid-overlay.exe but it is called hybrid-overlay-node.exe. We've a hardcoding to hybrid-overlay.exe in the following locations:

 -   Dockerfile
 -   Dockefile.ci
 -   wellknownlocations.go

And there are other places where it is mentioned in code comments.The name of this binary needs to be changed for the operator to start working. Otherwise the CI will keep failing.

In addition, [commit](openshift/ovn-kubernetes@fc16768#diff-7374600df6a5d7b56af840179f7ad27fR86) brought in changes related to renaming OVN overlay networks. This commit address that as well.