### PR TITLE
Run kube-proxy on new Windows nodes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,6 +52,7 @@ RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.6.tgz
 #│   └── kube-proxy.exe
 #├── powershell
 #│   └── wget-ignore-cert.ps1
+#│   └── hns.psm1
 #└── wmcb.exe
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -77,10 +78,11 @@ COPY --from=download /download/cni/win-bridge.exe .
 COPY --from=download /download/cni/win-overlay.exe .
 COPY pkg/internal/cni-conf-template.json .
 
-# Copy wget-ignore-cert powershell script
+# Copy required powershell scripts
 RUN mkdir /payload/powershell/
 WORKDIR /payload/powershell/
 COPY pkg/internal/wget-ignore-cert.ps1 .
+COPY pkg/internal/hns.psm1 .
 
 WORKDIR /
 
@@ -93,9 +95,6 @@ COPY build/_output/bin/windows-machine-config-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
-
-# Copy the wget-ignore-powershell script needed to execute wget commands remotely
-COPY pkg/internal/wget-ignore-cert.ps1 /payload/powershell/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -66,6 +66,7 @@ RUN tar -zxf /download/cni-plugins-windows-amd64-v0.8.6.tgz
 #│   └── kube-proxy.exe
 #├── powershell
 #│   └── wget-ignore-cert.ps1
+#│   └── hns.psm1
 #└── wmcb.exe
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -94,10 +95,11 @@ COPY --from=download /download/cni/win-bridge.exe .
 COPY --from=download /download/cni/win-overlay.exe .
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/cni-conf-template.json .
 
-# Copy wget-ignore-cert powershell script
+# Copy required powershell scripts
 RUN mkdir /payload/powershell/
 WORKDIR /payload/powershell/
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/wget-ignore-cert.ps1 .
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/hns.psm1 .
 
 WORKDIR /
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -122,6 +122,7 @@ func main() {
 		wkl.CloudCredentialsPath,
 		wkl.PrivateKeyPath,
 		wkl.CNIConfigTemplatePath,
+		wkl.HNSPSModule,
 	}
 	if err := checkIfRequiredFilesExist(requiredFiles); err != nil {
 		log.Error(err, "could not start the operator")

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -120,7 +120,7 @@ OSDK_WMCO_management run $OSDK $MANIFEST_LOC
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
 # Run the creation tests and skip deletion of the Windows VMs
-OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=60m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
+OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=90m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created 
 # in the previous step

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -21,6 +21,9 @@ const (
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
 	IgnoreWgetPowerShellPath = payloadDirectory + "/powershell/wget-ignore-cert.ps1"
+	// HNSPSModule is the path to the powershell module which defines various functions for dealing with Windows HNS
+	// networks
+	HNSPSModule = payloadDirectory + "/powershell/hns.psm1"
 	// cniDirectory is the directory for storing the CNI plugins and the CNI config template
 	cniDirectory = "/cni/"
 	// FlannelCNIPluginPath is the path of the flannel CNI plugin binary. The container image should already have this

--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig.go
@@ -42,7 +42,7 @@ type nodeConfig struct {
 	// k8sclientset holds the information related to kubernetes clientset
 	k8sclientset *kubernetes.Clientset
 	// Windows holds the information related to the windows VM
-	*windows.Windows
+	windows.Windows
 	// Node holds the information related to node object
 	node *v1.Node
 	// network holds the network information specific to the node
@@ -181,6 +181,10 @@ func (nc *nodeConfig) configureNetwork() error {
 	// Configure CNI in the Windows VM
 	if err := nc.configureCNI(); err != nil {
 		return errors.Wrapf(err, "error configuring CNI for %s", nc.node.GetName())
+	}
+	// Start the kube-proxy service
+	if err := nc.Windows.ConfigureKubeProxy(nc.node.GetName(), nc.node.Annotations[HybridOverlaySubnet]); err != nil {
+		return errors.Wrapf(err, "error starting kube-proxy for %s", nc.node.GetName())
 	}
 	return nil
 }

--- a/pkg/controller/windowsmachineconfig/windows/service.go
+++ b/pkg/controller/windowsmachineconfig/windows/service.go
@@ -1,0 +1,46 @@
+package windows
+
+// service represents a Windows service
+type service interface {
+	Name() string
+	BinaryPath() string
+	Args() string
+}
+
+// kubeProxyService implements the service interface and is specific to the kube-proxy service
+type kubeProxyService struct {
+	// binaryPath is the path to the binary to be ran as a service
+	binaryPath string
+	// name is the name of the service
+	name string
+	// args is the arguments that the binary will be ran with
+	args string
+}
+
+// newKubeProxyService returns a service interface with a kubeProxyService implementation
+func newKubeProxyService(nodeName, hostSubnet, sourceVIP string) (service, error) {
+	return &kubeProxyService{
+		binaryPath: kubeProxyPath,
+		name:       kubeProxyServiceName,
+		args: "--windows-service --v=4 --proxy-mode=kernelspace --feature-gates=WinOverlay=true " +
+			"--hostname-override=" + nodeName + " --kubeconfig=c:\\k\\kubeconfig " +
+			"--cluster-cidr=" + hostSubnet + " --log-dir=" + kubeProxyLogDir + " --logtostderr=false " +
+			"--network-name=OVNKubernetesHybridOverlayNetwork --source-vip=" + sourceVIP +
+			" --enable-dsr=false",
+	}, nil
+}
+
+// Name returns the name of the service
+func (s *kubeProxyService) Name() string {
+	return s.name
+}
+
+// Args returns the arguments that the service will run with
+func (s *kubeProxyService) Args() string {
+	return s.args
+}
+
+// BinaryPath returns the path of the binary that service the service will run
+func (s *kubeProxyService) BinaryPath() string {
+	return s.binaryPath
+}

--- a/pkg/controller/windowsmachineconfig/windows/windows.go
+++ b/pkg/controller/windowsmachineconfig/windows/windows.go
@@ -22,10 +22,16 @@ const (
 	cniDir = "C:\\Temp\\cni\\"
 	// wgetIgnoreCertCmd is the remote location of the wget-ignore-cert.ps1 script
 	wgetIgnoreCertCmd = remoteDir + "wget-ignore-cert.ps1"
+	// hnsPSModule is the remote location of the hns.psm1 module
+	hnsPSModule = remoteDir + "hns.psm1"
 	// k8sDir is the remote kubernetes executable directory
 	k8sDir = "C:\\k\\"
 	// logDir is the remote kubernetes log directory
 	logDir = k8sDir + "log\\"
+	// kubeProxyLogDir is the remote kube-proxy log directory
+	kubeProxyLogDir = logDir + "kube-proxy\\"
+	// kubeProxyPath is the location of the kube-proxy exe
+	kubeProxyPath = k8sDir + "kube-proxy.exe"
 	// HybridOverlayProcess is the process name of the hybrid-overlay-node.exe in the Windows VM
 	HybridOverlayProcess = "hybrid-overlay-node"
 	// hybridOverlayConfigurationTime is the approximate time taken for the hybrid-overlay to complete reconfiguring
@@ -35,12 +41,24 @@ const (
 	BaseOVNKubeOverlayNetwork = "BaseOVNKubernetesHybridOverlayNetwork"
 	// OVNKubeOverlayNetwork is the name of the OVN HNS Overlay network
 	OVNKubeOverlayNetwork = "OVNKubernetesHybridOverlayNetwork"
+	// kubeProxyServiceName is the name of the kube-proxy Windows service
+	kubeProxyServiceName = "kube-proxy"
 )
 
 var log = logf.Log.WithName("windows")
 
-// Windows is a wrapper for the WindowsVM interface.
-type Windows struct {
+// Windows is a wrapper for the WindowsVM interface
+type Windows interface {
+	types.WindowsVM
+	Configure() error
+	ConfigureCNI(string) error
+	ConfigureHybridOverlay(string) error
+	ConfigureKubeProxy(string, string) error
+	Validate() error
+}
+
+// windows implements the Windows interface
+type windows struct {
 	types.WindowsVM
 	// workerIgnitionEndpoint is the Machine Config Server(MCS) endpoint from which we can download the
 	// the OpenShift worker ignition file.
@@ -48,12 +66,12 @@ type Windows struct {
 }
 
 // New returns a new instance of windows struct
-func New(vm types.WindowsVM, workerIgnitionEndpoint string) *Windows {
-	return &Windows{WindowsVM: vm, workerIgnitionEndpoint: workerIgnitionEndpoint}
+func New(vm types.WindowsVM, workerIgnitionEndpoint string) Windows {
+	return &windows{WindowsVM: vm, workerIgnitionEndpoint: workerIgnitionEndpoint}
 }
 
 // Configure prepares the Windows VM for the bootstrapper and then runs it
-func (vm *Windows) Configure() error {
+func (vm *windows) Configure() error {
 	if err := vm.createDirectories(); err != nil {
 		return errors.Wrap(err, "error creating directories on Windows VM")
 	}
@@ -64,12 +82,13 @@ func (vm *Windows) Configure() error {
 }
 
 // createDirectories creates directories required for configuring the Windows node on the VM
-func (vm *Windows) createDirectories() error {
+func (vm *windows) createDirectories() error {
 	directoriesToCreate := []string{
 		k8sDir,
 		remoteDir,
 		cniDir,
 		logDir,
+		kubeProxyLogDir,
 	}
 	for _, dir := range directoriesToCreate {
 		if _, err := vm.RunOverSSH(mkdirCmd(dir), false); err != nil {
@@ -80,15 +99,17 @@ func (vm *Windows) createDirectories() error {
 }
 
 // transferFiles copies various files required for configuring the Windows node, to the VM.
-func (vm *Windows) transferFiles() error {
+func (vm *windows) transferFiles() error {
 	srcDestPairs := map[string]string{
 		wkl.IgnoreWgetPowerShellPath: remoteDir,
 		wkl.WmcbPath:                 remoteDir,
 		wkl.HybridOverlayPath:        remoteDir,
+		wkl.HNSPSModule:              remoteDir,
 		wkl.FlannelCNIPluginPath:     cniDir,
 		wkl.WinBridgeCNIPlugin:       cniDir,
 		wkl.HostLocalCNIPlugin:       cniDir,
 		wkl.WinOverlayCNIPlugin:      cniDir,
+		wkl.KubeProxyPath:            k8sDir,
 		wkl.KubeletPath:              winTemp,
 	}
 	for src, dest := range srcDestPairs {
@@ -100,7 +121,7 @@ func (vm *Windows) transferFiles() error {
 }
 
 // validate the WindowsVM node object
-func (vm *Windows) Validate() error {
+func (vm *windows) Validate() error {
 	if vm.GetCredentials() == nil {
 		return fmt.Errorf("nil credentials for VM")
 	}
@@ -117,7 +138,7 @@ func (vm *Windows) Validate() error {
 }
 
 // runBootstrapper copies the bootstrapper and runs the code on the remote Windows VM
-func (vm *Windows) runBootstrapper() error {
+func (vm *windows) runBootstrapper() error {
 	err := vm.initializeBootstrapperFiles()
 	if err != nil {
 		return errors.Wrap(err, "error initializing bootstrapper files")
@@ -133,7 +154,7 @@ func (vm *Windows) runBootstrapper() error {
 }
 
 // initializeTestBootstrapperFiles initializes the files required for initialize-kubelet
-func (vm *Windows) initializeBootstrapperFiles() error {
+func (vm *windows) initializeBootstrapperFiles() error {
 	// Download the worker ignition to C:\Windows\Temp\ using the script that ignores the server cert
 	ignitionFileDownloadCmd := wgetIgnoreCertCmd + " -server " + vm.workerIgnitionEndpoint + " -output " +
 		winTemp + "worker.ign"
@@ -146,7 +167,7 @@ func (vm *Windows) initializeBootstrapperFiles() error {
 }
 
 // ConfigureHybridOverlay ensures that the hybrid overlay is running on the node
-func (vm *Windows) ConfigureHybridOverlay(nodeName string) error {
+func (vm *windows) ConfigureHybridOverlay(nodeName string) error {
 	// Check if the hybrid-overlay is running
 	_, err := vm.RunOverSSH("Get-Process -Name \""+HybridOverlayProcess+"\"", true)
 
@@ -193,7 +214,7 @@ func (vm *Windows) ConfigureHybridOverlay(nodeName string) error {
 }
 
 // waitForHNSNetworks waits for the OVN overlay HNS networks to be created until the timeout is reached
-func (vm *Windows) waitForHNSNetworks() error {
+func (vm *windows) waitForHNSNetworks() error {
 	var out string
 	var err error
 	for retries := 0; retries < retry.Count; retries++ {
@@ -216,7 +237,7 @@ func (vm *Windows) waitForHNSNetworks() error {
 }
 
 // waitForHybridOverlayToRun waits for the hybrid-overlay-node.exe to run until the timeout is reached
-func (vm *Windows) waitForHybridOverlayToRun() error {
+func (vm *windows) waitForHybridOverlayToRun() error {
 	var err error
 	for retries := 0; retries < retry.Count; retries++ {
 		_, err = vm.RunOverSSH("Get-Process -Name \""+HybridOverlayProcess+"\"", true)
@@ -231,7 +252,7 @@ func (vm *Windows) waitForHybridOverlayToRun() error {
 }
 
 // ConfigureCNI ensures that the CNI configuration in done on the node
-func (vm *Windows) ConfigureCNI(configFile string) error {
+func (vm *windows) ConfigureCNI(configFile string) error {
 	// copy the CNI config file to the Windows VM
 	if err := vm.CopyFile(configFile, cniDir); err != nil {
 		return errors.Errorf("unable to copy CNI file %s to %s", configFile, cniDir)
@@ -249,6 +270,66 @@ func (vm *Windows) ConfigureCNI(configFile string) error {
 	}
 
 	return nil
+}
+
+// createService creates the service on the Windows VM
+func (vm *windows) createService(svc service) error {
+	out, err := vm.RunOverSSH("sc.exe create "+svc.Name()+" binPath=\""+svc.BinaryPath()+" "+
+		svc.Args()+"\" start=auto", false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create service with output: %s", out)
+	}
+	return nil
+}
+
+// startService starts a previously created Windows service
+func (vm *windows) startService(svc service) error {
+	out, err := vm.RunOverSSH("sc.exe start "+svc.Name(), false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to start service with output: %s", out)
+	}
+	log.V(1).Info("started service", "name", svc.Name(), "binary", svc.BinaryPath(), "args", svc.Args())
+	return nil
+}
+
+// ConfigureKubeProxy ensures that the kube-proxy service is running
+func (vm *windows) ConfigureKubeProxy(nodeName, hostSubnet string) error {
+	sVIP, err := vm.getSourceVIP()
+	if err != nil {
+		return errors.Wrap(err, "error getting source VIP")
+	}
+	kubeProxyService, err := newKubeProxyService(nodeName, hostSubnet, sVIP)
+	if err != nil {
+		return errors.Wrap(err, "error creating service object")
+	}
+	if err := vm.createService(kubeProxyService); err != nil {
+		return errors.Wrap(err, "error creating kube-proxy Windows service")
+	}
+	if err := vm.startService(kubeProxyService); err != nil {
+		return errors.Wrap(err, "error starting kube-proxy Windows service")
+	}
+	return nil
+}
+
+// getSourceVIP returns the source VIP of the VM
+func (vm *windows) getSourceVIP() (string, error) {
+	cmd := "\"Import-Module -DisableNameChecking " + hnsPSModule + "; " +
+		"$net = (Get-HnsNetwork | where { $_.Name -eq 'OVNKubernetesHybridOverlayNetwork' }); " +
+		"$endpoint = New-HnsEndpoint -NetworkId $net.ID -Name VIPEndpoint; " +
+		"Attach-HNSHostEndpoint -EndpointID $endpoint.ID -CompartmentID 1; " +
+		"(Get-NetIPConfiguration -AllCompartments -All -Detailed | " +
+		"where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()\""
+	out, err := vm.RunOverSSH(cmd, true)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get source VIP with output: %s", out)
+	}
+
+	// stdout will have trailing '\r\n', so need to trim it
+	sourceVIP := strings.TrimSpace(out)
+	if sourceVIP == "" {
+		return "", fmt.Errorf("source VIP is empty")
+	}
+	return sourceVIP, nil
 }
 
 // mkdirCmd returns the Windows command to create a directory if it does not exists

--- a/pkg/internal/hns.psm1
+++ b/pkg/internal/hns.psm1
@@ -1,0 +1,173 @@
+# Code from https://github.com/microsoft/SDN/blob/master/Kubernetes/windows/hns.psm1
+
+# SDN Sample Scripts  v.1.0
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+# MIT License
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#########################################################################
+# Global Initialize
+function Get-VmComputeNativeMethods()
+{
+        $signature = @'
+                     [DllImport("vmcompute.dll")]
+                     public static extern void HNSCall([MarshalAs(UnmanagedType.LPWStr)] string method, [MarshalAs(UnmanagedType.LPWStr)] string path, [MarshalAs(UnmanagedType.LPWStr)] string request, [MarshalAs(UnmanagedType.LPWStr)] out string response);
+'@
+
+    # Compile into runtime type
+    Add-Type -MemberDefinition $signature -Namespace VmCompute.PrivatePInvoke -Name NativeMethods -PassThru
+}
+
+#########################################################################
+# Endpoints
+#########################################################################
+function New-HnsEndpoint
+{
+    param
+    (
+        [parameter(Mandatory=$false, Position = 0)] [string] $JsonString = $null,
+        [parameter(Mandatory = $false, Position = 0)] [Guid] $NetworkId,
+        [parameter(Mandatory = $false)] [string] $Name,
+        [parameter(Mandatory = $false)] [string] $IPAddress,
+        [parameter(Mandatory = $false)] [string] $Gateway,
+        [parameter(Mandatory = $false)] [string] $MacAddress,
+        [parameter(Mandatory = $false)] [switch] $EnableOutboundNat
+    )
+
+    begin
+    {
+        if ($JsonString)
+        {
+            $EndpointData = $JsonString | ConvertTo-Json | ConvertFrom-Json
+        }
+        else
+        {
+            $endpoint = @{
+                VirtualNetwork = $NetworkId;
+                Policies       = @();
+            }
+
+            if ($Name) {
+                $endpoint += @{
+                    Name = $Name;
+                }
+            }
+
+            if ($MacAddress) {
+                $endpoint += @{
+                    MacAddress     = $MacAddress;
+                }
+            }
+
+            if ($IPAddress) {
+                $endpoint += @{
+                    IPAddress      = $IPAddress;
+                }
+            }
+
+            if ($Gateway) {
+                $endpoint += @{
+                    GatewayAddress = $Gateway;
+                }
+            }
+
+            if ($EnableOutboundNat) {
+                $endpoint.Policies += @{
+                    Type = "OutBoundNAT";
+                }
+
+            }
+            # Try to Generate the data
+            $EndpointData = convertto-json $endpoint
+        }
+    }
+
+    Process
+    {
+        return Invoke-HNSRequest -Method POST -Type endpoints -Data $EndpointData
+    }
+}
+
+function Attach-HnsHostEndpoint
+{
+    param
+    (
+     [parameter(Mandatory=$true)] [Guid] $EndpointID,
+     [parameter(Mandatory=$true)] [int] $CompartmentID
+     )
+    $request = @{
+        SystemType    = "Host";
+        CompartmentId = $CompartmentID;
+    };
+
+    return Invoke-HNSRequest -Method POST -Type endpoints -Data (ConvertTo-Json $request) -Action "attach" -Id $EndpointID
+}
+
+#########################################################################
+
+function Invoke-HNSRequest
+{
+    param
+    (
+        [ValidateSet('GET', 'POST', 'DELETE')]
+        [parameter(Mandatory=$true)] [string] $Method,
+        [ValidateSet('networks', 'endpoints', 'activities', 'policylists', 'endpointstats', 'plugins')]
+        [parameter(Mandatory=$true)] [string] $Type,
+        [parameter(Mandatory=$false)] [string] $Action = $null,
+        [parameter(Mandatory=$false)] [string] $Data = $null,
+        [parameter(Mandatory=$false)] [Guid] $Id = [Guid]::Empty
+    )
+
+    $hnsPath = "/$Type"
+
+    if ($id -ne [Guid]::Empty)
+    {
+        $hnsPath += "/$id";
+    }
+
+    if ($Action)
+    {
+        $hnsPath += "/$Action";
+    }
+
+    $request = "";
+    if ($Data)
+    {
+        $request = $Data
+    }
+
+    $output = "";
+    $response = "";
+    Write-Verbose "Invoke-HNSRequest Method[$Method] Path[$hnsPath] Data[$request]"
+
+    $hnsApi = Get-VmComputeNativeMethods
+    $hnsApi::HNSCall($Method, $hnsPath, "$request", [ref] $response);
+
+    Write-Verbose "Result : $response"
+    if ($response)
+    {
+        try {
+            $output = ($response | ConvertFrom-Json);
+        } catch {
+            Write-Error $_.Exception.Message
+            return ""
+        }
+        if ($output.Error)
+        {
+             Write-Error $output;
+        }
+        $output = $output.Output;
+    }
+
+    return $output;
+}
+
+#########################################################################
+
+Export-ModuleMember -Function New-HNSEndpoint
+
+Export-ModuleMember -Function Attach-HNSHostEndpoint
+
+Export-ModuleMember -Function Invoke-HNSRequest


### PR DESCRIPTION
This commit adds running kube-proxy as a Windows service as part of the
procedure of configuring new Windows nodes. This enables communication
with workloads on the Windows node from outside the cluster.