### PR TITLE
[ci] Add write permission to the image's go folder

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,11 +2,6 @@
 FROM golang:1.13.8 as build
 LABEL stage=build
 
-# Create cache directory as user running the tests doesn't have the permissions to create it at runtime. This is required
-# for the go builds below to succeed
-RUN mkdir /go/.cache
-ENV GOCACHE="/go/.cache"
-
 # Build WMCB
 RUN mkdir /build/
 WORKDIR /build/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,11 +7,6 @@
 FROM golang:1.13.8 as build
 LABEL stage=build
 
-# Create cache directory as user running the tests doesn't have the permissions to create it at runtime. This is required
-# for the go builds below to succeed
-RUN mkdir /go/.cache
-ENV GOCACHE="/go/.cache"
-
 # Build WMCB
 RUN mkdir /build/
 WORKDIR /build/
@@ -136,8 +131,8 @@ RUN mkdir -p /go/src/github.com/openshift/windows-machine-config-operator/
 WORKDIR /go/src/github.com/openshift/windows-machine-config-operator/
 COPY --from=build /build/windows-machine-config-operator .
 
-# Allow building binaries
-RUN chmod -R g=u /go
+# Allow building binaries and creation of /go/.cache directory by the hack script
+RUN chmod -R g=u+w /go
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/go"


### PR DESCRIPTION
78409f0 incorrectly fixed the permission issue [being seen](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/8323/rehearse-8323-pull-ci-openshift-windows-machine-config-operator-master-e2e-operator/7) during the run of hack script in CI when moving to the step-registry. The fix was in the build stage in the Dockerfile instead of the main stage. Now rather than creating the directory we give the user write permission to the "/go" folder in the container image.