### PR TITLE
[ci] Ensure WMC CRD is up to date in lint job 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 .PHONY: lint
 lint:
 	hack/lint-gofmt.sh
+	hack/lint-generate-crds.sh
 
 .PHONY: unit
 unit:

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+get_operator_sdk() {
+  # Download the operator-sdk binary only if it is not already available
+  # We do not validate the version of operator-sdk if it is available already
+  if type operator-sdk >/dev/null 2>&1; then
+    which operator-sdk
+    return
+  fi
+
+  DOWNLOAD_DIR=/tmp/operator-sdk
+  # TODO: Make this download the same version we have in go dependencies in gomod
+  wget -O $DOWNLOAD_DIR https://github.com/operator-framework/operator-sdk/releases/download/v0.17.0/operator-sdk-v0.17.0-x86_64-linux-gnu >/dev/null  && chmod +x /tmp/operator-sdk || return
+  echo $DOWNLOAD_DIR
+}

--- a/hack/lint-generate-crds.sh
+++ b/hack/lint-generate-crds.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+
+WMCO_ROOT=$(pwd)
+source $WMCO_ROOT/hack/common.sh
+
+# The golang 1.13 image used in CI enforces vendoring. Workaround that by unsetting it.
+if [[ "${OPENSHIFT_CI}" == "true" ]]; then
+  unset GOFLAGS
+fi
+
+# Ensure all generated files are up to date
+OSDK=$(get_operator_sdk)
+
+WMC_CRD_PATH=$WMCO_ROOT/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+WMC_CRD=$(cat $WMC_CRD_PATH)
+CRD_GEN="$OSDK generate crds"
+
+# Run generator and read new state
+$CRD_GEN
+GENERATED_WMC_CRD=$(cat $WMC_CRD_PATH)
+
+if [ "$WMC_CRD" != "$GENERATED_WMC_CRD" ]; then
+  echo $WMC_CRD_PATH is not up to date. $CRD_GEN needs to be ran
+  # Return CRD back to original state
+  echo "$WMC_CRD" > $WMC_CRD_PATH
+  exit 1
+fi


### PR DESCRIPTION
This PR makes sure the generated CRDs are in line with the go code.