### PR TITLE
Bug 1835166: [wmco] fix validation for replicas

### DIFF
--- a/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -59,6 +59,7 @@ spec:
             replicas:
               description: Replicas represent how many Windows nodes to be added to
                 the OpenShift cluster
+              format: int32
               minimum: 0
               type: integer
           required:

--- a/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
+++ b/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
@@ -8,12 +8,16 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// TODO: change replicas field to type `int` once we bump operator-sdk version to 0.18 or above
+// jira ticket https://issues.redhat.com/browse/WINC-407
+// operator-sdk issue https://github.com/operator-framework/operator-sdk/issues/2952
+
 // WindowsMachineConfigSpec defines the desired state of WindowsMachineConfig
 type WindowsMachineConfigSpec struct {
 	// Replicas represent how many Windows nodes to be added to the
 	// OpenShift cluster
 	// +kubebuilder:validation:Minimum=0
-	Replicas int `json:"replicas"`
+	Replicas int32 `json:"replicas"`
 	// InstanceType represents the flavor of instance to be used while
 	// creating the virtual machines. Please note that this is common
 	// across all the Windows nodes in the cluster

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -211,7 +211,7 @@ func (r *ReconcileWindowsMachineConfig) Reconcile(request reconcile.Request) (re
 	}
 
 	// Add or remove nodes
-	nodeCount, nodeReconcileErrs := r.reconcileWindowsNodes(instance.Spec.Replicas, currentCountOfWindowsVMs)
+	nodeCount, nodeReconcileErrs := r.reconcileWindowsNodes(int(instance.Spec.Replicas), currentCountOfWindowsVMs)
 
 	// Update all conditions and node count
 	r.statusMgr.joinedVMCount = nodeCount

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -68,7 +68,7 @@ func (tc *testContext) createWMC(replicas int, keyPair string) (*operator.Window
 		Spec: operator.WindowsMachineConfigSpec{
 			InstanceType: instanceType,
 			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: keyPair},
-			Replicas:     replicas,
+			Replicas:     int32(replicas),
 		},
 	}
 	return wmco, framework.Global.Client.Create(context.TODO(), wmco,

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -31,7 +31,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 		t.Fatalf("error getting wcmo custom resource  %v", err)
 	}
 	// Delete the Windows VM that got created.
-	wmco.Spec.Replicas = gc.numberOfNodes
+	wmco.Spec.Replicas = int32(gc.numberOfNodes)
 	if err := framework.Global.Client.Update(context.TODO(), wmco); err != nil {
 		t.Fatalf("error updating wcmo custom resource  %v", err)
 	}

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -35,7 +35,7 @@ func testStatusWhenSuccessful(t *testing.T) {
 		Namespace: testCtx.namespace}, wmc)
 	require.NoError(t, err, "Could not retrieve instance of WMC")
 
-	assert.Equal(t, wmc.Spec.Replicas, wmc.Status.JoinedVMCount, "Num of nodes in status not equal to spec")
+	assert.Equal(t, wmc.Spec.Replicas, int32(wmc.Status.JoinedVMCount), "Num of nodes in status not equal to spec")
 
 	degraded := wmc.Status.GetWindowsMachineConfigCondition(operator.Degraded)
 	require.NotNil(t, degraded)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -272,7 +272,7 @@ func createWindowsMachineConfig(namespace string, isReplicasFieldRequired bool, 
 		},
 	}
 	if isReplicasFieldRequired {
-		wmc.Spec.Replicas = replicasFieldValue
+		wmc.Spec.Replicas = int32(replicasFieldValue)
 	}
 	return wmc
 }


### PR DESCRIPTION
[wmco] remove validation for replicas
fixes validation for replicas field as it was being interpreted as
float while validating.
this was because replicas was defined as `int` in place of `int32`
which is causing the `operator-sdk generate crds` to not create a
`format` field in crd. This is a known issue in
operator-sdk 0.17.

Created [ticket](https://issues.redhat.com/browse/WINC-407) to revert this change 
once we bump operator sdk to 0.18 or above 
operator-sdk [issue](https://github.com/operator-framework/operator-sdk/issues/2952) 

[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1835166) 