### PR TITLE
[wmco] Migrate to using asserts and require in e2e

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -48,12 +48,10 @@ func testWindowsNodeCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	// create WMCO custom resource
-	if _, err := testCtx.createWMC(gc.numberOfNodes, gc.sshKeyPair); err != nil {
-		t.Fatalf("error creating wcmo custom resource  %v", err)
-	}
-	if err := testCtx.waitForWindowsNodes(gc.numberOfNodes, true); err != nil {
-		t.Fatalf("windows node creation failed  with %v", err)
-	}
+	_, err = testCtx.createWMC(gc.numberOfNodes, gc.sshKeyPair)
+	require.NoError(t, err, "error creating wcmo custom resource")
+	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true)
+	require.NoError(t, err, "windows node creation failed")
 	log.Printf("Created %d Windows worker nodes", len(gc.nodes))
 }
 

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -38,13 +38,10 @@ func testWindowsNodeDeletion(t *testing.T) {
 	gc.numberOfNodes = 0
 	// Delete the Windows VM that got created.
 	wmco.Spec.Replicas = int32(gc.numberOfNodes)
-	if err := framework.Global.Client.Update(context.TODO(), wmco); err != nil {
-		t.Fatalf("error updating wcmo custom resource  %v", err)
-	}
+	err = framework.Global.Client.Update(context.TODO(), wmco)
+	require.NoError(t, err, "error updating wcmo custom resource")
 	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
 	// side, let's make it as 60 minutes.
 	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true)
-	if err != nil {
-		t.Fatalf("windows node deletion failed  with %v", err)
-	}
+	require.NoError(t, err, "windows node deletion failed")
 }

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -8,6 +8,7 @@ import (
 	operator "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -19,9 +20,8 @@ var (
 
 // TestWMCO sets up the testing suite for WMCO.
 func TestWMCO(t *testing.T) {
-	if err := setupWMCOResources(); err != nil {
-		t.Fatalf("%v", err)
-	}
+	err := setupWMCOResources()
+	require.NoError(t, err)
 
 	// We've to update the global context struct here as the operator-sdk's framework has coupled flag
 	// parsing along with test suite execution.


### PR DESCRIPTION
This commit standardizes on using require in the e2e tests
instead of t.fatal() to ensure there are no more instances
of t.fatal()