### PR TITLE
revert replicas type int32 change

### DIFF
--- a/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/crds/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -59,7 +59,6 @@ spec:
             replicas:
               description: Replicas represent how many Windows nodes to be added to
                 the OpenShift cluster
-              format: int32
               minimum: 0
               type: integer
           required:

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/wmc.openshift.io_windowsmachineconfigs_crd.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/wmc.openshift.io_windowsmachineconfigs_crd.yaml
@@ -59,7 +59,6 @@ spec:
             replicas:
               description: Replicas represent how many Windows nodes to be added to
                 the OpenShift cluster
-              format: int32
               minimum: 0
               type: integer
           required:

--- a/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
+++ b/pkg/apis/wmc/v1alpha1/windowsmachineconfig_types.go
@@ -8,16 +8,12 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// TODO: change replicas field to type `int` once we bump operator-sdk version to 0.18 or above
-// jira ticket https://issues.redhat.com/browse/WINC-407
-// operator-sdk issue https://github.com/operator-framework/operator-sdk/issues/2952
-
 // WindowsMachineConfigSpec defines the desired state of WindowsMachineConfig
 type WindowsMachineConfigSpec struct {
 	// Replicas represent how many Windows nodes to be added to the
 	// OpenShift cluster
 	// +kubebuilder:validation:Minimum=0
-	Replicas int32 `json:"replicas"`
+	Replicas int `json:"replicas"`
 	// InstanceType represents the flavor of instance to be used while
 	// creating the virtual machines. Please note that this is common
 	// across all the Windows nodes in the cluster

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileWindowsMachineConfig) Reconcile(request reconcile.Request) (re
 	}
 
 	// Add or remove nodes
-	nodeCount, nodeReconcileErrs := r.reconcileWindowsNodes(int(instance.Spec.Replicas), currentCountOfWindowsVMs)
+	nodeCount, nodeReconcileErrs := r.reconcileWindowsNodes(instance.Spec.Replicas, currentCountOfWindowsVMs)
 
 	// Update all conditions and node count
 	r.statusMgr.joinedVMCount = nodeCount

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -71,7 +71,7 @@ func (tc *testContext) createWMC(replicas int, keyPair string) (*operator.Window
 		Spec: operator.WindowsMachineConfigSpec{
 			InstanceType: instanceType,
 			AWS:          &operator.AWS{CredentialAccountID: credentialAccountID, SSHKeyPair: keyPair},
-			Replicas:     int32(replicas),
+			Replicas:     replicas,
 		},
 	}
 	return wmco, framework.Global.Client.Create(context.TODO(), wmco,

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -37,7 +37,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 	// Reset the number of nodes to be deleted to 0
 	gc.numberOfNodes = 0
 	// Delete the Windows VM that got created.
-	wmco.Spec.Replicas = int32(gc.numberOfNodes)
+	wmco.Spec.Replicas = gc.numberOfNodes
 	if err := framework.Global.Client.Update(context.TODO(), wmco); err != nil {
 		t.Fatalf("error updating wcmo custom resource  %v", err)
 	}

--- a/test/e2e/status_test.go
+++ b/test/e2e/status_test.go
@@ -35,7 +35,7 @@ func testStatusWhenSuccessful(t *testing.T) {
 		Namespace: testCtx.namespace}, wmc)
 	require.NoError(t, err, "Could not retrieve instance of WMC")
 
-	assert.Equal(t, wmc.Spec.Replicas, int32(wmc.Status.JoinedVMCount), "Num of nodes in status not equal to spec")
+	assert.Equal(t, wmc.Spec.Replicas, wmc.Status.JoinedVMCount, "Num of nodes in status not equal to spec")
 
 	degraded := wmc.Status.GetWindowsMachineConfigCondition(operator.Degraded)
 	require.NotNil(t, degraded)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -284,7 +284,7 @@ func createWindowsMachineConfig(namespace string, isReplicasFieldRequired bool, 
 		},
 	}
 	if isReplicasFieldRequired {
-		wmc.Spec.Replicas = int32(replicasFieldValue)
+		wmc.Spec.Replicas = replicasFieldValue
 	}
 	return wmc
 }


### PR DESCRIPTION
revert the changes brought in https://github.com/openshift/windows-machine-config-operator/pull/53/ as the change didn't really fix Bug 1835166

the bug was fixed as a part of upgrading to operator-sdk v0.18