### PR TITLE
[wmco] Run hybrid overlay as a Windows service

### DIFF
--- a/pkg/controller/windowsmachine/windows/service.go
+++ b/pkg/controller/windowsmachine/windows/service.go
@@ -1,14 +1,9 @@
 package windows
 
-// service represents a Windows service
-type service interface {
-	Name() string
-	BinaryPath() string
-	Args() string
-}
+import "github.com/pkg/errors"
 
-// kubeProxyService implements the service interface and is specific to the kube-proxy service
-type kubeProxyService struct {
+// service struct contains the service information
+type service struct {
 	// binaryPath is the path to the binary to be ran as a service
 	binaryPath string
 	// name is the name of the service
@@ -17,30 +12,14 @@ type kubeProxyService struct {
 	args string
 }
 
-// newKubeProxyService returns a service interface with a kubeProxyService implementation
-func newKubeProxyService(nodeName, hostSubnet, sourceVIP string) (service, error) {
-	return &kubeProxyService{
-		binaryPath: kubeProxyPath,
-		name:       kubeProxyServiceName,
-		args: "--windows-service --v=4 --proxy-mode=kernelspace --feature-gates=WinOverlay=true " +
-			"--hostname-override=" + nodeName + " --kubeconfig=c:\\k\\kubeconfig " +
-			"--cluster-cidr=" + hostSubnet + " --log-dir=" + kubeProxyLogDir + " --logtostderr=false " +
-			"--network-name=OVNKubernetesHybridOverlayNetwork --source-vip=" + sourceVIP +
-			" --enable-dsr=false",
+// newService initializes and returns a pointer to the service struct
+func newService(binaryPath, name, args string) (*service, error) {
+	if binaryPath == "" || name == "" {
+		return nil, errors.Errorf("can't instantiate a service with incomplete service parameters")
+	}
+	return &service{
+		binaryPath: binaryPath,
+		name:       name,
+		args:       args,
 	}, nil
-}
-
-// Name returns the name of the service
-func (s *kubeProxyService) Name() string {
-	return s.name
-}
-
-// Args returns the arguments that the service will run with
-func (s *kubeProxyService) Args() string {
-	return s.args
-}
-
-// BinaryPath returns the path of the binary that service the service will run
-func (s *kubeProxyService) BinaryPath() string {
-	return s.binaryPath
 }


### PR DESCRIPTION
With the newly introduced feature, we can now run hybrid-overlay-node.exe as a Windows Service. This PR will leverage this functionality to start running hybrid-overlay-node as a Windows Service on the Windows nodes using WMCO.