### PR TITLE
[wmco] Remove Kubeconfig requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,6 @@ oc create secret generic cloud-credentials --from-file=credentials=$HOME/.aws/cr
 oc create secret generic cloud-private-key --from-file=private-key.pem=$HOME/.ssh/$keyname
 ```
 
-Put the kubeconfig you wish to use in a secret. In order to use the permissions of the windows-machine-config-operator
-service account the kubeconfig should be generated from the service account.
-```shell script
-# Change paths as necessary
-oc create secret generic kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
-```
-
 ##### Running with bundle and index images
 You can skip this step if you want to run the operator locally [without bundle and index images](#running-without-bundle-and-index-images)
 

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -109,8 +109,6 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: windows-machine-config-operator
-                - name: KUBECONFIG
-                  value: /etc/kubeconfig/kubeconfig
                 image: REPLACE_IMAGE
                 imagePullPolicy: Always
                 name: windows-machine-config-operator
@@ -122,9 +120,6 @@ spec:
                 - mountPath: /etc/private-key/
                   name: cloud-private-key
                   readOnly: true
-                - mountPath: /etc/kubeconfig/
-                  name: kubeconfig
-                  readOnly: true
               serviceAccountName: windows-machine-config-operator
               volumes:
               - name: cloud-credentials
@@ -133,9 +128,6 @@ spec:
               - name: cloud-private-key
                 secret:
                   secretName: cloud-private-key
-              - name: kubeconfig
-                secret:
-                  secretName: kubeconfig
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -67,6 +67,12 @@ spec:
           - list
           - update
         - apiGroups:
+            - certificates.k8s.io
+          resources:
+            - signers
+          verbs:
+            - approve
+        - apiGroups:
           - operator.openshift.io
           resources:
           - networks
@@ -173,6 +179,13 @@ spec:
           - deployments/finalizers
           verbs:
           - update
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+          verbs:
+            - get
+            - list
         - apiGroups:
           - apps
           resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,10 +22,6 @@ spec:
       - name: cloud-private-key
         secret:
           secretName: cloud-private-key
-      # TODO: Remove the kubeconfig volume as part of https://issues.redhat.com/browse/WINC-328
-      - name: kubeconfig
-        secret:
-          secretName: kubeconfig
       containers:
         - name: windows-machine-config-operator
           # Replace this with the built image name
@@ -47,9 +43,6 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "windows-machine-config-operator"
-            # TODO: Remove the KUBECONFIG environment variable as part of https://issues.redhat.com/browse/WINC-328
-            - name: KUBECONFIG
-              value: /etc/kubeconfig/kubeconfig
           volumeMounts:
           # TODO: Remove the cloud-credentials and cloud-private-key volumeMounts as part of
           # https://issues.redhat.com/browse/WINC-325
@@ -58,8 +51,4 @@ spec:
             readOnly: true
           - name: cloud-private-key
             mountPath: "/etc/private-key/"
-            readOnly: true
-          # TODO: Remove the kubeconfig volumeMount as part of https://issues.redhat.com/browse/WINC-328
-          - name: kubeconfig
-            mountPath: "/etc/kubeconfig/"
             readOnly: true

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -97,3 +97,19 @@ rules:
      - networks
    verbs:
      - get
+# Pod permissions used to get OwnerReference corresponding to the current pod. This is required to ensure that
+# the operator pod is the leader in the given namespace.
+ - apiGroups:
+     - ""
+   resources:
+     - pods
+   verbs:
+     - get
+     - list
+# Permissions needed to approve a CSR.
+ - apiGroups:
+     - certificates.k8s.io
+   resources:
+     - signers
+   verbs:
+     - approve

--- a/pkg/controller/windowsmachineconfig/nodeconfig/init.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/init.go
@@ -34,5 +34,5 @@ func init() {
 		log.Error(err, "error getting cluster address")
 	}
 	// populate the cache
-	nodeConfigCache.workerIgnitionEndPoint = "https://api-int." + clusterAddress + ":22623/config/worker"
+	nodeConfigCache.workerIgnitionEndPoint = "https://" + clusterAddress + ":22623/config/worker"
 }

--- a/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig_test.go
+++ b/pkg/controller/windowsmachineconfig/nodeconfig/nodeconfig_test.go
@@ -19,8 +19,8 @@ func Test_getClusterAddr(t *testing.T) {
 	}{
 		{
 			name:    "Valid test case",
-			args:    args{kubeAPIServerEndpoint: "https://api.abc.devcluster.openshift.com:6443"},
-			want:    "abc.devcluster.openshift.com",
+			args:    args{kubeAPIServerEndpoint: "https://api-int.abc.devcluster.openshift.com:6443"},
+			want:    "api-int.abc.devcluster.openshift.com",
 			wantErr: false,
 		},
 		{
@@ -31,8 +31,8 @@ func Test_getClusterAddr(t *testing.T) {
 		},
 		{
 			name:    "Test case with invalid api at the last",
-			args:    args{kubeAPIServerEndpoint: "https://api.abc.devcluster.openshift.com.api:6443"},
-			want:    "abc.devcluster.openshift.com.api",
+			args:    args{kubeAPIServerEndpoint: "https://api-int.abc.devcluster.openshift.com.api:6443"},
+			want:    "api-int.abc.devcluster.openshift.com.api",
 			wantErr: false,
 		},
 	}

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -3,8 +3,6 @@ package windowsmachineconfig
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/cloudprovider"
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	wmcapi "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
@@ -131,7 +129,7 @@ func (r *ReconcileWindowsMachineConfig) getCloudProvider(instance *wmcapi.Window
 	//              Jira story: https://issues.redhat.com/browse/WINC-262
 	// TODO: Add validation for the fields in the WindowsMachineConfig CRD.
 	//              Jira story: https://issues.redhat.com/browse/WINC-279
-	r.cloudProvider, err = cloudprovider.CloudProviderFactory(os.Getenv("KUBECONFIG"),
+	r.cloudProvider, err = cloudprovider.CloudProviderFactory("",
 		// We assume the credential path is `/etc/aws/credentials` mounted as a secret.
 		wkl.CloudCredentialsPath,
 		instance.Spec.AWS.CredentialAccountID,


### PR DESCRIPTION
This commit ensures that we no longer use KUBECONFIG to create or delete
instances. The changes include

-  removing all instances of kubeconfig

- adding pod, certificate approval permissions 

-  using infrastructure resource to get api server url.

[WINC-397](https://issues.redhat.com/browse/WINC-397)