### PR TITLE
Bug 1860372: [wmco] Remove applying worker label

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,18 @@ Below is the example of an AWS Windows MachineSet which can create Windows Machi
 note that the `windows-user-data` secret will be created by the WMCO lazily when it is configuring the first Windows 
 Machine. After that, the `windows-user-data` will be available for the subsequent MachineSets to be consumed. It might 
 take around 10 minutes for the Windows VM to be configured so that it joins the cluster. Please note that the MachineSet
-should have `machine.openshift.io/os-id: Windows` label, and _\<windows_container_ami\>_ should be replaced with the
-AMI ID of a Windows image with a container run-time installed. _\<infrastructureID\>_ should be replaced with the output
+should have following labels:
+-  `machine.openshift.io/os-id: Windows`
+- ` machine.openshift.io/cluster-api-machine-role: worker` 
+-  `machine.openshift.io/cluster-api-machine-type: worker` 
+
+The following label, needs to be added to the `Machine` spec with the `MachineSet` spec:
+-  `node-role.kubernetes.io/worker: ""`
+
+Not having these labels will result in the Windows node not being marked as a worker.
+
+_\<windows_container_ami\>_ should be replaced with the AMI ID of a Windows image with a container run-time installed. 
+_\<infrastructureID\>_ should be replaced with the output
 of:
 ```shell script
  oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster

--- a/pkg/controller/windowsmachine/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachine/nodeconfig/nodeconfig.go
@@ -132,8 +132,7 @@ func (nc *nodeConfig) Configure() error {
 	if err := nc.setNode(); err != nil {
 		return errors.Wrapf(err, "error getting node object for VM %s", nc.ID())
 	}
-	// Apply labels and annotations to nc.node
-	nc.addWorkerLabel()
+	// Apply version annotation to nc.node
 	nc.addVersionAnnotation()
 	// update node object
 	node, err := nc.k8sclientset.CoreV1().Nodes().Update(context.TODO(), nc.node, metav1.UpdateOptions{})
@@ -188,15 +187,6 @@ func (nc *nodeConfig) configureNetwork() error {
 // addVersionAnnotation adds the version annotation to nc.node
 func (nc *nodeConfig) addVersionAnnotation() {
 	nc.node.Annotations[VersionAnnotation] = version.Get()
-}
-
-// addWorkerLabel adds the worker label to nc.node
-func (nc *nodeConfig) addWorkerLabel() {
-	if _, found := nc.node.Labels[WorkerLabel]; found {
-		log.V(1).Info("worker label %s already present on node %s", WorkerLabel, nc.node.GetName())
-		return
-	}
-	nc.node.Labels[WorkerLabel] = ""
 }
 
 // setNode identifies the node from the instanceID provided and sets the node object in the nodeconfig.

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -28,6 +28,9 @@ func creationTestSuite(t *testing.T) {
 		return
 	}
 	t.Run("Network validation", testNetwork)
+	// The label is not actually added by WMCO however we would like to validate if the Machine Api is properly
+	// adding the worker label, if it was specified in the MachineSet. The MachineSet created in the test suite has
+	// the worker label
 	t.Run("Label validation", func(t *testing.T) { testWorkerLabel(t) })
 	t.Run("Version annotation", func(t *testing.T) { testVersionAnnotation(t) })
 	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -390,6 +390,7 @@ func (a *awsProvider) GenerateMachineSet(withWindowsLabel bool, replicas int32) 
 			Template: mapi.MachineTemplateSpec{
 				ObjectMeta: mapi.ObjectMeta{Labels: machineLabels},
 				Spec: mapi.MachineSpec{
+					ObjectMeta: mapi.ObjectMeta{Labels: map[string]string{"node-role.kubernetes.io/worker": ""}},
 					ProviderSpec: mapi.ProviderSpec{
 						Value: &runtime.RawExtension{
 							Raw: rawBytes,


### PR DESCRIPTION
As of now, WMCO is applying worker label to the node object created. The label
should be specified by the end-user in the MachineSet spec instead of WMCO being
prescriptive and applying the label.

This also solves:
https://bugzilla.redhat.com/show_bug.cgi?id=1860372