### PR TITLE
Make WMCO run on hostNetwork

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -127,6 +127,7 @@ spec:
                 - mountPath: /etc/private-key/
                   name: cloud-private-key
                   readOnly: true
+              hostNetwork: true
               serviceAccountName: windows-machine-config-operator
               volumes:
               - name: cloud-credentials
@@ -191,6 +192,14 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - hostnetwork
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         serviceAccountName: windows-machine-config-operator
     strategy: deployment
   installModes:

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -67,17 +67,24 @@ spec:
           - list
           - update
         - apiGroups:
-            - certificates.k8s.io
-          resources:
-            - signers
-          verbs:
-            - approve
-        - apiGroups:
           - operator.openshift.io
           resources:
           - networks
           verbs:
           - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - signers
+          verbs:
+          - approve
         serviceAccountName: windows-machine-config-operator
       deployments:
       - name: windows-machine-config-operator
@@ -171,13 +178,6 @@ spec:
           - deployments/finalizers
           verbs:
           - update
-        - apiGroups:
-            - ""
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
         - apiGroups:
           - apps
           resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         name: windows-machine-config-operator
     spec:
+      hostNetwork: true
       serviceAccountName: windows-machine-config-operator
       volumes:
       # TODO: Remove the cloud-credentials and cloud-private-key volumes as part of

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -61,6 +61,15 @@ rules:
   - '*'
   verbs:
   - '*'
+# Permissions to access hostnetwork SCC
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostnetwork
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200422081840-fdd1b0c14c88 // OpenShift 4.5
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 // OpenShift 4.5
+	github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer => github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200619143322-727c39ac62ac // Pinned WNI to version before SSH connection failing
 	k8s.io/api => k8s.io/api v0.18.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -727,8 +727,8 @@ github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 h1:LvJxSt/lnLT
 github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70/go.mod h1:HeCrq1LSOBgHAUpINH4IgBLkt2U/NBwE5sq4JJgcl2Y=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200619015040-0288e17404c0 h1:y27NdWhVduDta+Jv673G5MEUK5lzolyAK7LciCySJ0s=
-github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200619015040-0288e17404c0/go.mod h1:XWbD38xHnqMWtKV4PaOAFqebhXFp3bJTWAtwt1FtmAg=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200619143322-727c39ac62ac h1:nmCJeW33hhPpt4+VNzhPQUCO2m0sHOkwJJXjuJpmD/A=
+github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer v0.0.0-20200619143322-727c39ac62ac/go.mod h1:XWbD38xHnqMWtKV4PaOAFqebhXFp3bJTWAtwt1FtmAg=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/controller/windowsmachineconfig/tracker.go
+++ b/pkg/controller/windowsmachineconfig/tracker.go
@@ -99,10 +99,7 @@ func getNodeIP(nodeList *v1.NodeList, instanceID string) (string, error) {
 		}
 		if strings.Contains(node.Spec.ProviderID, instanceID) {
 			for _, address := range node.Status.Addresses {
-				// If external ip exists return it as it is used in AWS, if it doesn't return internal(in case of azure)
-				// TODO: collect all the ips and define a priority order, external then internal etc.
-				// https://issues.redhat.com/browse/WINC-355?focusedCommentId=14100301&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14100301
-				if address.Type == v1.NodeExternalIP && len(address.Address) > 0 {
+				if address.Type == v1.NodeInternalIP && len(address.Address) > 0 {
 					return address.Address, nil
 				}
 			}

--- a/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
+++ b/pkg/controller/windowsmachineconfig/windowsmachineconfig_controller.go
@@ -3,6 +3,7 @@ package windowsmachineconfig
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/cloudprovider"
 	"github.com/openshift/windows-machine-config-bootstrapper/tools/windows-node-installer/pkg/types"
 	wmcapi "github.com/openshift/windows-machine-config-operator/pkg/apis/wmc/v1alpha1"
@@ -315,7 +316,7 @@ func (r *ReconcileWindowsMachineConfig) removeWorkerNodes(count int) (int, []Rec
 func (r *ReconcileWindowsMachineConfig) addWorkerNode() (types.WindowsVM, ReconcileError) {
 	// Create Windows VM in the cloud provider
 	log.V(1).Info("creating a Windows VM")
-	vm, err := r.cloudProvider.CreateWindowsVM()
+	vm, err := r.cloudProvider.CreateWindowsVMWithPrivateSubnet()
 	if err != nil {
 		return nil, newReconcileError(wmcapi.VMCreationFailureReason, errors.Wrap(err, "error creating windows VM"))
 	}


### PR DESCRIPTION
As of now, WMCO runs on pod network. This PR ensures that WMCO runs on
hostNetwork. This is a step towards making WMCO use machine api.
The advantage of running WMCO on hostNetwork includes not having a public IP
for the Windows VM created. This relies on
openshift/windows-machine-config-bootstrapper#214

The master branch of WNI is having issues while setting up SSH client. So pinning WNI in go.mod to
https://github.com/openshift/windows-machine-config-bootstrapper/commit/727c39ac62ac0b7622029f3ffc0eccbbb44e5693
