### PR TITLE
[wmco] Generate cluster address from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To run the e2e tests for WMCO locally against an OpenShift cluster set up on AWS
 ```shell script
 export KUBECONFIG=<path to kubeconfig>
 export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
-export CLUSTER_ADDR=<cluster_name, eg: ravig211.devcluster.openshift.com>
 export KUBE_SSH_KEY_PATH=<path to ssh key>
 ```
 - Ensure that /payload directory exists and is accessible by the user account. The directory needs to be populated with the following files. Please see the [Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/build/Dockerfile) for figuring where to download and build these binaries. It is up to the user to keep these files up to date.
@@ -159,12 +158,6 @@ service account the kubeconfig should be generated from the service account.
 ```shell script
 # Change paths as necessary
 oc create secret generic kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
-```
-
-Put the cluster address in a secret:
-```shell script
-CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
-oc create secret generic cluster-address --from-literal=cluster-address=$CLUSTER_ADDR
 ```
 
 Change `spec.startingCSV` in `deploy/olm-catalog/subscription.yaml` to match the version of the operator you wish to deploy.

--- a/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
@@ -102,11 +102,6 @@ spec:
                   value: windows-machine-config-operator
                 - name: KUBECONFIG
                   value: /etc/kubeconfig/kubeconfig
-                - name: CLUSTER_ADDR
-                  valueFrom:
-                    secretKeyRef:
-                      key: cluster-address
-                      name: cluster-address
                 image: REPLACE_IMAGE
                 imagePullPolicy: Always
                 name: windows-machine-config-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -47,12 +47,6 @@ spec:
             # TODO: Remove the KUBECONFIG environment variable as part of https://issues.redhat.com/browse/WINC-328
             - name: KUBECONFIG
               value: /etc/kubeconfig/kubeconfig
-            # TODO: Remove the CLUSTER_ADDR environment variable as part of https://issues.redhat.com/browse/WINC-274
-            - name: CLUSTER_ADDR
-              valueFrom:
-                secretKeyRef:
-                  name: cluster-address
-                  key: cluster-address
           volumeMounts:
           # TODO: Remove the cloud-credentials and cloud-private-key volumeMounts as part of
           # https://issues.redhat.com/browse/WINC-325

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -12,7 +12,6 @@ KEY_PAIR_NAME=""
 
 
 export CGO_ENABLED=0
-export CLUSTER_ADDR=$(oc cluster-info | head -n1 | sed 's/.*\/\/api.//g'| sed 's/:.*//g')
 
 while getopts ":n:k:s" opt; do
   case ${opt} in

--- a/pkg/controller/windowsmachineconfig/nodeconfig/init.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/init.go
@@ -1,0 +1,38 @@
+package nodeconfig
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// cache holds the information of the nodeConfig that is invariant for multiple reconciliation cycles. We'll use this
+// information when we don't want to get the information from the global context coming from reconciler
+// but to have something at nodeConfig package locally which will be passed onto other structs. There is no need to
+// invalidate this cache as of now, since the only entry in this workerIgnitionEndPoint which will be immutable. If
+// someone wants to change it, they've to restart the operator which will invalidate the cache automatically.
+// Note : It is ok to remove this struct in future, if we don't want to continue. As of now, I can think of only
+// 		  worker ignition endpoint being part of this struct.
+type cache struct {
+	// workerIgnitionEndpoint is the Machine Config Server(MCS) endpoint from which we can download the
+	// the OpenShift worker ignition file.
+	workerIgnitionEndPoint string
+}
+
+var log = logf.Log.WithName("nodeconfig")
+
+// cache has the information related to nodeConfig that should not be changed.
+var nodeConfigCache = cache{}
+
+// init populates the cache that we need for nodeConfig
+func init() {
+	var kubeAPIServerEndpoint string
+	kubeAPIServerEndpoint, err := discoverKubeAPIServerEndpoint()
+	if err != nil {
+		log.Error(err, "unable to find kube api server endpoint")
+	}
+	clusterAddress, err := getClusterAddr(kubeAPIServerEndpoint)
+	if err != nil {
+		log.Error(err, "error getting cluster address")
+	}
+	// populate the cache
+	nodeConfigCache.workerIgnitionEndPoint = "https://api-int." + clusterAddress + ":22623/config/worker"
+}

--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig_test.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig_test.go
@@ -1,0 +1,51 @@
+package nodeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_getClusterAddr tests the getClusterAddr function
+func Test_getClusterAddr(t *testing.T) {
+	type args struct {
+		kubeAPIServerEndpoint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid test case",
+			args:    args{kubeAPIServerEndpoint: "https://api.abc.devcluster.openshift.com:6443"},
+			want:    "abc.devcluster.openshift.com",
+			wantErr: false,
+		},
+		{
+			name:    "Test case with invalid no-api",
+			args:    args{kubeAPIServerEndpoint: "https://no-api.abc.devcluster.openshift.com:6443"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Test case with invalid api at the last",
+			args:    args{kubeAPIServerEndpoint: "https://api.abc.devcluster.openshift.com.api:6443"},
+			want:    "abc.devcluster.openshift.com.api",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getClusterAddr(tt.args.kubeAPIServerEndpoint)
+			if (err != nil) != tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			if got != tt.want {
+				assert.Equal(t, tt.want, got, "getClusterAddr() got = %v, want %v")
+			}
+		})
+	}
+}


### PR DESCRIPTION
As of now, we're relying on an environment variable for
cluster address. If the operator runs in a container,
we are mounting the cluster address as the secret
to be used within operator. This commit removes
the dependency on the environment variable. We can
now generate the cluster address from apiserver
config.

https://issues.redhat.com/browse/WINC-274



