### PR TITLE
[ci] Fix failure of e2e hack script

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,11 @@
 FROM golang:1.13.8 as build
 LABEL stage=build
 
+# Create cache directory as user running the tests doesn't have the permissions to create it at runtime. This is required
+# for the go builds below to succeed
+RUN mkdir /go/.cache
+ENV GOCACHE="/go/.cache"
+
 # Build WMCB
 RUN mkdir /build/
 WORKDIR /build/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,6 +7,11 @@
 FROM golang:1.13.8 as build
 LABEL stage=build
 
+# Create cache directory as user running the tests doesn't have the permissions to create it at runtime. This is required
+# for the go builds below to succeed
+RUN mkdir /go/.cache
+ENV GOCACHE="/go/.cache"
+
 # Build WMCB
 RUN mkdir /build/
 WORKDIR /build/


### PR DESCRIPTION
**Problem:** hack/run-ci-e2e-test.sh fails in the following manner as observed when working on https://github.com/openshift/release/pull/8323:
```
failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
Error: failed to build test binary: ...
```

**Solution:** Preemptively create the go cache directory in the image being built by CI.