### PR TITLE
Bug 1819227: [wmco] Remove unnecessary watching of Pods

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/0.0.0/windows-machine-config-operator.v0.0.0.clusterserviceversion.yaml
@@ -171,14 +171,6 @@ spec:
           verbs:
           - update
         - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - apps
           resources:
           - replicasets

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -47,16 +47,6 @@ rules:
   - deployments/finalizers
   verbs:
   - update
-# TODO: pods permissions needed as we are currently watching pods
-# remove as part of https://issues.redhat.com/browse/WINC-340
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
 # These permissions needed for the metrics server
 - apiGroups:
   - apps

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -85,17 +85,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return errors.Wrap(err, "could not create watch on WindowsMachineConfig objects")
 	}
-
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner WindowsMachineConfig
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &wmcapi.WindowsMachineConfig{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR ensures that operator runs without having to watch pod resources

The operator is watching pod during reconcile. Updated the controller to
remove watch on pod resources. Updated the rbac rules to remove pod permissions.

[WINC-340](https://issues.redhat.com/browse/WINC-340)