### PR TITLE
[ci] Fix flakiness of Windows webserver deployment

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -125,6 +125,9 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2) (string, error) {
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
 	// The ami's will have the name format: Windows_Server-2019-English-Full-ContainersLatest-2020.01.15
 	// so the question marks will match the date of creation
+	// The image obtained by using windowsAMIFilterValue is compatible with  the test container image -
+	// "mcr.microsoft.com/powershell:lts-nanoserver-1809". If the windowsAMIFilterValue changes,
+	// the test container image also needs to be changed.
 	windowsAMIFilterValue := "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	searchFilter := ec2.Filter{Name: &windowsAMIFilterName, Values: []*string{&windowsAMIFilterValue}}
 


### PR DESCRIPTION
This PR makes following changes to e2e tests:

- `retryInterval` is increased while pulling the Windows image for the first time in e2e tests

- To reduce the total duration of the tests, Windows NanoServer is introduced instead of using 
Windows ServerCore.