### PR TITLE
[wmco] Delete Machines with mismatched version annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,17 @@ spec:
           userDataSecret:
             name: windows-user-data
 ```
+### Windows nodes Kubernetes component upgrade
+
+When a new version of WMCO is released that is compatible with the current cluster version, an operator upgrade will 
+take place which will result in the Kubernetes components in the Windows Machine to be upgraded. For a non-disruptive 
+upgrade, WMCO terminates the Windows Machines configured by previous version of WMCO and recreates them using the
+current version. This is done by deleting the Machine object that results in the drain and deletion of the Windows node.
+To facilitate an upgrade, WMCO adds a version annotation to all the configured nodes. During an upgrade, a mismatch in
+version annotation will result in deletion and recreation of Windows Machine. In order to have minimal service 
+disruption during an upgrade, WMCO makes sure that the cluster will have atleast 1 Windows Machine per MachineSet in the
+running state.
+
+WMCO is not responsible for Windows operating system updates. The cluster administrator provides the Window image while
+creating the VMs and hence, the cluster administrator is responsible for providing an updated image. The cluster 
+administrator can provide an updated image by changing the image in the MachineSet spec.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -152,8 +152,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// watch `openshift-machine-api` namespace along with wmco namespace
-	namespaces := []string{"openshift-machine-api", namespace}
+	// Allow for the watching of cluster-wide resources with "", so that we can watch nodes,
+	// as well as resources within the `openshift-machine-api` and WMCO namespace
+	namespaces := []string{"", "openshift-machine-api", namespace}
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		NewCache:           cache.MultiNamespacedCacheBuilder(namespaces),

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -81,6 +81,15 @@ spec:
           - get
           - list
           - watch
+          - delete
+        - apiGroups:
+          - machine.openshift.io
+          resources:
+          - machinesets
+          verbs:
+          - list
+          - get
+          - watch
         serviceAccountName: windows-machine-config-operator
       deployments:
       - name: windows-machine-config-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -137,3 +137,12 @@ rules:
      - get
      - list
      - watch
+     - delete
+ - apiGroups:
+     - machine.openshift.io
+   resources:
+     - machinesets
+   verbs:
+     - list
+     - get
+     - watch

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -102,17 +102,25 @@ OSDK_WMCO_test $OSDK "-run=TestWMCO/operator_deployed_without_private_key_secret
 
 # Run the creation tests of the Windows VMs
 OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=90m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
+# Get logs for the creation tests
+printf "\n####### WMCO logs for creation tests #######\n"
+get_WMCO_logs
+
+# Run the upgrade tests and skip deletion of the Windows VMs
+OSDK_WMCO_test $OSDK "-run=TestWMCO/upgrade -v -timeout=90m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then
   OSDK_WMCO_test $OSDK "-run=TestWMCO/destroy -v -timeout=60m --private-key-path=$KUBE_SSH_KEY_PATH"
   # Get logs on success before cleanup
+  printf "\n####### WMCO logs for upgrade and deletion tests #######\n"
   get_WMCO_logs
   # Cleanup the operator resources
   cleanup_WMCO $OSDK
 else
   # Get logs on success
+  printf "\n####### WMCO logs for upgrade tests #######\n"
   get_WMCO_logs
 fi
 

--- a/pkg/apis/addtoscheme_mapi_v1beta1.go
+++ b/pkg/apis/addtoscheme_mapi_v1beta1.go
@@ -26,6 +26,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&mapi.Machine{},
 		&mapi.MachineList{},
+		&mapi.MachineSet{},
 	)
 	meta.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -12,6 +12,8 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
 )
 
 func deletionTestSuite(t *testing.T) {
@@ -52,7 +54,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 		t.Fatalf("error updating windowsMachineSet custom resource  %v", err)
 	}
 	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster
-	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, true)
+	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, true, false)
 	if err != nil {
 		t.Fatalf("windows node deletion failed  with %v", err)
 	}
@@ -68,4 +70,8 @@ func testWindowsNodeDeletion(t *testing.T) {
 	// Cleanup secrets created by us.
 	err = framework.Global.KubeClient.CoreV1().Secrets("openshift-machine-api").Delete(context.TODO(), "windows-user-data", meta.DeleteOptions{})
 	require.NoError(t, err, "could not delete userData secret")
+
+	err = framework.Global.KubeClient.CoreV1().Secrets("windows-machine-config-operator").Delete(context.TODO(), secrets.PrivateKeySecret, meta.DeleteOptions{})
+	require.NoError(t, err, "could not delete privateKey secret")
+
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,150 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
+)
+
+const (
+	// deploymentRetryInterval is the retry time for WMCO deployment to scale up/down
+	deploymentRetryInterval = time.Second * 10
+	// deploymentTimeout is the maximum duration to update WMCO deployment
+	deploymentTimeout = time.Minute * 1
+	// resourceName is the name of a resource in the watched namespace (e.g pod name, deployment name)
+	resourceName = "windows-machine-config-operator"
+)
+
+// upgradeTestSuite tests behaviour of the operator when an upgrade takes place.
+func upgradeTestSuite(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	// apply configuration steps before running the upgrade tests
+	err = testCtx.configureUpgradeTest()
+	require.NoError(t, err, "error configuring upgrade")
+
+	t.Run("Operator version upgrade", testUpgradeVersion)
+	t.Run("Version annotation tampering", testTamperAnnotation)
+}
+
+// testUpgradeVersion tests the upgrade scenario of the operator. The node version annotation is changed when
+// the operator is shut-down. The function tests if the operator on restart deletes the machines and recreates
+// them on version annotation mismatch.
+func testUpgradeVersion(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, false, true)
+	require.NoError(t, err, "windows node upgrade failed")
+	// Test if the version annotation corresponds to the current operator version
+	testVersionAnnotation(t)
+}
+
+// testTamperAnnotation tests if the operator deletes machines and recreates them, if the node annotation is changed to an invalid value
+// with the expected annotation when the operator is in running state
+func testTamperAnnotation(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	// tamper node annotation
+	nodes, err := testCtx.kubeclient.CoreV1().Nodes().List(context.TODO(),
+		metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})
+	require.NoError(t, err)
+
+	for _, node := range nodes.Items {
+		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, nc.VersionAnnotation, "badVersion")
+		_, err := testCtx.kubeclient.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+		require.NoError(t, err)
+		if err == nil {
+			break
+		}
+	}
+
+	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, false, true)
+	require.NoError(t, err, "windows node upgrade failed")
+	// Test if the version annotation corresponds to the current operator version
+	testVersionAnnotation(t)
+}
+
+// configureUpgradeTest carries out steps required before running tests for upgrade scenario.
+// The steps include -
+// 1. Scale down the operator to 0.
+// 2. Change Windows node version annotation to an invalid value
+// 3. Scale up the operator to 1
+func (tc *testContext) configureUpgradeTest() error {
+	// Scale down the WMCO deployment to 0
+	if err := tc.scaleWMCODeployment(0); err != nil {
+		return err
+	}
+
+	// Override the Windows Node Version Annotation
+	nodes, err := tc.kubeclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})
+	if err != nil {
+		return err
+	}
+	if len(nodes.Items) != int(gc.numberOfNodes) {
+		return errors.Wrapf(nil, "unexpected number of nodes %v", gc.numberOfNodes)
+	}
+
+	for _, node := range nodes.Items {
+		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, nc.VersionAnnotation, "badVersion")
+		_, err := tc.kubeclient.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+		log.Printf("Node Annotation changed to %v", node.Annotations[nc.VersionAnnotation])
+	}
+
+	// Scale up the WMCO deployment to 1
+	if err := tc.scaleWMCODeployment(1); err != nil {
+		return err
+	}
+	return nil
+}
+
+// scaleWMCODeployment scales the WMCO operator to the given replicas. If the deployment is managed by OLM, updating the
+// replicas only scales the deployment to 0 or 1. If we want to scale the deployment to more than 1 replicas, we need to
+// make changes in replicas defined in the corresponding CSV.
+func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
+	// update the windows-machine-config-operator deployment to the desired replicas - 0 or 1
+	err := wait.Poll(deploymentRetryInterval, deploymentTimeout, func() (done bool, err error) {
+
+		patchData := fmt.Sprintf(`{"spec":{"replicas":%v}}`, desiredReplicas)
+
+		_, err = tc.kubeclient.AppsV1().Deployments(resourceName).Patch(context.TODO(), resourceName,
+			types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+		if err != nil {
+			log.Printf("error patching operator deployment : %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// wait for the windows-machine-config-operator to scale up/down
+	err = wait.Poll(deploymentRetryInterval, deploymentTimeout, func() (done bool, err error) {
+		deployment, err := tc.kubeclient.AppsV1().Deployments(resourceName).Get(context.TODO(), resourceName,
+			metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error getting operator deployment: %v", err)
+			return false, nil
+		}
+		return deployment.Status.ReadyReplicas == desiredReplicas, nil
+	})
+
+	return err
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	nodeCreationTime     = time.Minute * 20
+	nodeCreationTime     = time.Minute * 30
 	nodeRetryInterval    = time.Minute * 1
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
@@ -46,8 +46,8 @@ func TestWMCO(t *testing.T) {
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
+	t.Run("upgrade", upgradeTestSuite)
 	t.Run("destroy", deletionTestSuite)
-
 }
 
 // setupWMCO setups the resources needed to run WMCO tests


### PR DESCRIPTION
This PR makes sure that machine controller handles changes in version
annotation on Windows nodes. The version annotation can be changed in the following scenarios -

- During upgrade process, where `operatorVersion` would not match with the version used in the annotation
- When node annotation is tampered by an user

The controller makes sure to delete the machines and subsequently the nodes, when annotation is mismatched and the number of nodes after deletion are greater than the predetermined `minHealthyCount`

This PR also increases the value of `nodeCreation` in the e2e tests, to take into consideration time required to delete the node and recreate it.
