### PR TITLE
Bug 1840837: Get reconcile error on wmco reboot

### DIFF
--- a/pkg/apis/wmc/v1alpha1/conditions.go
+++ b/pkg/apis/wmc/v1alpha1/conditions.go
@@ -23,6 +23,8 @@ const (
 	VMTerminationFailureReason string = "VMTerminationFailure"
 	// TrackerFailureReason indicates there was a problem tracking and storing VM information
 	TrackerFailureReason string = "TrackerFailure"
+	// StatusFailureReason indicates there was an issue updating the status for the operator
+	StatusFailureReason string = "StatusFailure"
 )
 
 // NewWindowsMachineConfigCondition creates a new WindowsMachineConfig condition.

--- a/pkg/controller/windowsmachineconfig/status.go
+++ b/pkg/controller/windowsmachineconfig/status.go
@@ -48,8 +48,11 @@ func (s *StatusManager) updateStatus() error {
 		return errors.Wrapf(err, "could not get %v", s.wmcName)
 	}
 
-	object.Status.JoinedVMCount = s.joinedVMCount
 	for _, condition := range s.conditionsToSet {
+		// update the joined VM count if we are done reconciling
+		if condition.Type == wmcapi.Reconciling && condition.Status == corev1.ConditionFalse {
+			object.Status.JoinedVMCount = s.joinedVMCount
+		}
 		object.Status.SetWindowsMachineConfigCondition(condition)
 	}
 	if (s.degradedCondition != wmcapi.WindowsMachineConfigCondition{}) {


### PR DESCRIPTION
This PR fixes the wmco reboot error that occurs due to
a stale resource read of the object from client cache for a
subsequent update. This PR replaces the default client
with a non-default-client that does not read from cache and
only updates the status to reconciling when we scale up or down.
Ref: [opertaor-sdk-non-default-client]( https://github.com/operator-framework/operator-sdk/blob/3efa98cb74a8388877724c574473c291677f2a18/website/content/en/docs/golang/references/client.md#non-default-client)