### PR TITLE
[ci] Fix waits in VM creation failure scenarios

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"log"
+	"math"
 	"testing"
 	"time"
 
@@ -75,8 +76,9 @@ func (tc *testContext) waitForWindowsNode() error {
 	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac}
 
 	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
-	// side, let's make it as 20 minutes per node. The value comes from nodeCreationTime variable
-	err := wait.Poll(nodeRetryInterval, time.Duration(gc.numberOfNodes)*nodeCreationTime, func() (done bool, err error) {
+	// side, let's make it as 20 minutes per node. The value comes from nodeCreationTime variable.  If we are testing a
+	// scale down from n nodes to 0, then we should not take the number of nodes into account.
+	err := wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(gc.numberOfNodes), 1))*nodeCreationTime, func() (done bool, err error) {
 		nodes, err = tc.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: nodeconfig.WindowsOSLabel})
 		if err != nil {
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -27,8 +28,9 @@ import (
 func (tc *testContext) waitForTrackerConfigMap() error {
 	var trackerConfigMap *corev1.ConfigMap
 	// timeout is a factor of the number of nodes we are dealing with as all nodes have to finish their full
-	// configuration before the ConfigMap is updated.
-	err := wait.Poll(tc.retryInterval, time.Duration(gc.numberOfNodes)*tc.timeout, func() (done bool, err error) {
+	// configuration before the ConfigMap is updated. If we are testing a scale down from n nodes to 0, then we should
+	// not take the number of nodes into account.
+	err := wait.Poll(tc.retryInterval, time.Duration(math.Max(float64(gc.numberOfNodes), 1))*tc.timeout, func() (done bool, err error) {
 		trackerConfigMap, err = tc.kubeclient.CoreV1().ConfigMaps(tc.namespace).Get(tracker.StoreName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
**Problem**
In cases where the VM creation failed and then the scale down tests are executed, there is potential for waitForTrackerConfigMap() and waitForWindowsNode() to wait until the go test time out is reached instead of the expected 10 minutes.

**Solution**
The reason for the issues is the way we created the duration based on the number of nodes. Correct this to account for the scale down to 0 nodes scenarios.