### PR TITLE
[ci] Explicitly set GOCACHE environment variable

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -136,6 +136,7 @@ RUN chmod -R g=u+w /go
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOPATH="/go"
+ENV GOCACHE="/go/.cache"
 
 # install operator binary
 COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-machine-config-operator ${OPERATOR}


### PR DESCRIPTION
Without explicitly setting the GOCACHE environment variable, it is defaulting to `/.cache` in the CI runs which is causing the following error:
```
"failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied
```
as seen in https://github.com/openshift/release/pull/8323 [pj-rehearse job](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/8323/rehearse-8323-pull-ci-openshift-windows-machine-config-operator-master-e2e-operator/9)