### PR TITLE
[wmco] Fix restart

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -50,7 +50,11 @@ cd $WMCO_ROOT
 oc create -f deploy/namespace.yaml
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
-$OSDK test local ./test/e2e --debug --up-local --operator-namespace=windows-machine-config-operator --local-operator-flags "--zap-level=debug --zap-encoder=console" --go-test-flags "-v -timeout=60m -node-count=$NODE_COUNT $SKIP_NODE_DELETION -ssh-key-pair=$KEY_PAIR_NAME"
-oc delete -f deploy/namespace.yaml 
+# Run the creation tests and skip deletion of the Windows VMs
+$OSDK test local ./test/e2e --debug --up-local --operator-namespace=windows-machine-config-operator --local-operator-flags "--zap-level=debug --zap-encoder=console" --go-test-flags "-run=TestWMCO/create -v -timeout=60m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
+# Run the deletion tests while testing operator restart functionality. This will clean up VMs created 
+# in the previous step
+$OSDK test local ./test/e2e --debug --up-local --operator-namespace=windows-machine-config-operator --local-operator-flags "--zap-level=debug --zap-encoder=console" --go-test-flags "-run=TestWMCO/destroy -v -timeout=60m -ssh-key-pair=$KEY_PAIR_NAME"
+oc delete -f deploy/namespace.yaml
 
 exit 0

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -10,7 +10,6 @@ import (
 	wmcapi "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
 	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/nodeconfig"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +53,7 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 	}
 
 	windowsVMs := make(map[types.WindowsVM]bool)
-	vmTracker, err := tracker.NewTracker(clientset, windowsVMs)
+	vmTracker, err := newTracker(clientset, windowsVMs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate tracker")
 	}
@@ -116,7 +115,7 @@ type ReconcileWindowsMachineConfig struct {
 	// k8sclientset holds the kube client that we can re-use for all kube objects other than custom resources.
 	k8sclientset *kubernetes.Clientset
 	// tracker is used to track all the Windows nodes created via WMCO
-	tracker *tracker.Tracker
+	tracker *tracker
 	// statusMgr is used to keep track of and update the WMC status
 	statusMgr *StatusManager
 }

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -30,6 +30,9 @@ func creationTestSuite(t *testing.T) {
 	// are the secrets but they are created only after the VMs have been fully configured.
 	// Any node object related tests should be run only after testNodeCreation as that initializes the node objects in
 	// the global context.
+	t.Run("WMC CR validation", testWMCValidation)
+	// the failure behavior test will be skipped if gc.nodes = 0
+	t.Run("failure behavior", testFailureSuite)
 	t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t) })
 	t.Run("Status", func(t *testing.T) { testStatusWhenSuccessful(t) })
 	t.Run("ConfigMap validation", func(t *testing.T) { testConfigMapValidation(t) })

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/retry"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig/tracker"
+	wmc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachineconfig"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -61,7 +61,7 @@ type testContext struct {
 	// osdkTestCtx is the operator sdk framework's test Context
 	osdkTestCtx *framework.TestCtx
 	// credentials to be used to access the Windows nodes
-	credentials []tracker.Credentials
+	credentials []wmc.Credentials
 	// kubeclient is the kube client
 	kubeclient kubernetes.Interface
 	// tracker is a pointer to the tracker ConfigMap created by operator

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -31,9 +31,6 @@ func TestWMCO(t *testing.T) {
 	gc.skipNodeDeletion = skipNodeDeletion
 	gc.sshKeyPair = sshKeyPair
 
-	t.Run("WMC CR validation", testWMCValidation)
-	// the failure behavior test will be skipped if gc.nodes = 0
-	t.Run("failure behavior", testFailureSuite)
 	t.Run("create", creationTestSuite)
 	if !gc.skipNodeDeletion {
 		t.Run("destroy", deletionTestSuite)


### PR DESCRIPTION
If the WMCO is restarted, the knowledge of the nodes
created via WMCO is lost. We can construct this information from
the tracker configmap. This PR addresses the following items:

- https://issues.redhat.com/browse/WINC-269
- https://issues.redhat.com/browse/WINC-280

We're addressing WINC-280 as part of this PR as the node can be in unready state
and we're still counting it towards the windowsVM that was created. Only the
nodes that are in ready state should be accounted for when the operator
restarts
