### PR TITLE
[ci] Remove kubeconfig secret

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -108,7 +108,6 @@ cd $WMCO_ROOT
 oc create -f deploy/namespace.yaml
 oc create secret generic cloud-credentials --from-file=credentials=$AWS_SHARED_CREDENTIALS_FILE -n windows-machine-config-operator
 oc create secret generic cloud-private-key --from-file=private-key.pem=$KUBE_SSH_KEY_PATH -n windows-machine-config-operator
-oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG -n windows-machine-config-operator
 
 # Run the operator in the windows-machine-config-operator namespace
 OSDK_WMCO_management run $OSDK $MANIFEST_LOC


### PR DESCRIPTION
This commit ensures that KUBECONFIG secret is not created
in the hack script used for running e2e tests in CI. We removed
relying on the kubeconfig secret in
#66