### PR TITLE
[wmco] fix formatting of errors.wrap messages

### DIFF
--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
@@ -115,8 +115,8 @@ func (nc *nodeConfig) Configure() error {
 	// populate node object in nodeConfig
 	err = nc.getNode()
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error getting node object for VM %s",
-			nc.GetCredentials().GetInstanceId()))
+		return errors.Wrapf(err, "error getting node object for VM %s",
+			nc.GetCredentials().GetInstanceId())
 	}
 	// Apply worker labels
 	if err := nc.applyWorkerLabel(); err != nil {
@@ -135,8 +135,8 @@ func (nc *nodeConfig) configureNetwork() error {
 	// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
 	// start
 	if err := nc.waitForNodeAnnotation(HybridOverlaySubnet); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error waiting for %s node annotation for %s", HybridOverlaySubnet,
-			nc.node.GetName()))
+		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlaySubnet,
+			nc.node.GetName())
 	}
 
 	// NOTE: Investigate if we need to introduce a interface wrt to the VM's networking configuration. This will
@@ -144,14 +144,14 @@ func (nc *nodeConfig) configureNetwork() error {
 
 	// Configure the hybrid overlay in the Windows VM
 	if err := nc.Windows.ConfigureHybridOverlay(nc.node.GetName()); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error configuring hybrid overlay for %s", nc.node.GetName()))
+		return errors.Wrapf(err, "error configuring hybrid overlay for %s", nc.node.GetName())
 	}
 
 	// Wait until the node object has the hybrid overlay MAC annotation. This is required for the CNI configuration to
 	// start.
 	if err := nc.waitForNodeAnnotation(HybridOverlayMac); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error waiting for %s node annotation for %s", HybridOverlayMac,
-			nc.node.GetName()))
+		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlayMac,
+			nc.node.GetName())
 	}
 	return nil
 }
@@ -307,7 +307,7 @@ func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
 	err := wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
 		node, err := nc.k8sclientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 		if err != nil {
-			return false, errors.Wrap(err, fmt.Sprintf("error getting node %s", nodeName))
+			return false, errors.Wrapf(err, "error getting node %s", nodeName)
 		}
 		_, found := node.Annotations[annotation]
 		if found {
@@ -319,7 +319,7 @@ func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
 	})
 
 	if !found {
-		return errors.Wrap(err, fmt.Sprintf("timeout waiting for %s node annotation", annotation))
+		return errors.Wrapf(err, "timeout waiting for %s node annotation", annotation)
 	}
 	return nil
 }

--- a/pkg/controller/windowsmachineconfig/tracker.go
+++ b/pkg/controller/windowsmachineconfig/tracker.go
@@ -163,7 +163,7 @@ func initWindowsVMs(k8sclientset *kubernetes.Clientset, operatorNS string) (map[
 	// It is ok if the tracker ConfigMap doesn't exist. It is usually the case when the operator starts
 	// for the first time but it is not ok when the tracker ConfigMap exists but it unqueryable for some reason
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to query %s/%s ConfigMap", operatorNS, StoreName))
+		return nil, errors.Wrapf(err, "unable to query %s/%s ConfigMap", operatorNS, StoreName)
 	}
 	if err != nil && k8serrors.IsNotFound(err) {
 		log.Info(" Skipping VM map initialization as tracker does not exist")
@@ -204,12 +204,12 @@ func initWindowsVMs(k8sclientset *kubernetes.Clientset, operatorNS string) (map[
 func (t *tracker) Reconcile() error {
 	store, err := t.k8sclientset.CoreV1().ConfigMaps(t.operatorNS).Get(StoreName, metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return errors.Wrap(err, fmt.Sprintf("unable to query %s/%s ConfigMap", t.operatorNS, StoreName))
+		return errors.Wrapf(err, "unable to query %s/%s ConfigMap", t.operatorNS, StoreName)
 	}
 	// The ConfigMap does not exist, so we need to create it based on the WindowsVM slice
 	if err != nil && k8serrors.IsNotFound(err) {
 		if store, err = t.createStore(); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to create %s/%s ConfigMap", t.operatorNS, StoreName))
+			return errors.Wrapf(err, "unable to create %s/%s ConfigMap", t.operatorNS, StoreName)
 		}
 	}
 	// sync the node records
@@ -218,7 +218,7 @@ func (t *tracker) Reconcile() error {
 	t.syncSecrets(store)
 	// sync the store
 	if err = t.updateStore(store); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to update %s/%s ConfigMap", t.operatorNS, StoreName))
+		return errors.Wrapf(err, "unable to update %s/%s ConfigMap", t.operatorNS, StoreName)
 	}
 	return nil
 }
@@ -339,14 +339,14 @@ func (t *tracker) createSecret(credentials *types.Credentials) (string, error) {
 	if err == nil || (err != nil && !k8serrors.IsNotFound(err)) {
 		deleteOptions := &metav1.DeleteOptions{}
 		if err := t.k8sclientset.CoreV1().Secrets(t.operatorNS).Delete(credentials.GetInstanceId(), deleteOptions); err != nil {
-			return "", errors.Wrap(err, fmt.Sprintf("error deleting existing secret %s/%s", t.operatorNS,
-				credentials.GetInstanceId()))
+			return "", errors.Wrapf(err, "error deleting existing secret %s/%s", t.operatorNS,
+				credentials.GetInstanceId())
 		}
 	}
 
 	secret, err = t.k8sclientset.CoreV1().Secrets(t.operatorNS).Create(secret)
 	if err != nil {
-		return "", errors.Wrap(err, fmt.Sprintf("error creating secret %s/%s", t.operatorNS, credentials.GetInstanceId()))
+		return "", errors.Wrapf(err, "error creating secret %s/%s", t.operatorNS, credentials.GetInstanceId())
 	}
 	return secret.GetName(), nil
 }

--- a/pkg/controller/windowsmachineconfig/windows/windows.go
+++ b/pkg/controller/windowsmachineconfig/windows/windows.go
@@ -140,12 +140,12 @@ func (vm *Windows) ConfigureHybridOverlay(nodeName string) error {
 
 	_, stderr, err = vm.Run(mkdirCmd(logDir), false)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to create %s directory:\n%s", logDir, stderr))
+		return errors.Wrapf(err, "unable to create %s directory:\n%s", logDir, stderr)
 	}
 
 	if err := vm.CopyFile(wkl.HybridOverlayPath, remoteDir); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error copying %s-->%s", wkl.HybridOverlayPath,
-			remoteDir+wkl.HybridOverlayName))
+		return errors.Wrapf(err, "error copying %s-->%s", wkl.HybridOverlayPath,
+			remoteDir+wkl.HybridOverlayName)
 	}
 
 	// Start the hybrid-overlay in the background over ssh. We cannot use vm.Run() and by extension WinRM.Run() here as
@@ -156,7 +156,7 @@ func (vm *Windows) ConfigureHybridOverlay(nodeName string) error {
 		" --k8s-kubeconfig c:\\k\\kubeconfig > "+logDir+"hybrid-overlay.log 2>&1", false)
 
 	if err = vm.waitForHybridOverlayToRun(); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error running %s", wkl.HybridOverlayName))
+		return errors.Wrapf(err, "error running %s", wkl.HybridOverlayName)
 	}
 
 	// Wait for the hybrid-overlay to complete reconfiguring the network. The only way to detect that it has completed


### PR DESCRIPTION
This commit corrects the format of error.wrap messages from
errors.Wrap(err, fmt.Sprintf(msg)) -> errors.wrapf(err, msg)
This will ensure consistency across the repo and start using
errors.wrap moving forward.