### PR TITLE
WIP: [wmco] Disable kube version check

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -319,7 +319,8 @@ func (c *clusterConfig) validateK8sVersion() error {
 func (c *clusterConfig) validate() error {
 	err := c.validateK8sVersion()
 	if err != nil {
-		return errors.Wrap(err, "error validating k8s version")
+		// Temporarily just log this error until https://bugzilla.redhat.com/show_bug.cgi?id=1859614 is fixed
+		log.Error(err, "error validating k8s version")
 	}
 	if err = c.network.Validate(); err != nil {
 		return errors.Wrap(err, "error validating network configuration")


### PR DESCRIPTION
Temporarily disable kube version check until [BZ 1859614](https://bugzilla.redhat.com/show_bug.cgi?id=1859614) is fixed.