### PR TITLE
[ci] Test with OLM deployed operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,9 @@ To run the e2e tests for WMCO locally against an OpenShift cluster set up on AWS
 export KUBECONFIG=<path to kubeconfig>
 export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
 export KUBE_SSH_KEY_PATH=<path to ssh key>
+export OPERATOR_IMAGE=<registry url for remote WMCO image>
 ```
-- Ensure that /payload directory exists and is accessible by the user account. The directory needs to be populated with the following files. Please see the [Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/build/Dockerfile) for figuring where to download and build these binaries. It is up to the user to keep these files up to date.
-```
-/payload/
-├── cni
-│   ├── flannel.exe
-│   ├── host-local.exe
-│   ├── win-bridge.exe
-│   ├── win-overlay.exe
-│   └── cni-conf-template.json
-├── hybrid-overlay-node.exe
-├── kube-node
-│   ├── kubelet.exe
-│   └── kube-proxy.exe
-├── powershell
-│   └── wget-ignore-cert.ps1
-└── wmcb.exe
-```
-Once the above variables are set and the /payload directory has been populated, run the following script:
+Once the above variables are set, run the following script:
 ```shell script
 hack/run-ci-e2e-test.sh -k "openshift-dev"
 ```

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -120,8 +120,8 @@ RUN curl -L -s https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz > go1.13.8.l
     && rm -rf ./go*
 
 # Download and install oc
-RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.2.2/openshift-client-linux-4.2.2.tar.gz -o openshift-origin-client-tools.tar.gz \
-    && echo "8f853477fa99cfc4087ad2ddf9b13b9d22e5fc4d5dc24c63ec5b0a91bb337fc9 openshift-origin-client-tools.tar.gz" | sha256sum -c \
+RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.4.6/openshift-client-linux-4.4.6.tar.gz -o openshift-origin-client-tools.tar.gz \
+    && echo "97ac91f9dede0d93bad8525934ef5a4f1c02e0b42d4f6ef58de99713e0f60d9c openshift-origin-client-tools.tar.gz" | sha256sum -c \
     && tar -xzf openshift-origin-client-tools.tar.gz \
     && mv oc /usr/bin/oc \
     && mv kubectl /usr/bin/kubectl \

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -87,7 +87,10 @@ spec:
                 name: windows-machine-config-operator
             spec:
               containers:
-              - command:
+              - args:
+                - --zap-level=debug
+                - --zap-encoder=console
+                command:
                 - windows-machine-config-operator
                 env:
                 - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,6 +32,9 @@ spec:
           image: REPLACE_IMAGE
           command:
           - windows-machine-config-operator
+          args:
+          - "--zap-level=debug"
+          - "--zap-encoder=console"
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -10,8 +10,55 @@ NODE_COUNT=""
 SKIP_NODE_DELETION=""
 KEY_PAIR_NAME=""
 
-
 export CGO_ENABLED=0
+
+get_WMCO_logs() {
+  oc logs -l name=windows-machine-config-operator -n windows-machine-config-operator
+}
+
+# This function runs operator-sdk run --olm/cleanup depending on the given parameters
+# Parameters:
+# 1: command to run [run/cleanup]
+# 2: path to the operator-sdk binary to use
+# 3: path to the directory holding the operator manifests
+OSDK_WMCO_management() {
+  if [ $# != 3 ]; then
+    echo incorrect parameter count for OSDK_WMCO_management
+    return 1
+  fi
+  if [[ "$1" != "run" && "$1" != "cleanup" ]]; then
+    echo $1 does not match either run or cleanup
+    return 1
+  fi
+
+  local COMMAND=$1
+  local OSDK_PATH=$2
+
+  # Currently this fails even on successes, adding this check to ignore the failure
+  # https://github.com/operator-framework/operator-sdk/issues/2938
+  if ! $OSDK_PATH $COMMAND --olm --olm-namespace openshift-operator-lifecycle-manager --operator-namespace windows-machine-config-operator --operator-version 0.0.0 --manifests $3/windows-machine-config-operator; then
+    echo operator-sdk $1 failed
+  fi
+}
+
+# This function runs operator-sdk test with certain go test arguments
+# Parameters:
+# 1: path to the operator-sdk binary to use
+# 2: go test arguments
+OSDK_WMCO_test() {
+  if [ $# != 2 ]; then
+    echo incorrect parameter count for OSDK_WMCO_test
+    return 1
+  fi
+
+  local OSDK_PATH=$1
+  local TEST_FLAGS=$2
+
+  if ! $OSDK_PATH test local ./test/e2e --no-setup --debug --operator-namespace=windows-machine-config-operator --go-test-flags "$TEST_FLAGS"; then
+    get_WMCO_logs
+    return 1
+  fi
+}
 
 while getopts ":n:k:s" opt; do
   case ${opt} in
@@ -31,10 +78,6 @@ while getopts ":n:k:s" opt; do
   esac
 done
 
-# Copy the cloud credentials and KUBESSH key path so that they can be used by operator
-cp $AWS_SHARED_CREDENTIALS_FILE /etc/cloud/credentials
-cp $KUBE_SSH_KEY_PATH /etc/private-key/private-key.pem
-
 OSDK=$(get_operator_sdk)
 
 # Set default values for the flags. Without this operator-sdk flags are getting
@@ -46,15 +89,44 @@ NODE_COUNT=${NODE_COUNT:-2}
 SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"-skip-node-deletion=false"}
 KEY_PAIR_NAME=${KEY_PAIR_NAME:-"libra"}
 
+# OPERATOR_IMAGE defines where the WMCO image to test with is located. If $OPERATOR_IMAGE is already set, use its value.
+# Setting $OPERATOR_IMAGE is required for local testing.
+# In OpenShift CI $IMAGE_FORMAT will be set to a value such as registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:${component}
+# We need to replace ${component} with the name of the WMCO image.
+# The stable namespace is used as it will use the last promoted version when the test is run in an repository other than this one.
+# When running in this repository the image built in the pipeline will be used instead.
+# https://steps.svc.ci.openshift.org/help/ci-operator#release
+OPERATOR_IMAGE=${OPERATOR_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//stable:windows-machine-config-operator-test}}
+
+# Create a temporary directory to hold the edited manifests which will be removed on exit
+MANIFEST_LOC=`mktemp -d`
+trap "rm -r $MANIFEST_LOC" EXIT
+cp -r deploy/olm-catalog/windows-machine-config-operator/ $MANIFEST_LOC
+sed -i "s|REPLACE_IMAGE|$OPERATOR_IMAGE|g" $MANIFEST_LOC/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+
 cd $WMCO_ROOT
 oc create -f deploy/namespace.yaml
+oc create secret generic cloud-credentials --from-file=credentials=$AWS_SHARED_CREDENTIALS_FILE -n windows-machine-config-operator
+oc create secret generic cloud-private-key --from-file=private-key.pem=$KUBE_SSH_KEY_PATH -n windows-machine-config-operator
+oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG -n windows-machine-config-operator
+
+# Run the operator in the windows-machine-config-operator namespace
+OSDK_WMCO_management run $OSDK $MANIFEST_LOC
+
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
 # Run the creation tests and skip deletion of the Windows VMs
-$OSDK test local ./test/e2e --debug --up-local --operator-namespace=windows-machine-config-operator --local-operator-flags "--zap-level=debug --zap-encoder=console" --go-test-flags "-run=TestWMCO/create -v -timeout=60m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
+OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=60m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
+
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created 
 # in the previous step
-$OSDK test local ./test/e2e --debug --up-local --operator-namespace=windows-machine-config-operator --local-operator-flags "--zap-level=debug --zap-encoder=console" --go-test-flags "-run=TestWMCO/destroy -v -timeout=60m -ssh-key-pair=$KEY_PAIR_NAME"
+OSDK_WMCO_test $OSDK "-run=TestWMCO/destroy -v -timeout=60m -ssh-key-pair=$KEY_PAIR_NAME"
+
+# Get logs on success before cleanup
+get_WMCO_logs
+
+# Cleanup the operator resources
+OSDK_WMCO_management cleanup $OSDK $MANIFEST_LOC
 oc delete -f deploy/namespace.yaml
 
 exit 0

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -41,8 +41,6 @@ type globalContext struct {
 	numberOfNodes int
 	// nodes are the Windows nodes created by the operator
 	nodes []v1.Node
-	// windowsVMs is used to interact with the Windows VMs created by the test suite
-	windowsVMs []testVM
 	// skipNodeDeletion allows the Windows nodes to hang around after the test suite has been run.
 	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -15,6 +15,9 @@ var (
 	nodeRetryInterval    = time.Minute * 1
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
+	// deploymentRetries is the amount of time to retry creating a Windows Server deployment, to compensate for the
+	// time it takes to download the Server2019 image to the node
+	deploymentRetries = 10
 )
 
 // TestWMCO sets up the testing suite for WMCO.


### PR DESCRIPTION
This PR makes it so that our CI tests use an OLM deployed operator instead of a locally deployed one.