### PR TITLE
[wmco] Add WMCO version to Windows node

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ Once the above variables are set, run the following script:
 ```shell script
 hack/run-ci-e2e-test.sh -k "openshift-dev"
 ```
-We assume that the developer uses `openshift-dev` as the key pair in the aws cloud
+We assume that the developer uses `openshift-dev` as the key pair in the aws cloud.
 
 Additional flags that can be passed to `hack/run-ci-e2e-test.sh` are
 - `-s` to skip the deletion of Windows nodes that are created as part of test suite run
 - `-n` to represent the number of Windows nodes to be created for test run
 - `-k` to represent the AWS specific key pair that will be used during e2e run and it should map to the private key
        that we have in `KUBE_SSH_KEY_PATH`. The default value points to `openshift-dev` which we use in our CI
+- `-b` gives an alternative path to the WMCO binary. This option overridden in OpenShift CI.
+       When building the operator locally, the WMCO binary is created as part of the operator image build process and
+       can be found at `build/_output/bin/windows-machine-config-operator`, this is the default value of this option.
+
        
 Example command to spin up 2 Windows nodes and retain them after test run:
 ```

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -9,6 +9,7 @@ source $WMCO_ROOT/hack/common.sh
 NODE_COUNT=""
 SKIP_NODE_DELETION=""
 KEY_PAIR_NAME=""
+WMCO_PATH_OPTION=""
 
 export CGO_ENABLED=0
 
@@ -35,7 +36,7 @@ OSDK_WMCO_test() {
   fi
 }
 
-while getopts ":n:k:s" opt; do
+while getopts ":n:k:b:s" opt; do
   case ${opt} in
     n ) # process option for the node count
       NODE_COUNT=$OPTARG
@@ -46,8 +47,11 @@ while getopts ":n:k:s" opt; do
     s ) # process option for skipping deleting Windows VMs created by test suite
       SKIP_NODE_DELETION="-skip-node-deletion"
       ;;
+    b ) # path to the WMCO binary, used for version validation
+      WMCO_PATH_OPTION="-wmco-path=$OPTARG"
+      ;;
     \? )
-      echo "Usage: $0 [-n] [-k] [-s]"
+      echo "Usage: $0 [-n] [-k] [-s] [-b]"
       exit 0
       ;;
   esac
@@ -92,7 +96,7 @@ fi
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
 # Run the creation tests and skip deletion of the Windows VMs
-OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=90m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME"
+OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=90m -node-count=$NODE_COUNT -skip-node-deletion -ssh-key-pair=$KEY_PAIR_NAME $WMCO_PATH_OPTION"
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -29,6 +29,7 @@ func creationTestSuite(t *testing.T) {
 	}
 	t.Run("Network validation", testNetwork)
 	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
+	t.Run("Version annotation", func(t *testing.T) { testVersionAnnotation(t) })
 	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })
 	t.Run("User Data validation", func(t *testing.T) { testUserData(t) })
 	t.Run("Node Logs", func(t *testing.T) { testNodeLogs(t) })

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -21,6 +21,8 @@ var (
 	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
 	sshKeyPair string
+	// wmcoPath is the path to the WMCO binary that was used within the operator image
+	wmcoPath string
 	// gc is the global context across the test suites.
 	gc = globalContext{}
 )
@@ -90,5 +92,7 @@ func TestMain(m *testing.M) {
 	// We're using openshift-dev as default value to be used in CI
 	flag.StringVar(&sshKeyPair, "ssh-key-pair", "openshift-dev", "SSH Key Pair to be used for decrypting "+
 		"the Windows Node password")
+	flag.StringVar(&wmcoPath, "wmco-path", "./build/_output/bin/windows-machine-config-operator",
+		"Path to the WMCO binary, used for version validation")
 	framework.MainEntry(m)
 }

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -32,6 +33,11 @@ func TestWMCO(t *testing.T) {
 	gc.numberOfNodes = int32(numberOfNodes)
 	gc.skipNodeDeletion = skipNodeDeletion
 	gc.sshKeyPair = sshKeyPair
+	// When the OPENSHIFT_CI env var is set to true, the test is running within CI
+	if inCI := os.Getenv("OPENSHIFT_CI"); inCI == "true" {
+		// In the CI container the WMCO binary will be found here
+		wmcoPath = "/usr/local/bin/windows-machine-config-operator"
+	}
 
 	t.Run("create", creationTestSuite)
 	if !gc.skipNodeDeletion {


### PR DESCRIPTION
This commit adds the version of the WMCO instance that configured each
node to that node's annotations. This will be used in the WMCO upgrade
process, as this allows WMCO to see which nodes were not configured by
the current version.