### PR TITLE
[wmco] Save Windows component logs to C:\\var\\log

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -64,6 +64,14 @@ NODE_COUNT=${NODE_COUNT:-2}
 SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"-skip-node-deletion=false"}
 KEY_PAIR_NAME=${KEY_PAIR_NAME:-"openshift-dev"}
 
+# If ARTIFACT_DIR is not set, create a temp directory for artifacts
+ARTIFACT_DIR=${ARTIFACT_DIR:-}
+if [ -z "$ARTIFACT_DIR" ]; then
+  ARTIFACT_DIR=`mktemp -d`
+  echo "ARTIFACT_DIR is not set. Artifacts will be stored in: $ARTIFACT_DIR"
+  export ARTIFACT_DIR=$ARTIFACT_DIR
+fi
+
 # OPERATOR_IMAGE defines where the WMCO image to test with is located. If $OPERATOR_IMAGE is already set, use its value.
 # Setting $OPERATOR_IMAGE is required for local testing.
 # In OpenShift CI $IMAGE_FORMAT will be set to a value such as registry.svc.ci.openshift.org/ci-op-<input-hash>/stable:${component}

--- a/pkg/controller/windowsmachine/windows/windows.go
+++ b/pkg/controller/windowsmachine/windows/windows.go
@@ -27,9 +27,11 @@ const (
 	// k8sDir is the remote kubernetes executable directory
 	k8sDir = "C:\\k\\"
 	// logDir is the remote kubernetes log directory
-	logDir = k8sDir + "log\\"
+	logDir = "C:\\var\\log\\"
 	// kubeProxyLogDir is the remote kube-proxy log directory
 	kubeProxyLogDir = logDir + "kube-proxy\\"
+	// hybridOverlayLogDir is the remote hybrid-overlay log directory
+	hybridOverlayLogDir = logDir + "hybrid-overlay\\"
 	// kubeProxyPath is the location of the kube-proxy exe
 	kubeProxyPath = k8sDir + "kube-proxy.exe"
 	// HybridOverlayProcess is the process name of the hybrid-overlay-node.exe in the Windows VM
@@ -170,7 +172,7 @@ func (vm *windows) ConfigureHybridOverlay(nodeName string) error {
 	// Start the hybrid-overlay in the background over ssh.
 	// TODO: This will be removed in https://issues.redhat.com/browse/WINC-353
 	go vm.Run(remoteDir+wkl.HybridOverlayName+" --node "+nodeName+
-		" --k8s-kubeconfig c:\\k\\kubeconfig > "+logDir+"hybrid-overlay.log 2>&1", false)
+		" --k8s-kubeconfig c:\\k\\kubeconfig --logfile="+hybridOverlayLogDir+"hybrid-overlay.log", false)
 
 	if err = vm.waitForHybridOverlayToRun(); err != nil {
 		return errors.Wrapf(err, "error running %s", wkl.HybridOverlayName)
@@ -244,6 +246,7 @@ func (vm *windows) createDirectories() error {
 		cniDir,
 		logDir,
 		kubeProxyLogDir,
+		hybridOverlayLogDir,
 	}
 	for _, dir := range directoriesToCreate {
 		if _, err := vm.Run(mkdirCmd(dir), false); err != nil {

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -28,6 +28,7 @@ func creationTestSuite(t *testing.T) {
 	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
 	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })
 	t.Run("User Data validation", func(t *testing.T) { testUserData(t) })
+	t.Run("Node Logs", func(t *testing.T) { testNodeLogs(t) })
 }
 
 // testWindowsNodeCreation tests the Windows node creation in the cluster

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testNodeLogs ensures that all required log files were created, and copies them to the test's artifact directory
+// It also tests that 'oc adm node-logs' works with the nodes created by WMCO.
+func testNodeLogs(t *testing.T) {
+	// All these paths are relative to /var/log/
+	logFiles := []string{
+		"kube-proxy/kube-proxy.exe.INFO",
+		"kube-proxy/kube-proxy.exe.ERROR",
+		"kube-proxy/kube-proxy.exe.WARNING",
+		"hybrid-overlay/hybrid-overlay.log",
+		"kubelet/kubelet.log",
+	}
+
+	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
+	for _, node := range gc.nodes {
+		nodeDir := filepath.Join(nodeArtifacts, node.Name)
+		for _, file := range logFiles {
+			// A subtest is useful here to attempt to get all the logs and not bail on the first error
+			t.Run(node.Name+"/"+file, func(t *testing.T) {
+				// Use oc to read the expected log files, using this instead of API calls as we are supporting compatibility
+				// with 'oc adm node-logs', so we should test directly with the oc tool.
+				cmd := exec.Command("oc", "adm", "node-logs", "--path="+file, node.Name)
+				out, err := cmd.Output()
+				require.NoErrorf(t, err, "failed to get file %s from node %s: %s", file, node.Name, out)
+
+				// Save log files to the artifact directory
+				splitPath := strings.Split(file, "/")
+				require.Greater(t, len(splitPath), 1)
+				err = os.MkdirAll(filepath.Join(nodeDir, splitPath[0]), os.ModePerm)
+				require.NoError(t, err, "failed to create log directory")
+				outputFile := filepath.Join(nodeDir, splitPath[0], filepath.Base(file))
+				err = ioutil.WriteFile(outputFile, out, os.ModePerm)
+				// This doesn't actually indicate an error, but because the artifacts are important for debugging issues
+				// lets make sure we know if there's an issue saving them, in a non-ignorable way
+				assert.NoErrorf(t, err, "error writing to %s", outputFile)
+			})
+		}
+	}
+}


### PR DESCRIPTION
This commit changes the log locations of kube-proxy and hybrid-overlay
to C:\\var\\log. This allows the use of `oc adm node-logs`, as log
paths given to the command must be relative to `/var/log`.

This commit also results in the gathering of the Windows node
artifacts in CI.