### PR TITLE
[olm] Add minKubeVersion to CSV

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -200,6 +200,7 @@ spec:
   maintainers:
   - {}
   maturity: alpha
+  minKubeVersion: 1.19.0
   provider:
     name: Red Hat
   version: 0.0.0


### PR DESCRIPTION
This commit adds sets the WMCO CSV minKubeVersion to 1.19.0. This change
prevents WMCO from being deployed on clusters with Kubernetes versions
earlier than 1.19.0.