### PR TITLE
[wmco] add version sub-command

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,6 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
+source $WMCO_ROOT/hack/common.sh
+
 OUTPUT_DIR=${1:-}
 if [[ -z "$OUTPUT_DIR" ]]; then
     echo "usage: $0 OUTPUT_DIR"
@@ -14,6 +17,8 @@ MAIN_PACKAGE="${PACKAGE}/cmd/manager"
 BIN_NAME="windows-machine-config-operator"
 BIN_DIR="${OUTPUT_DIR}/bin"
 
+VERSION=$(get_version)
+
 echo "building ${BIN_NAME}..."
 mkdir -p "${BIN_DIR}"
 
@@ -24,4 +29,4 @@ goflags=${GOFLAGS:-}
 if [[ "$goflags" == *"-mod=vendor"* ]]; then
   unset GOFLAGS
 fi
-CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -o ${BIN_DIR}/${BIN_NAME} ${MAIN_PACKAGE}
+CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}'" -o ${BIN_DIR}/${BIN_NAME} ${MAIN_PACKAGE}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -85,3 +85,16 @@ cleanup_WMCO() {
   OSDK_WMCO_management cleanup $OSDK
   oc delete -f deploy/namespace.yaml
 }
+
+# returns the operator version in `Version+GitHash` format
+get_version() {
+  OPERATOR_VERSION=0.0.1
+  GIT_COMMIT=$(git rev-parse --short HEAD)
+  VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
+
+  if [ -n "$(git status --porcelain)" ]; then
+    VERSION="${VERSION}-dirty"
+  fi
+
+  echo $VERSION
+}

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -47,6 +47,7 @@ source $WMCO_ROOT/hack/common.sh
 
 cd $WMCO_ROOT
 OSDK=$(get_operator_sdk)
+VERSION=$(get_version)
 
 # Builds the container image and pushes it to remote repository. Uses this built image to run the operator on the cluster.
 # It is user's responsibility to clean old/unused containers in container repository as well as local system.
@@ -56,7 +57,8 @@ case "$ACTION" in
       error-exit "OPERATOR_IMAGE not set"
   fi
 
-  $OSDK build "$OPERATOR_IMAGE" --image-builder $CONTAINER_TOOL $noCache
+  $OSDK build "$OPERATOR_IMAGE" --image-builder $CONTAINER_TOOL $noCache \
+    --go-build-args "-ldflags -X=github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}"
   if [ $? -ne 0 ] ; then
       error-exit "failed to build operator image"
   fi

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,28 @@
 package version
 
-var (
-	Version = "0.0.1"
+import (
+	"fmt"
+	"runtime"
+
+	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("version")
+
+var (
+	Version   = "" // version will be replaced while building the binary using ldflags
+	GoVersion = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+)
+
+// Print() logs the operator version and related information
+func Print() {
+	log.Info("operator", "version", Version)
+	log.Info("go", "version", GoVersion)
+	log.Info("operator-sdk", "version", sdkVersion.Version)
+}
+
+// Get() returns the operator version
+func Get() string {
+	return Version
+}


### PR DESCRIPTION
this PR shifts all version related code to `version.go`

also, adds version sub-command as a CLI option to indicate what
version of the operator is being used.