### PR TITLE
[ci] Fix tracker validation test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,9 @@ replace (
 )
 
 require (
-	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200311205055-ff0cd166abd4
+	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
+	github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b
+	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c
 	github.com/operator-framework/operator-sdk v0.15.2
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,8 @@ github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a h1:Otk3CuCAEHi
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200311205055-ff0cd166abd4 h1:2IU45PnTc9vvZ8zKjUgQQonmI5d6l0zC6iYNM1J77Bs=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200311205055-ff0cd166abd4/go.mod h1:QZWD9cvvClAtVEe8UqFM7q0cgg6GtHpo8AqhQaj6Lz0=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c h1:ndiItBGbJHGR1xZWG/ZK30dwY8tuqL17acqKN5fF/Zk=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c/go.mod h1:9fgVIgtre3REZp/GgiIEbWjTBaNxPP5v4wfKU1ozw0c=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.0.0-20200120235816-80fd2f1a09c9/go.mod h1:S5IdlJvmKkF84K2tBvsrqJbI2FVy03P88R75snpRxJo=


### PR DESCRIPTION
**Problem** 
Any vm.Run() call after the hybrid overlay configuration has completed was taking more than 5 minutes to complete. This is causing the tracker validation test to be flaky as its timeout was 10 munutes.

**Solution** 
To mitigate this openshift/windows-machine-config-bootstrapper#182 introduces reinitializing the WinRM client as part of the Reinitialize() call. Reorder the waitForHNSNetworks() call after the Reinitialize() call to take advantage of this. We are adding a 2 minute sleep after the hybrid overlay starts running to allow it complete its work.

This fix has the very useful side effect of making the node preparation time lower.