### PR TITLE
[wmco] Bump wni version to reflect latest changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ replace (
 require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b
-	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c
+	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200521181434-c9423833fb65
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a h1:Otk3CuCAEHi
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c h1:ndiItBGbJHGR1xZWG/ZK30dwY8tuqL17acqKN5fF/Zk=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200427215039-03033d75837c/go.mod h1:9fgVIgtre3REZp/GgiIEbWjTBaNxPP5v4wfKU1ozw0c=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200521181434-c9423833fb65 h1:WuY8+Z6Cpk2C89XBzelKu0Bc+W2sJuyuFH9OZCwAt+4=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200521181434-c9423833fb65/go.mod h1:gXLIxBpEcpGcgfwxflSsolfvMRueHdoYNmuUXdnTerU=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.1.1/go.mod h1:yzNYR7qyJqRGOOp+bT6Z/iYSbSPNxeh3Si93Gx/3OBY=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88/go.mod h1:7Ut8p9jJ8C6RZyyhZfZypmlibCIJwK5Wcc+WZDgLkOA=


### PR DESCRIPTION
Operator imports wni module. This commit ensures that latest changes of wni
are reflected in the operator