### PR TITLE
[wmco] Add user-agent for ignition url

### DIFF
--- a/pkg/controller/windowsmachineconfig/windows/windows.go
+++ b/pkg/controller/windowsmachineconfig/windows/windows.go
@@ -155,9 +155,11 @@ func (vm *windows) runBootstrapper() error {
 
 // initializeTestBootstrapperFiles initializes the files required for initialize-kubelet
 func (vm *windows) initializeBootstrapperFiles() error {
+	// The 0.35.0 maps to ignition spec v2. This should be modified when we switch to v3
+	ignitionUserAgentSpec := "Ignition/0.35.0"
 	// Download the worker ignition to C:\Windows\Temp\ using the script that ignores the server cert
 	ignitionFileDownloadCmd := wgetIgnoreCertCmd + " -server " + vm.workerIgnitionEndpoint + " -output " +
-		winTemp + "worker.ign"
+		winTemp + "worker.ign" + " -useragent " + ignitionUserAgentSpec
 	out, err := vm.RunOverSSH(ignitionFileDownloadCmd, true)
 	log.V(1).Info("ignition file download", "cmd", ignitionFileDownloadCmd, "output", out)
 	if err != nil {

--- a/pkg/internal/wget-ignore-cert.ps1
+++ b/pkg/internal/wget-ignore-cert.ps1
@@ -1,7 +1,8 @@
 # Script that downloads a file from the server to the output location ignoring the server certificate
 param (
     [Parameter(Mandatory=$true)][string]$server,
-    [Parameter(Mandatory=$true)][string]$output
+    [Parameter(Mandatory=$true)][string]$output,
+    [Parameter(Mandatory=$true)][string]$useragent
 )
 
 # Prevent the progress meter from accessing the console.
@@ -28,4 +29,4 @@ public static class Dummy {
 
 # $null is needed to prevent wget from attempting read the standard input or
 # output streams when attached to the console.
-$null | wget $server -o $output > $null
+$null | wget -UserAgent $useragent $server -o $output > $null


### PR DESCRIPTION
The MCO team have started moving to ignition v3 spec in MCS. For 4.6 timeframe,
they are supporting both v2 and v3. As a result, MCS now requires user-agent
in the header to tell which version of ignition spec to be served by MCS.
This PR modifies the powershell script to include a new parameter for the
user-agent header

https://issues.redhat.com/browse/WINC-457