### PR TITLE
Bug 1840504: Copy cni-conf-template.json failed

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -75,7 +75,7 @@ COPY --from=download /download/cni/flannel.exe .
 COPY --from=download /download/cni/host-local.exe .
 COPY --from=download /download/cni/win-bridge.exe .
 COPY --from=download /download/cni/win-overlay.exe .
-COPY --from=build /build/windows-machine-config-operator/pkg/internal/cni-conf-template.json .
+COPY pkg/internal/cni-conf-template.json .
 
 # Copy wget-ignore-cert powershell script
 RUN mkdir /payload/powershell/


### PR DESCRIPTION
The path for cni-conf-template.json needs to be corrected in the
Dockerfile used for building operator image since we do not
clone windows-machine-config-operator project in the build directory
for this Dockerfile.