### PR TITLE
[wmco] Configure CNI on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ export KUBE_SSH_KEY_PATH=<path to ssh key>
 - Ensure that /payload directory exists and is accessible by the user account. The directory needs to be populated with the following files. Please see the [Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/build/Dockerfile) for figuring where to download and build these binaries. It is up to the user to keep these files up to date.
 ```
 /payload/
-├── cni-plugins
+├── cni
 │   ├── flannel.exe
 │   ├── host-local.exe
 │   ├── win-bridge.exe
-│   └── win-overlay.exe
+│   ├── win-overlay.exe
+│   └── cni-conf-template.json
 ├── hybrid-overlay-node.exe
 ├── kube-node
 │   ├── kubelet.exe

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,17 +34,18 @@ RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz
 RUN echo "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0 cni-plugins-windows-amd64-v0.8.2.tgz" > cni-plugins-windows-amd64-v0.8.2.tgz.sha512
 RUN sha512sum -c cni-plugins-windows-amd64-v0.8.2.tgz.sha512
-RUN mkdir /download/cni-plugins/
-WORKDIR /download/cni-plugins/
+RUN mkdir /download/cni/
+WORKDIR /download/cni/
 RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
 
 # Build the operator image with following payload structure
 # /payload/
-#├── cni-plugins
+#├── cni
 #│   ├── flannel.exe
 #│   ├── host-local.exe
 #│   ├── win-bridge.exe
-#│   └── win-overlay.exe
+#│   ├── win-overlay.exe
+#│   └── cni-conf-template.json
 #├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
@@ -68,12 +69,13 @@ WORKDIR /payload/kube-node/
 COPY --from=download /download/kubernetes/node/bin/kubelet.exe .
 COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
 
-# Copy CNI plugin binaries
-WORKDIR /payload/cni-plugins/
-COPY --from=download /download/cni-plugins/flannel.exe .
-COPY --from=download /download/cni-plugins/host-local.exe .
-COPY --from=download /download/cni-plugins/win-bridge.exe .
-COPY --from=download /download/cni-plugins/win-overlay.exe .
+# Copy CNI plugin binaries and CNI config template cni-conf-template.json
+WORKDIR /payload/cni/
+COPY --from=download /download/cni/flannel.exe .
+COPY --from=download /download/cni/host-local.exe .
+COPY --from=download /download/cni/win-bridge.exe .
+COPY --from=download /download/cni/win-overlay.exe .
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/cni-conf-template.json .
 
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -48,17 +48,18 @@ RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz
 RUN echo "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0 cni-plugins-windows-amd64-v0.8.2.tgz" > cni-plugins-windows-amd64-v0.8.2.tgz.sha512
 RUN sha512sum -c cni-plugins-windows-amd64-v0.8.2.tgz.sha512
-RUN mkdir /download/cni-plugins/
-WORKDIR /download/cni-plugins/
+RUN mkdir /download/cni/
+WORKDIR /download/cni/
 RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
 
 # Build the operator image with following payload structure
 # /payload/
-#├── cni-plugins
+#├── cni
 #│   ├── flannel.exe
 #│   ├── host-local.exe
 #│   ├── win-bridge.exe
-#│   └── win-overlay.exe
+#│   ├── win-overlay.exe
+#│   └── cni-conf-template.json
 #├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
@@ -84,13 +85,14 @@ WORKDIR /payload/kube-node/
 COPY --from=download /download/kubernetes/node/bin/kubelet.exe .
 COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
 
-# Copy CNI plugin binaries
-RUN mkdir /payload/cni-plugins/
-WORKDIR /payload/cni-plugins/
-COPY --from=download /download/cni-plugins/flannel.exe .
-COPY --from=download /download/cni-plugins/host-local.exe .
-COPY --from=download /download/cni-plugins/win-bridge.exe .
-COPY --from=download /download/cni-plugins/win-overlay.exe .
+# Copy CNI plugin binaries and CNI config template cni-conf-template.json
+RUN mkdir /payload/cni/
+WORKDIR /payload/cni/
+COPY --from=download /download/cni/flannel.exe .
+COPY --from=download /download/cni/host-local.exe .
+COPY --from=download /download/cni/win-bridge.exe .
+COPY --from=download /download/cni/win-overlay.exe .
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/cni-conf-template.json .
 
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -121,6 +121,7 @@ func main() {
 		wkl.WmcbPath,
 		wkl.CloudCredentialsPath,
 		wkl.PrivateKeyPath,
+		wkl.CNIConfigTemplatePath,
 	}
 	if err := checkIfRequiredFilesExist(requiredFiles); err != nil {
 		log.Error(err, "could not start the operator")
@@ -159,8 +160,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get the cluster serviceCIDR using clusterNetworkConfig interface
+	clusterServiceCIDR, err := clusterconfig.network.GetServiceCIDR()
+	if err != nil {
+		log.Error(err, "failed to get service CIDR from the cluster configuration")
+		os.Exit(1)
+	}
+
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, clusterServiceCIDR); err != nil {
 		log.Error(err, "failed to add all Controllers to the Manager")
 		os.Exit(1)
 	}

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -42,7 +42,7 @@ OSDK=$(get_operator_sdk)
 # the value is literally taken as "" instead of empty-string so default values we
 # specified in main_test.go has literally no effect. Not sure, if this is because of
 # the way operator-sdk testing is done using `go test []string{}
-NODE_COUNT=${NODE_COUNT:-1}
+NODE_COUNT=${NODE_COUNT:-2}
 SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"-skip-node-deletion=false"}
 KEY_PAIR_NAME=${KEY_PAIR_NAME:-"libra"}
 

--- a/pkg/clusternetwork/config_test.go
+++ b/pkg/clusternetwork/config_test.go
@@ -85,10 +85,12 @@ func TestNetworkConfigurationValidate(t *testing.T) {
 func createFakeClients(networkType string) (configclient.Interface, operatorclient.OperatorV1Interface) {
 	fakeOperatorClient := fakeoperatorclient.NewSimpleClientset().OperatorV1()
 	fakeConfigClient := fakeconfigclient.NewSimpleClientset()
+	serviceNetworks := []string{"172.30.0.0/16", "134.20.0.0/16"}
 
 	testNetworkConfig := &v1.Network{}
 	testNetworkConfig.Name = "cluster"
 	testNetworkConfig.Spec.NetworkType = networkType
+	testNetworkConfig.Spec.ServiceNetwork = serviceNetworks
 
 	testNetworkOperator := &operatorv1.Network{}
 	testNetworkOperator.Name = "cluster"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,12 +5,12 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, string) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, clusterServiceCIDR string) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, clusterServiceCIDR); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -21,18 +21,22 @@ const (
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
 	IgnoreWgetPowerShellPath = payloadDirectory + "/powershell/wget-ignore-cert.ps1"
+	// cniDirectory is the directory for storing the CNI plugins and the CNI config template
+	cniDirectory = "/cni/"
 	// FlannelCNIPluginPath is the path of the flannel CNI plugin binary. The container image should already have this
 	// binary mounted
-	FlannelCNIPluginPath = payloadDirectory + "/cni-plugins/flannel.exe"
+	FlannelCNIPluginPath = payloadDirectory + cniDirectory + "flannel.exe"
 	// HostLocalCNIPluginPath is the path of the host-local CNI plugin binary. The container image should already have
 	// this binary mounted
-	HostLocalCNIPlugin = payloadDirectory + "/cni-plugins/host-local.exe"
+	HostLocalCNIPlugin = payloadDirectory + cniDirectory + "host-local.exe"
 	// WinBridgeCNIPluginPath is the path of the win-bridge CNI plugin binary. The container image should already have
 	// this binary mounted
-	WinBridgeCNIPlugin = payloadDirectory + "/cni-plugins/win-bridge.exe"
+	WinBridgeCNIPlugin = payloadDirectory + cniDirectory + "win-bridge.exe"
 	// WinOverlayCNIPluginPath is the path of the win-overlay CNI Plugin binary. The container image should already have
 	// this binary mounted
-	WinOverlayCNIPlugin = payloadDirectory + "/cni-plugins/win-overlay.exe"
+	WinOverlayCNIPlugin = payloadDirectory + cniDirectory + "win-overlay.exe"
+	// CNIConfigTemplatePath is the path for CNI config template
+	CNIConfigTemplatePath = payloadDirectory + cniDirectory + "cni-conf-template.json"
 	// hybridOverlayName is the name of the hybrid overlay executable
 	HybridOverlayName = "hybrid-overlay-node.exe"
 	// HybridOverlayPath contains the path of the hybrid overlay binary. The container image should already have this

--- a/pkg/controller/windowsmachineconfig/nodeconfig/network.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/network.go
@@ -1,0 +1,131 @@
+package nodeconfig
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
+	"github.com/pkg/errors"
+)
+
+// cniConf contains the structure of the CNI template
+type cniConf struct {
+	CNIVersion   string       `json:"cniVersion"`
+	Name         string       `json:"name"`
+	Type         string       `json:"type"`
+	Capabilities capabilities `json:"capabilities"`
+	IPAM         ipam         `json:"ipam"`
+	Policies     policies     `json:"policies"`
+}
+
+// nested structs required for creating cniConf struct
+type capabilities struct {
+	DNS bool `json:"dns"`
+}
+
+type ipam struct {
+	Type   string `json:"type"`
+	Subnet string `json:"subnet"`
+}
+
+type policies []struct {
+	Name  string `json:"name"`
+	Value value  `json:"value"`
+}
+
+type value struct {
+	Type              string   `json:"Type"`
+	ExceptionList     []string `json:"ExceptionList,omitempty"`
+	DestinationPrefix string   `json:"DestinationPrefix,omitempty"`
+	NeedEncap         bool     `json:"NeedEncap"`
+}
+
+// network struct contains the node network information
+type network struct {
+	// hostSubnet holds the node host subnet value
+	hostSubnet string
+}
+
+// newNetwork returns a pointer to the network struct
+func newNetwork() *network {
+	return &network{}
+}
+
+// setHostSubnet sets the value for hostSubnet field in the network struct
+func (nw *network) setHostSubnet(hostSubnet string) error {
+	if hostSubnet == "" || clusternetwork.ValidateCIDR(hostSubnet) != nil {
+		return errors.Errorf("error receiving valid value for node hostSubnet")
+	}
+	nw.hostSubnet = hostSubnet
+	return nil
+}
+
+// cleanupTempConfig cleans up the temporary CNI directory and config file created
+func (nw *network) cleanupTempConfig(configFile string) error {
+	err := os.RemoveAll(configFile)
+	if err != nil {
+		log.Error(err, "couldn't delete temp CNI config file", "configFile", configFile)
+	}
+	return nil
+}
+
+// populateCniConfig populates the CNI config template with necessary information and
+// creates a new file in temp directory to store the modified template
+func (nw *network) populateCniConfig(serviceCIDR string, templatePath string) (string, error) {
+	if nw.hostSubnet == "" {
+		return "", errors.New("can't populate CNI config with empty hostSubnet")
+	}
+
+	cniConfTemplate, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		return "", errors.Wrapf(err, "error reading CNI config template from %s", templatePath)
+	}
+
+	cniCfg := cniConf{}
+	if err = json.Unmarshal(cniConfTemplate, &cniCfg); err != nil {
+		return "", errors.Wrap(err, "error converting CNI template into cniCfg struct")
+	}
+
+	if err = populateCfgPolicies(&cniCfg.Policies, serviceCIDR); err != nil {
+		return "", errors.Wrap(err, "error populating config policies in cniConf struct")
+	}
+
+	cniCfg.IPAM.Subnet = nw.hostSubnet
+
+	// retrieve the json file from the modified struct
+	cniCfgBuf, err := json.Marshal(&cniCfg)
+	if err != nil {
+		return "", errors.Wrap(err, "can't retrieve cniConf JSON using modified struct")
+	}
+
+	// Create a temp file to hold the cniCfg
+	tmpCniDir, err := ioutil.TempDir("", "cni")
+	if err != nil {
+		return "", errors.Wrapf(err, "error creating Local temp CNI directory")
+	}
+	cniConfigPath, err := os.Create(filepath.Join(tmpCniDir, "cni.conf"))
+	if err != nil {
+		return "", errors.Wrapf(err, "error creating local cni.conf file")
+	}
+	defer cniConfigPath.Close()
+
+	if _, err = cniConfigPath.Write(cniCfgBuf); err != nil {
+		return "", errors.Wrapf(err, "can't write JSON CNI config file to %s", cniConfigPath.Name())
+	}
+	if cniConfigPath.Name() == "" {
+		return "", errors.Errorf("couldn't retrieve CNI config file %s", cniConfigPath.Name())
+	}
+	return cniConfigPath.Name(), nil
+}
+
+// populateCfgPolicies populates the policies in cniConf struct with serviceCIDR information
+func populateCfgPolicies(cniCfgPolicies *policies, serviceCIDR string) error {
+	if len(*cniCfgPolicies) < 2 || len((*cniCfgPolicies)[0].Value.ExceptionList) == 0 || (*cniCfgPolicies)[1].Value.DestinationPrefix == "" {
+		return errors.Errorf("invalid policy fields in cniConf struct")
+	}
+	(*cniCfgPolicies)[0].Value.ExceptionList[0] = serviceCIDR
+	(*cniCfgPolicies)[1].Value.DestinationPrefix = serviceCIDR
+	return nil
+}

--- a/pkg/controller/windowsmachineconfig/nodeconfig/network_test.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/network_test.go
@@ -1,0 +1,97 @@
+package nodeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var tests = []struct {
+	name         string
+	policies     *policies
+	serviceCIDR  string
+	errorMessage string
+}{
+	{name: "invalid policies in cniCfg struct",
+		policies:     mockInvalidPolicies(),
+		serviceCIDR:  "10.128.0.0/14",
+		errorMessage: "invalid policy fields in cniConf struct"},
+
+	{name: "valid policies in cniCfg struct",
+		policies:     mockValidPolicies(),
+		serviceCIDR:  "10.128.0.0/14",
+		errorMessage: ""},
+}
+
+// TestPopulateCfgPoliciesError tests if populateCfgPolicies function throws appropriate errors when
+// the policy struct passed has invalid fields to populate CNI config
+func TestPopulateCfgPoliciesError(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := populateCfgPolicies(tt.policies, tt.serviceCIDR)
+			if tt.errorMessage == "" {
+				require.Nil(t, err, "Successful check for invalid CNI config template")
+			} else {
+				require.Error(t, err, "Function populateCniConfig did not throw an error "+
+					"when it was expected to")
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			}
+		})
+	}
+}
+
+// TestPopulateCfgPoliciesValues tests if populateCfgPolicies function sets appropriate values in
+// the CNI config policy struct
+func TestPopulateCfgPoliciesValues(t *testing.T) {
+	policies := mockValidPolicies()
+	serviceCIDR := "10.128.0.0/14"
+	_ = populateCfgPolicies(policies, serviceCIDR)
+	if (*policies)[0].Value.ExceptionList[0] != serviceCIDR || (*policies)[1].Value.DestinationPrefix != serviceCIDR {
+		t.Errorf("error populating policies in CNI config")
+	}
+}
+
+// mockValidPolicies is a helper function to create a set of valid CNI config policies
+// for testing populateCfgPolicies()
+func mockValidPolicies() *policies {
+	name := "EndPointPolicy"
+	exceptionList := []string{"10.132.0.0/16"}
+
+	value0 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+	value1 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+
+	data0 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value0}
+
+	data1 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value1}
+
+	return &policies{data0, data1}
+}
+
+// mockValidPolicies is a helper function to create a set of invalid CNI config policies
+// for testing populateCfgPolicies()
+func mockInvalidPolicies() *policies {
+	name := "EndPointPolicy"
+	exceptionList := []string{""}
+
+	value0 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+	value1 := &value{ExceptionList: exceptionList, DestinationPrefix: ""}
+
+	policy0 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value0}
+
+	policy1 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value1}
+
+	return &policies{policy0, policy1}
+}

--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
+	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/retry"
+	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/windows"
 	"github.com/pkg/errors"
 	certificates "k8s.io/api/certificates/v1beta1"
@@ -41,6 +43,10 @@ type nodeConfig struct {
 	*windows.Windows
 	// Node holds the information related to node object
 	node *v1.Node
+	// network holds the network information specific to the node
+	network *network
+	// clusterServiceCIDR holds the service CIDR for cluster
+	clusterServiceCIDR string
 }
 
 // discoverKubeAPIServerEndpoint discovers the kubernetes api server endpoint from the
@@ -56,7 +62,8 @@ func discoverKubeAPIServerEndpoint() (string, error) {
 }
 
 // NewNodeConfig creates a new instance of nodeConfig to be used by the caller.
-func NewNodeConfig(clientset *kubernetes.Clientset, windowsVM types.WindowsVM) (*nodeConfig, error) {
+func NewNodeConfig(clientset *kubernetes.Clientset, windowsVM types.WindowsVM,
+	clusterServiceCIDR string) (*nodeConfig, error) {
 	var err error
 	if nodeConfigCache.workerIgnitionEndPoint == "" {
 		var kubeAPIServerEndpoint string
@@ -72,7 +79,13 @@ func NewNodeConfig(clientset *kubernetes.Clientset, windowsVM types.WindowsVM) (
 		workerIgnitionEndpoint := "https://api-int." + clusterAddress + ":22623/config/worker"
 		nodeConfigCache.workerIgnitionEndPoint = workerIgnitionEndpoint
 	}
-	return &nodeConfig{k8sclientset: clientset, Windows: windows.New(windowsVM, nodeConfigCache.workerIgnitionEndPoint)}, nil
+	if err = clusternetwork.ValidateCIDR(clusterServiceCIDR); err != nil {
+		return nil, errors.Wrap(err, "error receiving valid CIDR value for "+
+			"creating new node config")
+	}
+	return &nodeConfig{k8sclientset: clientset, Windows: windows.New(windowsVM,
+		nodeConfigCache.workerIgnitionEndPoint), network: newNetwork(),
+		clusterServiceCIDR: clusterServiceCIDR}, nil
 }
 
 // getClusterAddr gets the cluster address associated with given kubernetes APIServerEndpoint.
@@ -152,6 +165,11 @@ func (nc *nodeConfig) configureNetwork() error {
 	if err := nc.waitForNodeAnnotation(HybridOverlayMac); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error waiting for %s node annotation for %s", HybridOverlayMac,
 			nc.node.GetName()))
+	}
+
+	// Configure CNI in the Windows VM
+	if err := nc.configureCNI(); err != nil {
+		return errors.Wrapf(err, "error configuring CNI for %s", nc.node.GetName())
 	}
 	return nil
 }
@@ -320,6 +338,29 @@ func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
 
 	if !found {
 		return errors.Wrap(err, fmt.Sprintf("timeout waiting for %s node annotation", annotation))
+	}
+	return nil
+}
+
+// configureCNI populates the CNI config template and sends the config file location
+// for completing CNI configuration in the windows VM
+func (nc *nodeConfig) configureCNI() error {
+	// set the hostSubnet value in the network struct
+	if err := nc.network.setHostSubnet(nc.node.Annotations[HybridOverlaySubnet]); err != nil {
+		return errors.Wrapf(err, "error populating host subnet in node network")
+	}
+	// populate the CNI config file with the host subnet and the service network CIDR
+	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, wkl.CNIConfigTemplatePath)
+	if err != nil {
+		return errors.Wrapf(err, "error populating CNI config file %s", configFile)
+	}
+	// configure CNI in the Windows VM
+	if err = nc.Windows.ConfigureCNI(configFile); err != nil {
+		return errors.Wrapf(err, "error configuring CNI for %s", nc.node.GetName())
+	}
+	if err = nc.network.cleanupTempConfig(configFile); err != nil {
+		log.Error(err, " could not delete temp CNI config file", "configFile",
+			configFile)
 	}
 	return nil
 }

--- a/pkg/controller/windowsmachineconfig/tracker.go
+++ b/pkg/controller/windowsmachineconfig/tracker.go
@@ -91,8 +91,8 @@ func GetWindowsVM(instanceID, ipAddress string, credentials Credentials) (types.
 	return winVM, nil
 }
 
-// GetNodeIP gets the instance IP address associated with a node
-func GetNodeIP(nodeList *v1.NodeList, instanceID string) (string, error) {
+// getNodeIP gets the instance IP address associated with a node
+func getNodeIP(nodeList *v1.NodeList, instanceID string) (string, error) {
 	// Ignore the nodes that are not ready.
 	for _, node := range nodeList.Items {
 		for _, condition := range node.Status.Conditions {
@@ -175,7 +175,7 @@ func initWindowsVMs(k8sclientset *kubernetes.Clientset, operatorNS string) (map[
 		return nil, errors.Wrap(err, "error while querying for Windows nodes")
 	}
 	for instanceID := range store.BinaryData {
-		ipAddress, err := GetNodeIP(nodeList, instanceID)
+		ipAddress, err := getNodeIP(nodeList, instanceID)
 		if err != nil {
 			// As of now, we're doing best effort to reconstruct the ConfigMap, so ignore errors while getting them
 			// from ConfigMap. Having said that, the ConfigMap entries should be perfect. Please look at syncNodeRecords

--- a/pkg/internal/cni-conf-template.json
+++ b/pkg/internal/cni-conf-template.json
@@ -1,0 +1,34 @@
+{
+	"CniVersion":"0.2.0",
+	"Name":"OVNKubernetesHybridOverlayNetwork",
+	"Type":"win-overlay",
+	"Capabilities":{
+		"Dns":true
+	},
+	"Ipam":{
+		"Type":"host-local",
+		"Subnet":"ovn_host_subnet"
+	},
+	"Policies":[
+		{
+			"Name":"EndpointPolicy",
+			"Value":{
+				"Type":"OutBoundNAT",
+				"ExceptionList":[
+					"service_network_cidr"
+				],
+				"DestinationPrefix":"",
+				"NeedEncap":false
+			}
+		},
+		{
+			"Name":"EndpointPolicy",
+			"Value":{
+				"Type":"ROUTE",
+				"ExceptionList":[],
+				"DestinationPrefix":"service_network_cidr",
+				"NeedEncap":true
+			}
+		}
+	]
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -90,7 +90,7 @@ func (tc *testContext) cleanup() {
 }
 
 func TestMain(m *testing.M) {
-	flag.IntVar(&numberOfNodes, "node-count", 1, "number of nodes to be created for testing")
+	flag.IntVar(&numberOfNodes, "node-count", 2, "number of nodes to be created for testing")
 	flag.BoolVar(&skipNodeDeletion, "skip-node-deletion", false,
 		"Option to disable deletion of the VMs")
 	// We're using libra as default value to be used in CI

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -1,18 +1,41 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/windows"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // testNetwork runs all the cluster and node network tests
 func testNetwork(t *testing.T) {
 	t.Run("Hybrid overlay running", testHybridOverlayRunning)
 	t.Run("OpenShift HNS networks", testHNSNetworksCreated)
+	t.Run("East West Networking across Linux and Windows nodes",
+		func(t *testing.T) { testEastWestNetworking(t) })
+	t.Run("East West Networking across Windows nodes",
+		func(t *testing.T) { testEastWestNetworkingAcrossWindowsNodes(t) })
 }
+
+var (
+	// windowsServerImage is the name/location of the Windows Server 2019 image we will use to test pod deployment
+	windowsServerImage = "mcr.microsoft.com/windows/servercore:ltsc2019"
+	// ubi8Image is the name/location of the linux image we will use for testing
+	ubi8Image = "registry.access.redhat.com/ubi8/ubi:latest"
+	// retryCount is the amount of times we will retry an api operation
+	retryCount = 20
+	// retryInterval is the interval of time until we retry after a failure
+	retryInterval = 5 * time.Second
+)
 
 // testHNSNetworksCreated tests that the required HNS Networks have been created on the bootstrapped nodes
 func testHNSNetworksCreated(t *testing.T) {
@@ -24,11 +47,11 @@ func testHNSNetworksCreated(t *testing.T) {
 		// We don't need to retry as we are waiting long enough for the secrets to be created which implies that the
 		// network setup has succeeded.
 		stdout, _, err := vm.Run("Get-HnsNetwork", true)
-		require.NoError(t, err, "Could not run Get-HnsNetwork command")
+		require.NoError(t, err, "could not run Get-HnsNetwork command")
 		assert.Contains(t, stdout, windows.BaseOVNKubeOverlayNetwork,
-			"Could not find %s in %s", windows.BaseOVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
+			"could not find %s in %s", windows.BaseOVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
 		assert.Contains(t, stdout, windows.OVNKubeOverlayNetwork,
-			"Could not find %s in %s", windows.OVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
+			"could not find %s in %s", windows.OVNKubeOverlayNetwork, vm.GetCredentials().GetInstanceId())
 	}
 }
 
@@ -40,9 +63,373 @@ func testHybridOverlayRunning(t *testing.T) {
 
 	for _, vm := range gc.windowsVMs {
 		_, stderr, err := vm.Run("Get-Process -Name \""+windows.HybridOverlayProcess+"\"", true)
-		require.NoError(t, err, "Could not run Get-Process command")
+		require.NoError(t, err, "could not run Get-Process command")
 		// stderr being empty implies that hybrid-overlay was running.
 		assert.Equal(t, "", stderr, "hybrid-overlay was not running in %s",
 			vm.GetCredentials().GetInstanceId())
 	}
+}
+
+// testEastWestNetworking deploys Windows and Linux pods, and tests that the pods can communicate
+func testEastWestNetworking(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	for _, vm := range gc.windowsVMs {
+		instanceID := vm.GetCredentials().GetInstanceId()
+		node, err := testCtx.getNode(instanceID)
+		require.NoError(t, err, "could not get Windows node object associated with the vm")
+
+		affinity, err := getAffinityForNode(node)
+		require.NoError(t, err, "could not get affinity for first node")
+
+		// Deploy a webserver pod on the new node
+		winServerDeployment, err := testCtx.deployWindowsWebServer("win-webserver-"+vm.GetCredentials().GetInstanceId(), vm, affinity)
+		require.NoError(t, err, "could not create Windows Server deployment")
+
+		// Get the pod so we can use its IP
+		winServerIP, err := testCtx.getPodIP(*winServerDeployment.Spec.Selector)
+		require.NoError(t, err, "could not retrieve pod with selector %v", *winServerDeployment.Spec.Selector)
+
+		// test Windows <-> Linux
+		// This will install curl and then curl the windows server.
+		linuxCurlerCommand := []string{"bash", "-c", "yum update; yum install curl -y; curl " + winServerIP}
+		linuxCurlerJob, err := testCtx.createLinuxJob("linux-curler-"+vm.GetCredentials().GetInstanceId(), linuxCurlerCommand)
+		require.NoError(t, err, "could not create Linux job")
+		err = testCtx.waitUntilJobSucceeds(linuxCurlerJob.Name)
+		assert.NoError(t, err, "could not curl the Windows server from a linux container")
+
+		// test Windows <-> Windows on same node
+		winCurlerJob, err := testCtx.createWinCurlerJob(vm, winServerIP)
+		require.NoError(t, err, "could not create Windows job")
+		err = testCtx.waitUntilJobSucceeds(winCurlerJob.Name)
+		assert.NoError(t, err, "could not curl the Windows webserver pod from a separate Windows container")
+
+		// delete the deployments and jobs created
+		if err = testCtx.deleteDeployment(winServerDeployment.Name); err != nil {
+			t.Logf("could not delete deployment %s", winServerDeployment.Name)
+		}
+		if err = testCtx.deleteJob(linuxCurlerJob.Name); err != nil {
+			t.Logf("could not delete job %s", linuxCurlerJob.Name)
+		}
+		if err = testCtx.deleteJob(winCurlerJob.Name); err != nil {
+			t.Logf("could not delete job %s", winCurlerJob.Name)
+		}
+	}
+}
+
+//  testEastWestNetworkingAcrossWindowsNodes deploys Windows pods on two different Nodes, and tests that the pods can communicate
+func testEastWestNetworkingAcrossWindowsNodes(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+	defer testCtx.cleanup()
+
+	// Need at least two Windows VMs to run these tests, throwing error if this condition is not met
+	require.GreaterOrEqualf(t, len(gc.nodes), 2, "insufficient number of Windows VMs to run tests across"+
+		" VMs, Minimum VM count: 2, Current VM count: %d", len(gc.nodes))
+
+	firstVM := gc.windowsVMs[0]
+	secondVM := gc.windowsVMs[1]
+
+	instanceIDFirstVM := firstVM.GetCredentials().GetInstanceId()
+	firstNode, err := testCtx.getNode(instanceIDFirstVM)
+	require.NoError(t, err, "could not get Windows node object from first VM")
+
+	affinityForFirstNode, err := getAffinityForNode(firstNode)
+	require.NoError(t, err, "could not get affinity for first node")
+
+	// Deploy a webserver pod on the first node
+	winServerDeploymentOnFirstNode, err := testCtx.deployWindowsWebServer("win-webserver-"+firstVM.GetCredentials().GetInstanceId(),
+		firstVM, affinityForFirstNode)
+	require.NoError(t, err, "could not create Windows Server deployment on first Node")
+
+	// Get the pod so we can use its IP
+	winServerIP, err := testCtx.getPodIP(*winServerDeploymentOnFirstNode.Spec.Selector)
+	require.NoError(t, err, "could not retrieve pod with selector %v", *winServerDeploymentOnFirstNode.Spec.Selector)
+
+	// test Windows <-> Windows across nodes
+	winCurlerJobOnSecondNode, err := testCtx.createWinCurlerJob(secondVM, winServerIP)
+	require.NoError(t, err, "could not create Windows job on second Node")
+
+	err = testCtx.waitUntilJobSucceeds(winCurlerJobOnSecondNode.Name)
+	assert.NoError(t, err, "could not curl the Windows webserver pod on the first node from Windows container "+
+		"on the second node")
+
+	// delete the deployment and job created
+	if err = testCtx.deleteDeployment(winServerDeploymentOnFirstNode.Name); err != nil {
+		t.Logf("could not delete deployment %s", winServerDeploymentOnFirstNode.Name)
+	}
+
+	if err = testCtx.deleteJob(winCurlerJobOnSecondNode.Name); err != nil {
+		t.Logf("could not delete job %s", winCurlerJobOnSecondNode.Name)
+	}
+}
+
+// getAffinityForNode returns an affinity which matches the associated node's name
+func getAffinityForNode(node *v1.Node) (*v1.Affinity, error) {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "metadata.name",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{node.Name},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// deployWindowsWebServer creates a deployment with a single Windows Server pod, listening on port 80
+func (tc *testContext) deployWindowsWebServer(name string, vm testVM, affinity *v1.Affinity) (*appsv1.Deployment, error) {
+	// Preload the image that will be used on the Windows node, to prevent download timeouts
+	// and separate possible failure conditions into multiple operations
+	if err := pullContainerImage(windowsServerImage, vm); err != nil {
+		return nil, errors.Wrapf(err, "could not pull Windows Server image")
+	}
+	// This will run a Server on the container, which can be reached with a GET request
+	winServerCommand := []string{"powershell.exe", "-command",
+		"$listener = New-Object System.Net.HttpListener; $listener.Prefixes.Add('http://*:80/'); $listener.Start(); " +
+			"Write-Host('Listening at http://*:80/'); while ($listener.IsListening) { " +
+			"$context = $listener.GetContext(); $response = $context.Response; " +
+			"$content='<html><body><H1>Windows Container Web Server</H1></body></html>'; " +
+			"$buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; " +
+			"$response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };"}
+	winServerDeployment, err := tc.createWindowsServerDeployment(name, winServerCommand, affinity)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create Windows deployment")
+	}
+	// Wait until the server is ready to be queried
+	err = tc.waitUntilDeploymentScaled(winServerDeployment.Name)
+	if err != nil {
+		tc.deleteDeployment(winServerDeployment.Name)
+		return nil, errors.Wrapf(err, "deployment was unable to scale")
+	}
+	return winServerDeployment, nil
+}
+
+// deleteDeployment deletes the deployment with the given name
+func (tc *testContext) deleteDeployment(name string) error {
+	deploymentsClient := tc.kubeclient.AppsV1().Deployments(v1.NamespaceDefault)
+	return deploymentsClient.Delete(name, &metav1.DeleteOptions{})
+}
+
+// pullContainerImage pulls the designated image on the remote host
+func pullContainerImage(name string, vm testVM) error {
+	command := "docker pull " + name
+	_, _, err := vm.Run(command, false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remotely run docker pull")
+	}
+	return nil
+}
+
+// getPodIP returns the IP of the pod that matches the label selector. If more than one pod match the
+// selector, the function will return an error
+func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
+	selectorString := labels.Set(selector.MatchLabels).String()
+	podList, err := tc.kubeclient.CoreV1().Pods(v1.NamespaceDefault).List(metav1.ListOptions{
+		LabelSelector: selectorString})
+	if err != nil {
+		return "", err
+	}
+	if len(podList.Items) != 1 {
+		return "", errors.Errorf("expected one pod matching %s, but found %d", selectorString,
+			len(podList.Items))
+	}
+
+	return podList.Items[0].Status.PodIP, nil
+}
+
+// createWindowsServerDeployment creates a deployment with a Windows Server 2019 container
+func (tc *testContext) createWindowsServerDeployment(name string, command []string, affinity *v1.Affinity) (*appsv1.Deployment, error) {
+	deploymentsClient := tc.kubeclient.AppsV1().Deployments(v1.NamespaceDefault)
+	replicaCount := int32(1)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicaCount,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": name,
+					},
+				},
+				Spec: v1.PodSpec{
+					Affinity: affinity,
+					Tolerations: []v1.Toleration{
+						{
+							Key:    "os",
+							Value:  "Windows",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+					Containers: []v1.Container{
+						// Windows web server
+						{
+							Name:            name,
+							Image:           windowsServerImage,
+							ImagePullPolicy: v1.PullIfNotPresent,
+							Command:         command,
+							Ports: []v1.ContainerPort{
+								{
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: 80,
+								},
+							},
+						},
+					},
+					NodeSelector: map[string]string{"beta.kubernetes.io/os": "windows"},
+				},
+			},
+		},
+	}
+
+	// Create Deployment
+	deploy, err := deploymentsClient.Create(deployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create deployment")
+	}
+	return deploy, err
+}
+
+// waitUntilDeploymentScaled will return nil if the deployment reaches the amount of replicas specified in its spec
+func (tc *testContext) waitUntilDeploymentScaled(name string) error {
+	var deployment *appsv1.Deployment
+	var err error
+	for i := 0; i < retryCount; i++ {
+		deployment, err = tc.kubeclient.AppsV1().Deployments(v1.NamespaceDefault).Get(name,
+			metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "could not get deployment for %s", name)
+		}
+		if *deployment.Spec.Replicas == deployment.Status.AvailableReplicas {
+			return nil
+		}
+		time.Sleep(retryInterval)
+	}
+	events, _ := tc.getPodEvents(name)
+	return errors.Errorf("timed out waiting for deployment %v to scale: %v", deployment, events)
+}
+
+// getPodEvents gets all events for any pod with the input in its name. Used for debugging purposes
+func (tc *testContext) getPodEvents(name string) ([]v1.Event, error) {
+	eventList, err := tc.kubeclient.CoreV1().Events(v1.NamespaceDefault).List(metav1.ListOptions{
+		FieldSelector: "involvedObject.kind=Pod"})
+	if err != nil {
+		return []v1.Event{}, err
+	}
+	var podEvents []v1.Event
+	for _, event := range eventList.Items {
+		if strings.Contains(event.InvolvedObject.Name, name) {
+			podEvents = append(podEvents, event)
+		}
+	}
+	return podEvents, nil
+}
+
+// createLinuxJob creates a job which will run the provided command with a ubi8 image
+func (tc *testContext) createLinuxJob(name string, command []string) (*batchv1.Job, error) {
+	linuxNodeSelector := map[string]string{"beta.kubernetes.io/os": "linux"}
+	return tc.createJob(name, ubi8Image, command, linuxNodeSelector, []v1.Toleration{})
+}
+
+//  createWinCurlerJob creates a Job to curl Windows server at given IP address
+func (tc *testContext) createWinCurlerJob(vm testVM, winServerIP string) (*batchv1.Job, error) {
+	winCurlerCommand := getWinCurlerCommand(winServerIP)
+	winCurlerJob, err := tc.createWindowsServerJob("win-curler-"+vm.GetCredentials().GetInstanceId(), winCurlerCommand)
+	return winCurlerJob, err
+}
+
+// getWinCurlerCommand generates a command to curl a Windows server from the given IP address
+func getWinCurlerCommand(winServerIP string) []string {
+	// This will continually try to read from the Windows Server. We have to try multiple times as the Windows container
+	// takes some time to finish initial network setup.
+	winCurlerCommand := []string{"powershell.exe", "-command", "for (($i =0), ($j = 0); $i -lt 10; $i++) { " +
+		"$response = Invoke-Webrequest -UseBasicParsing -Uri " + winServerIP +
+		"; $code = $response.StatusCode; echo \"GET returned code $code\";" +
+		"If ($code -eq 200) {exit 0}; Start-Sleep -s 10;}; exit 1"}
+	return winCurlerCommand
+}
+
+// createWindowsServerJob creates a job which will run the provided command with a Windows Server image
+func (tc *testContext) createWindowsServerJob(name string, command []string) (*batchv1.Job, error) {
+	windowsNodeSelector := map[string]string{"beta.kubernetes.io/os": "windows"}
+	windowsTolerations := []v1.Toleration{{Key: "os", Value: "Windows", Effect: v1.TaintEffectNoSchedule}}
+	return tc.createJob(name, windowsServerImage, command, windowsNodeSelector, windowsTolerations)
+}
+
+func (tc *testContext) createJob(name, image string, command []string, selector map[string]string,
+	tolerations []v1.Toleration) (*batchv1.Job, error) {
+	jobsClient := tc.kubeclient.BatchV1().Jobs(v1.NamespaceDefault)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-job",
+		},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Tolerations:   tolerations,
+					Containers: []v1.Container{
+						{
+							Name:            name,
+							Image:           image,
+							ImagePullPolicy: v1.PullIfNotPresent,
+							Command:         command,
+						},
+					},
+					NodeSelector: selector,
+				},
+			},
+		},
+	}
+
+	// Create job
+	job, err := jobsClient.Create(job)
+	if err != nil {
+		return nil, err
+	}
+	return job, err
+}
+
+// deleteJob deletes the job with the given name
+func (tc *testContext) deleteJob(name string) error {
+	jobsClient := tc.kubeclient.BatchV1().Jobs(v1.NamespaceDefault)
+	return jobsClient.Delete(name, &metav1.DeleteOptions{})
+}
+
+// waitUntilJobSucceeds will return an error if the job fails or reaches a timeout
+func (tc *testContext) waitUntilJobSucceeds(name string) error {
+	var job *batchv1.Job
+	var err error
+	for i := 0; i < retryCount; i++ {
+		job, err = tc.kubeclient.BatchV1().Jobs(v1.NamespaceDefault).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if job.Status.Succeeded > 0 {
+			return nil
+		}
+		if job.Status.Failed > 0 {
+			events, _ := tc.getPodEvents(name)
+			return errors.Errorf("job %v failed: %v", job, events)
+		}
+		time.Sleep(retryInterval)
+	}
+	events, _ := tc.getPodEvents(name)
+	return errors.Errorf("job %v timed out: %v", job, events)
 }


### PR DESCRIPTION
This commit run the wmcb's configure-cni command on the windows
nodes. It also transfers the files required for the configuration to the
windows VM. cni.conf file has been added in internal directory to be
transferred to the payload directory.  In addition, added the east-west networking tests to test
connection between linux, windows pods.