### PR TITLE
Use downstream kubernetes node binaries

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,34 +1,46 @@
-# build stage for building binaries
-FROM golang:1.13.8 as build
+# We cannot use a golang image as building the kubelet requires rsync and that is not present plus there is no easy way
+# to install it.
+FROM registry.access.redhat.com/ubi8/ubi-minimal as build
 LABEL stage=build
+RUN microdnf -y install rsync make git tar findutils diffutils
+RUN mkdir /build/
+
+# Install go 1.14
+RUN mkdir /build/go
+WORKDIR /build/go
+RUN curl https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -L -o go.tar.gz
+# Check sha256
+RUN echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go.tar.gz" |sha256sum -c
+RUN tar -C /usr/local -xzf go.tar.gz
+ENV PATH=${PATH}:/usr/local/go/bin
 
 # Build WMCB
-RUN mkdir /build/
 WORKDIR /build/
-RUN git clone https://github.com/openshift/windows-machine-config-bootstrapper.git
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/windows-machine-config-bootstrapper.git
 WORKDIR windows-machine-config-bootstrapper
 RUN make build
 
 # Build hybrid-overlay
 WORKDIR /build/
-RUN git clone https://github.com/openshift/ovn-kubernetes/
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/ovn-kubernetes/
 WORKDIR ovn-kubernetes/go-controller/
 RUN make windows
+
+# Build Kubernetes node binaries
+WORKDIR /build/
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/kubernetes
+WORKDIR /build/kubernetes
+ENV KUBE_BUILD_PLATFORMS windows/amd64
+RUN make WHAT=cmd/kubelet
+RUN make WHAT=cmd/kube-proxy
 
 # download stage for downloading packages
 FROM registry.access.redhat.com/ubi8/ubi-minimal as download
 LABEL stage=download
+RUN mkdir /download/
 WORKDIR /download/
 RUN microdnf -y install wget tar gzip
 RUN microdnf -y update
-
-# Download, checksum and extract the kubernetes node package
-# We are tightly coupling the operator to the OpenShift version, so with every OpenShift release, we will update the
-# kubernetes node version.
-RUN wget https://dl.k8s.io/v1.19.0-rc.2/kubernetes-node-windows-amd64.tar.gz
-RUN echo "61389f8c05c682102e3432a2f05f41b11d531124f61443429627f94ef6e970d44240d44d32aa467b814de0b54a17208b2d2696602ba5dd6d30f64db964900230 kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
-RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
-RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 
 # Download, checksum and extract the CNI plugin package
 RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz
@@ -59,6 +71,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL stage=operator
 
 # Copy wmcb.exe
+RUN mkdir /payload/
 WORKDIR /payload/
 COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 
@@ -66,11 +79,13 @@ COPY --from=build /build/windows-machine-config-bootstrapper/wmcb.exe .
 COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
 
 # Copy kubelet.exe and kube-proxy.exe
+RUN mkdir /payload/kube-node/
 WORKDIR /payload/kube-node/
-COPY --from=download /download/kubernetes/node/bin/kubelet.exe .
-COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
+COPY --from=build /build/kubernetes/_output/local/bin/windows/amd64/kubelet.exe .
+COPY --from=build /build/kubernetes/_output/local/bin/windows/amd64/kube-proxy.exe .
 
 # Copy CNI plugin binaries and CNI config template cni-conf-template.json
+RUN mkdir /payload/cni/
 WORKDIR /payload/cni/
 COPY --from=download /download/cni/flannel.exe .
 COPY --from=download /download/cni/host-local.exe .

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -4,22 +4,42 @@
 # NOTE: RUN mkdir <dir> is being used in cases where a directory needs to be created as CI image builds does not seem to
 # be creating the directory as a result of the WORKDIR directive. 
 # build stage for building binaries
-FROM golang:1.13.8 as build
+
+# We cannot use a golang image as building the kubelet requires rsync and that is not present plus there is no easy way
+# to install it.
+FROM registry.access.redhat.com/ubi8/ubi-minimal as build
 LABEL stage=build
+RUN microdnf -y install rsync make git tar findutils diffutils
+RUN mkdir /build/
+
+# Install go 1.14
+RUN mkdir /build/go
+WORKDIR /build/go
+RUN curl https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -L -o go.tar.gz
+# Check sha256
+RUN echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go.tar.gz" |sha256sum -c
+RUN tar -C /usr/local -xzf go.tar.gz
+ENV PATH=${PATH}:/usr/local/go/bin
 
 # Build WMCB
-RUN mkdir /build/
 WORKDIR /build/
-# Pin this to a release branch once branching has ocurred and master is no longer fast forwarded.
-RUN git clone https://github.com/openshift/windows-machine-config-bootstrapper.git
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/windows-machine-config-bootstrapper.git
 WORKDIR windows-machine-config-bootstrapper
 RUN make build
 
 # Build hybrid-overlay
 WORKDIR /build/
-RUN git clone https://github.com/openshift/ovn-kubernetes/
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/ovn-kubernetes/
 WORKDIR ovn-kubernetes/go-controller/
 RUN make windows
+
+# Build Kubernetes node binaries
+WORKDIR /build/
+RUN git clone --single-branch --branch release-4.6 https://github.com/openshift/kubernetes
+WORKDIR /build/kubernetes
+ENV KUBE_BUILD_PLATFORMS windows/amd64
+RUN make WHAT=cmd/kubelet
+RUN make WHAT=cmd/kube-proxy
 
 # Build WMCO
 # The source here corresponds to the code in the PR and is placed here by the CI infrastructure.
@@ -35,14 +55,6 @@ RUN mkdir /download/
 WORKDIR /download/
 RUN microdnf -y install wget tar gzip
 RUN microdnf -y update
-
-# Download, checksum and extract the kubernetes node package
-# We are tightly coupling the operator to the OpenShift version, so with every OpenShift release, we will update the
-# kubernetes node version.
-RUN wget https://dl.k8s.io/v1.19.0-rc.2/kubernetes-node-windows-amd64.tar.gz
-RUN echo "61389f8c05c682102e3432a2f05f41b11d531124f61443429627f94ef6e970d44240d44d32aa467b814de0b54a17208b2d2696602ba5dd6d30f64db964900230 kubernetes-node-windows-amd64.tar.gz" > kubernetes-node-windows-amd64.tar.gz.sha512
-RUN sha512sum -c kubernetes-node-windows-amd64.tar.gz.sha512
-RUN tar -zxf kubernetes-node-windows-amd64.tar.gz
 
 # Download, checksum and extract the CNI plugin package
 RUN wget https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-windows-amd64-v0.8.6.tgz
@@ -83,8 +95,8 @@ COPY --from=build /build/ovn-kubernetes/go-controller/_output/go/bin/windows/hyb
 # Copy kubelet.exe and kube-proxy.exe
 RUN mkdir /payload/kube-node/
 WORKDIR /payload/kube-node/
-COPY --from=download /download/kubernetes/node/bin/kubelet.exe .
-COPY --from=download /download/kubernetes/node/bin/kube-proxy.exe .
+COPY --from=build /build/kubernetes/_output/local/bin/windows/amd64/kubelet.exe .
+COPY --from=build /build/kubernetes/_output/local/bin/windows/amd64/kube-proxy.exe .
 
 # Copy CNI plugin binaries and CNI config template cni-conf-template.json
 RUN mkdir /payload/cni/
@@ -110,16 +122,19 @@ ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
 # Changes needed for our CI
 
 # install make package
-RUN microdnf -y install make tar.x86_64 gzip.x86_64 wget.x86_64
+RUN microdnf -y install make tar gzip wget
 RUN microdnf -y update
 
-# Download and install Go. We need
-RUN curl -L -s https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz > go1.13.8.linux-amd64.tar.gz \
-    && sha256sum go1.13.8.linux-amd64.tar.gz \
-    && echo "0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8  go1.13.8.linux-amd64.tar.gz" | sha256sum -c \
-    && tar -xzf go1.13.8.linux-amd64.tar.gz \
-    && mv go /usr/local \
-    && rm -rf ./go*
+# Copy go from build stage, install within this stage
+COPY --from=build /build/go/go.tar.gz .
+RUN tar -C /usr/local -xzf go.tar.gz && rm go.tar.gz
+ENV PATH=${PATH}:/usr/local/go/bin
+# Allow building binaries and creation of /go/.cache directory by the hack script
+RUN go version
+RUN mkdir /go
+RUN chmod -R g=u+w /go
+ENV GOPATH="/go"
+ENV GOCACHE="/go/.cache"
 
 # Download and install oc
 RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.4.6/openshift-client-linux-4.4.6.tar.gz -o openshift-origin-client-tools.tar.gz \
@@ -134,13 +149,6 @@ RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.4.6/o
 RUN mkdir -p /go/src/github.com/openshift/windows-machine-config-operator/
 WORKDIR /go/src/github.com/openshift/windows-machine-config-operator/
 COPY --from=build /build/windows-machine-config-operator .
-
-# Allow building binaries and creation of /go/.cache directory by the hack script
-RUN chmod -R g=u+w /go
-
-ENV PATH="${PATH}:/usr/local/go/bin"
-ENV GOPATH="/go"
-ENV GOCACHE="/go/.cache"
 
 # install operator binary
 COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-machine-config-operator ${OPERATOR}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.13
+go 1.14
 
 replace github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helm
 

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.13') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.14') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -65,6 +65,8 @@ type testContext struct {
 	providers.CloudProvider
 	// hasCustomVXLAN tells if the cluster is using a custom VXLAN port for communication
 	hasCustomVXLAN bool
+	// workloadNamespace is the namespace to deploy our test pods on
+	workloadNamespace string
 }
 
 // NewTestContext returns a new test context to be used by every test.
@@ -89,7 +91,7 @@ func NewTestContext(t *testing.T) (*testContext, error) {
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{osdkTestCtx: fmwkTestContext, kubeclient: framework.Global.KubeClient,
 		timeout: retry.Timeout, retryInterval: retry.Interval, namespace: namespace, CloudProvider: cloudProvider,
-		hasCustomVXLAN: hasCustomVXLANPort}, nil
+		hasCustomVXLAN: hasCustomVXLANPort, workloadNamespace: "wmco-test"}, nil
 }
 
 // cleanup cleans up the test context

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,6 +12,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.5.0
 github.com/Azure/go-autorest/tracing
 # github.com/aws/aws-sdk-go v1.25.48
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
@@ -135,10 +136,12 @@ github.com/modern-go/reflect2
 github.com/onsi/gomega/gstruct/errors
 github.com/onsi/gomega/types
 # github.com/openshift/api v0.0.0-20200728200559-811027b63048 => github.com/openshift/api v0.0.0-20200803131051-87466835fcc0
+## explicit
 github.com/openshift/api/config/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operator/v1alpha1
 # github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 => github.com/openshift/client-go v0.0.0-20200729195840-c2b1adc6bed6
+## explicit
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/fake
 github.com/openshift/client-go/config/clientset/versioned/scheme
@@ -152,6 +155,7 @@ github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1/fa
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alpha1
 github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1alpha1/fake
 # github.com/openshift/machine-api-operator v0.2.1-0.20200520080344-fe76daf636f4
+## explicit
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
 # github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2
@@ -162,6 +166,7 @@ github.com/operator-framework/operator-registry/pkg/api
 github.com/operator-framework/operator-registry/pkg/image
 github.com/operator-framework/operator-registry/pkg/registry
 # github.com/operator-framework/operator-sdk v0.18.1
+## explicit
 github.com/operator-framework/operator-sdk/internal/scaffold
 github.com/operator-framework/operator-sdk/internal/scaffold/input
 github.com/operator-framework/operator-sdk/internal/scaffold/internal/deps
@@ -179,8 +184,10 @@ github.com/operator-framework/operator-sdk/version
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pkg/sftp v1.11.0
+## explicit
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -210,8 +217,10 @@ github.com/spf13/afero/mem
 # github.com/spf13/cobra v1.0.0
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # go.uber.org/atomic v1.6.0
@@ -226,6 +235,7 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+## explicit
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/curve25519
@@ -252,6 +262,7 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
@@ -335,6 +346,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2
 # k8s.io/api v0.19.0-rc.2 => k8s.io/api v0.18.2
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -382,6 +394,7 @@ k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 # k8s.io/apimachinery v0.19.0-rc.2 => k8s.io/apimachinery v0.18.2
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -429,6 +442,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.18.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached
 k8s.io/client-go/discovery/cached/memory
@@ -523,13 +537,16 @@ k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-state-metrics/pkg/metric
 k8s.io/kube-state-metrics/pkg/metrics_store
 # k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200520125206-5e266b553d8e
+## explicit
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1
 # sigs.k8s.io/controller-runtime v0.6.0
+## explicit
 sigs.k8s.io/controller-runtime/pkg/cache
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
@@ -567,3 +584,33 @@ sigs.k8s.io/kubebuilder/pkg/model/config
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+# github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
+# github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
+# github.com/go-logr/logr => github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6
+# github.com/go-logr/zapr => github.com/go-logr/zapr v0.2.0
+# github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20200803131051-87466835fcc0
+# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200729195840-c2b1adc6bed6
+# k8s.io/api => k8s.io/api v0.18.2
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
+# k8s.io/apimachinery => k8s.io/apimachinery v0.18.2
+# k8s.io/apiserver => k8s.io/apiserver v0.18.2
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.2
+# k8s.io/client-go => k8s.io/client-go v0.18.2
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.2
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.2
+# k8s.io/code-generator => k8s.io/code-generator v0.18.2
+# k8s.io/component-base => k8s.io/component-base v0.18.2
+# k8s.io/cri-api => k8s.io/cri-api v0.18.2
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.2
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.2
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
+# k8s.io/kubectl => k8s.io/kubectl v0.18.2
+# k8s.io/kubelet => k8s.io/kubelet v0.18.2
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2
+# k8s.io/metrics => k8s.io/metrics v0.18.2
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.2
+# sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200520125206-5e266b553d8e


### PR DESCRIPTION
This PR allows for Windows pods to be deployed in non-default namespaces.