### PR TITLE
[e2e] Fail on creation test failure

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -49,7 +49,7 @@ OSDK_WMCO_management() {
 # and prepares the cluster to run the operator and runs the operator on the cluster using OLM
 # Parameters:
 # 1: path to the operator-sdk binary to use
-run_WMCO(){
+run_WMCO() {
   local OSDK=$1
 
   # Create a temporary directory to hold the edited manifests which will be removed on exit
@@ -71,6 +71,11 @@ run_WMCO(){
 
   # Run the operator in the windows-machine-config-operator namespace
   OSDK_WMCO_management run $OSDK $MANIFEST_LOC
+
+  # Additional guard that ensures that operator was deployed given the SDK flakes in error reporting
+  if ! oc rollout status deployment windows-machine-config-operator -n windows-machine-config-operator --timeout=5s; then
+    return 1
+  fi
 }
 
 # Cleans up the installation of operator from the cluster and deletes the namespace

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -13,7 +13,7 @@ KEY_PAIR_NAME=""
 export CGO_ENABLED=0
 
 get_WMCO_logs() {
-  oc logs -l name=windows-machine-config-operator -n windows-machine-config-operator
+  oc logs -l name=windows-machine-config-operator -n windows-machine-config-operator --tail=-1
 }
 
 # This function runs operator-sdk test with certain go test arguments
@@ -74,7 +74,12 @@ KEY_PAIR_NAME=${KEY_PAIR_NAME:-"openshift-dev"}
 OPERATOR_IMAGE=${OPERATOR_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//stable:windows-machine-config-operator-test}}
 
 # Setup and run the operator
-run_WMCO $OSDK
+if ! run_WMCO $OSDK; then
+  # Try to get the WMCO logs if possible
+  get_WMCO_logs
+  cleanup_WMCO $OSDK
+  exit 1
+fi
 
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -23,7 +23,10 @@ func creationTestSuite(t *testing.T) {
 	// are the secrets but they are created only after the VMs have been fully configured.
 	// Any node object related tests should be run only after testNodeCreation as that initializes the node objects in
 	// the global context.
-	t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t) })
+	if !t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t) }) {
+		// No point in running the other tests if creation failed
+		return
+	}
 	t.Run("Network validation", testNetwork)
 	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
 	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })


### PR DESCRIPTION
- Don't proceed if the creation test fails
- Add additional guard that checks that the operator is running
- Update get_WMCO_logs with --tail=-1 to ensure we get all logs