### PR TITLE
[wmco] Bump cni-plugins to v0.8.6

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,12 +31,12 @@ RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
 RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 
 # Download, checksum and extract the CNI plugin package
-RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz
-RUN echo "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0 cni-plugins-windows-amd64-v0.8.2.tgz" > cni-plugins-windows-amd64-v0.8.2.tgz.sha512
-RUN sha512sum -c cni-plugins-windows-amd64-v0.8.2.tgz.sha512
+RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz
+RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz.sha512
+RUN sha512sum -c cni-plugins-windows-amd64-v0.8.6.tgz.sha512
 RUN mkdir /download/cni/
 WORKDIR /download/cni/
-RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
+RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.6.tgz
 
 # Build the operator image with following payload structure
 # /payload/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -45,12 +45,12 @@ RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
 RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 
 # Download, checksum and extract the CNI plugin package
-RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-windows-amd64-v0.8.2.tgz
-RUN echo "705a760673fd9e2164ac38f0df7d739ca6c3ec4f4204b0c439227ec6da7cb153859013c917e7f8f1a9456365dd9193f627a7e9e4e1981725cab89bb5ab881ec0 cni-plugins-windows-amd64-v0.8.2.tgz" > cni-plugins-windows-amd64-v0.8.2.tgz.sha512
-RUN sha512sum -c cni-plugins-windows-amd64-v0.8.2.tgz.sha512
+RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz
+RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz.sha512
+RUN sha512sum -c cni-plugins-windows-amd64-v0.8.6.tgz.sha512
 RUN mkdir /download/cni/
 WORKDIR /download/cni/
-RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.2.tgz
+RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.6.tgz
 
 # Build the operator image with following payload structure
 # /payload/


### PR DESCRIPTION
Update the download and sha512 location of the CNI plugins to v0.8.6.