### PR TITLE
[ci] Remove patching of network.operator CR

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -3,10 +3,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Set up hybrid networking on the cluster, a requirement for Windows support in OpenShift
-# TODO: This needs to be removed as part of https://issues.redhat.com/browse/WINC-351
-oc patch network.operator cluster --type=merge -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"hybridOverlayConfig":{"hybridClusterNetwork":[{"cidr":"10.132.0.0/14","hostPrefix":23}]}}}}}'
-
 NODE_COUNT=""
 SKIP_NODE_DELETION=""
 KEY_PAIR_NAME=""


### PR DESCRIPTION
Now that we are using the [step registry workflow](openshift/release#8323) for bringing up a hybrid OVN cluster in CI, we can stop patching the network.operator CR to enable hybrid networking.