### PR TITLE
[wmco] Upgrade to kube-node v1.19 RC

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,8 +25,8 @@ RUN microdnf -y update
 # Download, checksum and extract the kubernetes node package
 # We are tightly coupling the operator to the OpenShift version, so with every OpenShift release, we will update the
 # kubernetes node version.
-RUN wget https://dl.k8s.io/v1.18.3/kubernetes-node-windows-amd64.tar.gz
-RUN echo "f83802db06a86edd9ade8e737ed0e8a11ebeeaa69e102f9550b90f0d8a724e7864f6531f7f500ff70d4202168a774c5b328fea1ec0a95b9e275a0233a852f04f kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
+RUN wget https://dl.k8s.io/v1.19.0-rc.2/kubernetes-node-windows-amd64.tar.gz
+RUN echo "61389f8c05c682102e3432a2f05f41b11d531124f61443429627f94ef6e970d44240d44d32aa467b814de0b54a17208b2d2696602ba5dd6d30f64db964900230 kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
 RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
 RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -39,8 +39,8 @@ RUN microdnf -y update
 # Download, checksum and extract the kubernetes node package
 # We are tightly coupling the operator to the OpenShift version, so with every OpenShift release, we will update the
 # kubernetes node version.
-RUN wget https://dl.k8s.io/v1.18.3/kubernetes-node-windows-amd64.tar.gz
-RUN echo "f83802db06a86edd9ade8e737ed0e8a11ebeeaa69e102f9550b90f0d8a724e7864f6531f7f500ff70d4202168a774c5b328fea1ec0a95b9e275a0233a852f04f kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
+RUN wget https://dl.k8s.io/v1.19.0-rc.2/kubernetes-node-windows-amd64.tar.gz
+RUN echo "61389f8c05c682102e3432a2f05f41b11d531124f61443429627f94ef6e970d44240d44d32aa467b814de0b54a17208b2d2696602ba5dd6d30f64db964900230 kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
 RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
 RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,9 +44,9 @@ var (
 var log = logf.Log.WithName("cmd")
 
 const (
-	// baseK8sVersion specfies the base k8s version supported by the operator. (For eg. All versions in the format
-	// 1.18.x are supported for baseK8sVersion 1.18)
-	baseK8sVersion = "1.18"
+	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
+	// 1.19.x are supported for baseK8sVersion 1.18)
+	baseK8sVersion = "1.19"
 )
 
 // clusterConfig contains information specific to cluster configuration

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -35,9 +35,9 @@ func TestIsValidKubernetesVersion(t *testing.T) {
 		version      string
 		errorMessage string
 	}{
-		{"cluster version lower than supported version ", "v1.17.1", "Unsupported server version: v1.17.1. Supported version is v1.18.x"},
-		{"cluster version equals supported version", "v1.18.3", ""},
-		{"cluster version greater than supported version", "v1.19.0", "Unsupported server version: v1.19.0. Supported version is v1.18.x"},
+		{"cluster version lower than supported version ", "v1.17.1", "Unsupported server version: v1.17.1. Supported version is v1.19.x"},
+		{"cluster version equals supported version", "v1.19.0", ""},
+		{"cluster version greater than supported version", "v1.20.0", "Unsupported server version: v1.20.0. Supported version is v1.19.x"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Update the kube-node tarball URL and SHA to v1.19 RC as per the [release changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#v1190-rc2).