### PR TITLE
[wmco] Watch cloud-private-key secret

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -129,7 +129,6 @@ func main() {
 		wkl.KubeProxyPath,
 		wkl.IgnoreWgetPowerShellPath,
 		wkl.WmcbPath,
-		wkl.PrivateKeyPath,
 		wkl.CNIConfigTemplatePath,
 		wkl.HNSPSModule,
 	}
@@ -138,6 +137,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// The watched namespace defined by the WMCO CSV
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		log.Error(err, "failed to get watch namespace")
@@ -173,7 +173,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr, clusterconfig.network); err != nil {
+	if err := controller.AddToManager(mgr, clusterconfig.network, namespace); err != nil {
 		log.Error(err, "failed to add all Controllers to the Manager")
 		os.Exit(1)
 	}

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -116,16 +116,8 @@ spec:
                 imagePullPolicy: Always
                 name: windows-machine-config-operator
                 resources: {}
-                volumeMounts:
-                - mountPath: /etc/private-key/
-                  name: cloud-private-key
-                  readOnly: true
               hostNetwork: true
               serviceAccountName: windows-machine-config-operator
-              volumes:
-              - name: cloud-private-key
-                secret:
-                  secretName: cloud-private-key
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,10 +14,6 @@ spec:
     spec:
       hostNetwork: true
       serviceAccountName: windows-machine-config-operator
-      volumes:
-      - name: cloud-private-key
-        secret:
-          secretName: cloud-private-key
       containers:
         - name: windows-machine-config-operator
           # Replace this with the built image name
@@ -39,7 +35,3 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "windows-machine-config-operator"
-          volumeMounts:
-          - name: cloud-private-key
-            mountPath: "/etc/private-key/"
-            readOnly: true

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -65,10 +65,6 @@ run_WMCO() {
   fi
 
   oc apply -f deploy/namespace.yaml
-  if ! oc create secret generic cloud-private-key --from-file=private-key.pem=$KUBE_SSH_KEY_PATH -n windows-machine-config-operator; then
-    echo "cloud-private-key already present"
-  fi
-
   # Run the operator in the windows-machine-config-operator namespace
   OSDK_WMCO_management run $OSDK $MANIFEST_LOC
 

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -38,10 +38,6 @@ if [ -z "$AWS_SHARED_CREDENTIALS_FILE" ]; then
     error-exit "env AWS_SHARED_CREDENTIALS_FILE not found"
 fi
 
-if [ -z "$KUBE_SSH_KEY_PATH" ]; then
-    error-exit "env KUBE_SSH_KEY_PATH not found"
-fi
-
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 source $WMCO_ROOT/hack/common.sh
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,12 +6,12 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, clusternetwork.ClusterNetworkConfig) error
+var AddToManagerFuncs []func(manager.Manager, clusternetwork.ClusterNetworkConfig, string) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, config clusternetwork.ClusterNetworkConfig) error {
+func AddToManager(m manager.Manager, config clusternetwork.ClusterNetworkConfig, watchNamespace string) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, config); err != nil {
+		if err := f(m, config, watchNamespace); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -3,8 +3,6 @@ package secret
 import (
 	"context"
 
-	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
 )
 
 const (
@@ -33,12 +34,12 @@ var log = logf.Log.WithName(ControllerName)
 
 // Add creates a new Secret Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, _ clusternetwork.ClusterNetworkConfig) error {
+func Add(mgr manager.Manager, _ clusternetwork.ClusterNetworkConfig, watchNamespace string) error {
 	reconciler, err := newReconciler(mgr)
 	if err != nil {
 		return errors.Wrapf(err, "could not create %s reconciler", ControllerName)
 	}
-	return add(mgr, reconciler)
+	return add(mgr, reconciler, watchNamespace)
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -54,38 +55,65 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 	}
 
 	reconciler := &ReconcileSecret{client: client, scheme: mgr.GetScheme()}
-
-	// Create userData secret
-	if err := reconciler.createUserData(); err != nil {
-		return nil, errors.Wrapf(err, "error creating primary resource : %v", userDataSecret)
-	}
 	return reconciler, nil
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, watchNamespace string) error {
 	// Create a new controller
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return errors.Wrapf(err, "could not create the controller: %v", ControllerName)
 	}
-	predicateFilter := predicate.Funcs{
-		// get update event only when secret data is changed
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if string(e.ObjectOld.(*core.Secret).Data["userData"][:]) != string(e.ObjectNew.(*core.Secret).Data["userData"][:]) {
-				return true
-			}
-			return false
-		},
+
+	// Check that the private key exists, if it doesn't, log a warning
+	_, err = secrets.GetPrivateKey(kubeTypes.NamespacedName{Namespace: watchNamespace, Name: secrets.PrivateKeySecret}, mgr.GetClient())
+	if err != nil {
+		log.Error(err, "Unable to retrieve private key, please ensure it is created")
 	}
 
-	// Watch for changes to primary resource UserDataSecret
-	err = c.Watch(&source.Kind{Type: &core.Secret{ObjectMeta: meta.ObjectMeta{Namespace: userDataNamespace,
-		Name: userDataSecret}}}, &handler.EnqueueRequestForObject{}, predicateFilter)
+	// Watch for changes to the userData secret and enqueue the cloud-private-key if changed
+	// Name and namespace cannot be used to watch for specific secrets, so we filter out all the other secrets we
+	// dont care about.
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/244
+	err = c.Watch(&source.Kind{Type: &core.Secret{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: newUserDataMapper(watchNamespace)},
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return isPrivateKeySecret(e.Meta, watchNamespace) || isUserDataSecret(e.Meta)
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return isPrivateKeySecret(e.Meta, watchNamespace) || isUserDataSecret(e.Meta)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				// get update event only when secret data is changed
+				if isPrivateKeySecret(e.MetaNew, watchNamespace) {
+					if string(e.ObjectOld.(*core.Secret).Data[secrets.PrivateKeySecretKey]) !=
+						string(e.ObjectNew.(*core.Secret).Data[secrets.PrivateKeySecretKey]) {
+						return true
+					}
+				} else if isUserDataSecret(e.MetaNew) {
+					if string(e.ObjectOld.(*core.Secret).Data["userData"][:]) != string(e.ObjectNew.(*core.Secret).Data["userData"][:]) {
+						return true
+					}
+				}
+				return false
+			},
+		})
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+// isUserDataSecret returns true if the object meta indicates that the object is the userData Secret
+func isUserDataSecret(meta meta.Object) bool {
+	return meta.GetName() == userDataSecret && meta.GetNamespace() == userDataNamespace
+}
+
+// isPrivateKeySecret returns true if the object meta indicates that the object is the private key secret
+func isPrivateKeySecret(meta meta.Object, keyNamespace string) bool {
+	return meta.GetName() == secrets.PrivateKeySecret && meta.GetNamespace() == keyNamespace
 }
 
 // blank assignment to verify that ReconcileSecret implements reconcile.Reconciler
@@ -105,9 +133,19 @@ type ReconcileSecret struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling " + userDataSecret)
 
-	validUserData, err := secrets.GenerateUserData()
+	privateKey, err := secrets.GetPrivateKey(request.NamespacedName, r.client)
+	if err != nil {
+		if k8sapierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, errors.Wrapf(err, "unable to get secret %s", request.NamespacedName)
+	}
+	// Generate expected userData based on the existing private key
+	validUserData, err := secrets.GenerateUserData(privateKey)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "error generating userData secret")
 	}
@@ -117,7 +155,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	err = r.client.Get(context.TODO(), kubeTypes.NamespacedName{Name: userDataSecret, Namespace: userDataNamespace}, userData)
 	if err != nil && k8sapierrors.IsNotFound(err) {
 		// Secret is deleted
-		reqLogger.Info("UserData secret not found, recreating the secret.")
+		reqLogger.Info("UserData secret not found, creating the secret.")
 		err = r.client.Create(context.TODO(), validUserData)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -132,7 +170,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, nil
 	} else {
 		// secret is updated
-		reqLogger.Info("Restoring the userData secret")
+		reqLogger.Info("updating userdata secret")
 		err = r.client.Update(context.TODO(), validUserData)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -142,23 +180,20 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 }
 
-// createUserData creates userData secret if it is not present in the required namespace.
-func (r *ReconcileSecret) createUserData() error {
-	// generate valid userData secret
-	validUserDataSecret, err := secrets.GenerateUserData()
-	if err != nil {
-		return errors.Wrapf(err, "error generating valid userData secret")
-	}
+// userDataMapper is a simple implementation of the Mapper interface allowing for the mapping from the userData secret
+// to the private key secret
+type userDataMapper struct {
+	// watchNamespace is the namespace the operator is watching as defined by the CSV
+	watchNamespace string
+}
 
-	err = r.client.Get(context.TODO(), kubeTypes.NamespacedName{Name: userDataSecret,
-		Namespace: userDataNamespace}, &core.Secret{})
-	if err != nil && k8sapierrors.IsNotFound(err) {
-		// Create valid userData secret
-		if err = r.client.Create(context.TODO(), validUserDataSecret); err != nil {
-			return errors.Wrapf(err, "error creating userData secret")
-		}
-	} else if err != nil {
-		return errors.Wrapf(err, "error retrieving userData secret")
+// newUserDataMapper returns a pointer to a new userDataMapper
+func newUserDataMapper(namespace string) *userDataMapper {
+	return &userDataMapper{watchNamespace: namespace}
+}
+
+func (m *userDataMapper) Map(_ handler.MapObject) []reconcile.Request {
+	return []reconcile.Request{
+		{NamespacedName: kubeTypes.NamespacedName{Namespace: m.watchNamespace, Name: secrets.PrivateKeySecret}},
 	}
-	return nil
 }

--- a/pkg/controller/signer/signer.go
+++ b/pkg/controller/signer/signer.go
@@ -1,25 +1,15 @@
 package signer
 
 import (
-	"io/ioutil"
-
-	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
 // Create creates a signer using the private key from the privateKeyPath
-// TODO: As a part of https://issues.redhat.com/browse/WINC-316 , modify CreateSigner to take private key secret
-//  and return the signer
-func Create() (ssh.Signer, error) {
-	privateKeyBytes, err := ioutil.ReadFile(wkl.PrivateKeyPath)
+func Create(privateKey []byte) (ssh.Signer, error) {
+	signer, err := ssh.ParsePrivateKey(privateKey)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to find private key from path: %v", wkl.PrivateKeyPath)
-	}
-
-	signer, err := ssh.ParsePrivateKey(privateKeyBytes)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to parse private key: %v", wkl.PrivateKeyPath)
+		return nil, errors.Wrap(err, "unable to parse private key")
 	}
 	return signer, nil
 }

--- a/pkg/controller/wellknownlocations/wellknownlocations.go
+++ b/pkg/controller/wellknownlocations/wellknownlocations.go
@@ -1,10 +1,6 @@
 package wellknownlocations
 
 const (
-	// PrivateKeyPath contains the path to the private key which is used in decrypting password in case of AWS
-	// cloud provider. This would have been mounted as a secret by user
-	// TODO: Jira story for validation: https://issues.redhat.com/browse/WINC-316
-	PrivateKeyPath = "/etc/private-key/private-key.pem"
 	// payloadDirectory is the directory in the operator image where are all the binaries live
 	payloadDirectory = "/payload/"
 	// WmcbPath contains the path of the Windows Machine Config Bootstrapper binary. The container image should already

--- a/pkg/controller/windowsmachine/windowsmachine_controller.go
+++ b/pkg/controller/windowsmachine/windowsmachine_controller.go
@@ -6,10 +6,6 @@ import (
 
 	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/signer"
-	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
-	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	core "k8s.io/api/core/v1"
@@ -29,6 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/signer"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 )
 
 const (
@@ -40,8 +40,8 @@ var log = logf.Log.WithName(ControllerName)
 
 // Add creates a new WindowsMachine Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and start it when the Manager is Started.
-func Add(mgr manager.Manager, networkConfig clusternetwork.ClusterNetworkConfig) error {
-	reconciler, err := newReconciler(mgr, networkConfig)
+func Add(mgr manager.Manager, networkConfig clusternetwork.ClusterNetworkConfig, watchNamespace string) error {
+	reconciler, err := newReconciler(mgr, networkConfig, watchNamespace)
 	if err != nil {
 		return errors.Wrapf(err, "could not create %s reconciler", ControllerName)
 	}
@@ -49,7 +49,7 @@ func Add(mgr manager.Manager, networkConfig clusternetwork.ClusterNetworkConfig)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, networkConfig clusternetwork.ClusterNetworkConfig) (reconcile.Reconciler, error) {
+func newReconciler(mgr manager.Manager, networkConfig clusternetwork.ClusterNetworkConfig, watchNamespace string) (reconcile.Reconciler, error) {
 	// The default client serves read requests from the cache which
 	// could be stale and result in a get call to return an older version
 	// of the object. Hence we are using a non-default-client referenced
@@ -69,11 +69,6 @@ func newReconciler(mgr manager.Manager, networkConfig clusternetwork.ClusterNetw
 		return nil, errors.Wrap(err, "error creating kubernetes clientset")
 	}
 
-	signer, err := signer.Create()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error creating signer using private key: %v", wkl.PrivateKeyPath)
-	}
-
 	serviceCIDR, err := networkConfig.GetServiceCIDR()
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting service CIDR")
@@ -83,9 +78,9 @@ func newReconciler(mgr manager.Manager, networkConfig clusternetwork.ClusterNetw
 			scheme:             mgr.GetScheme(),
 			k8sclientset:       clientset,
 			clusterServiceCIDR: serviceCIDR,
-			signer:             signer,
 			vxlanPort:          networkConfig.VXLANPort(),
 			recorder:           mgr.GetEventRecorderFor(ControllerName),
+			watchNamespace:     watchNamespace,
 		},
 		nil
 }
@@ -149,6 +144,8 @@ type ReconcileWindowsMachine struct {
 	vxlanPort string
 	// recorder to generate events
 	recorder record.EventRecorder
+	// watchNamespace is the namespace the operator is watching as defined by the operator CSV
+	watchNamespace string
 }
 
 // Reconcile reads that state of the cluster for a Windows Machine object and makes changes based on the state read
@@ -157,10 +154,18 @@ type ReconcileWindowsMachine struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileWindowsMachine) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Info("reconciling", "namespace", request.Namespace, "name", request.Name)
-	// validate userData secret
-	if err := r.validateUserData(); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error validating userData secret")
+	// Get the private key that will be used to configure the instance
+	// Doing this before fetching the machine allows us to warn the user better about the missing private key
+	privateKey, err := secrets.GetPrivateKey(kubeTypes.NamespacedName{Namespace: r.watchNamespace,
+		Name: secrets.PrivateKeySecret}, r.client)
+	if err != nil {
+		if k8sapierrors.IsNotFound(err) {
+			// Private key was removed, requeue
+			return reconcile.Result{}, errors.Wrapf(err, "%s does not exist, please create it", secrets.PrivateKeySecret)
+		}
+		return reconcile.Result{}, errors.Wrapf(err, "unable to get secret %s", request.NamespacedName)
 	}
+
 	// Fetch the Machine instance
 	machine := &mapi.Machine{}
 	if err := r.client.Get(context.TODO(), request.NamespacedName, machine); err != nil {
@@ -179,6 +184,16 @@ func (r *ReconcileWindowsMachine) Reconcile(request reconcile.Request) (reconcil
 		// Phase can be nil and should be ignored by WMCO
 		// If the Machine is not in provisioned state, WMCO shouldn't care about it
 		return reconcile.Result{}, nil
+	}
+
+	// Update the signer with the existing privateKey
+	r.signer, err = signer.Create(privateKey)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "error creating signer")
+	}
+	// validate userData secret
+	if err := r.validateUserData(privateKey); err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "error validating userData secret")
 	}
 
 	// Get the IP address associated with the Windows machine.
@@ -238,7 +253,7 @@ func (r *ReconcileWindowsMachine) addWorkerNode(ipAddress, instanceID string) er
 
 // validateUserData validates userData secret. It returns error if the secret doesn`t
 // contain expected public key bytes.
-func (r *ReconcileWindowsMachine) validateUserData() error {
+func (r *ReconcileWindowsMachine) validateUserData(privateKey []byte) error {
 	userDataSecret := &core.Secret{}
 	err := r.client.Get(context.TODO(), kubeTypes.NamespacedName{Name: "windows-user-data", Namespace: "openshift-machine-api"}, userDataSecret)
 
@@ -247,7 +262,7 @@ func (r *ReconcileWindowsMachine) validateUserData() error {
 	}
 
 	secretData := string(userDataSecret.Data["userData"][:])
-	desiredUserDataSecret, err := secrets.GenerateUserData()
+	desiredUserDataSecret, err := secrets.GenerateUserData(privateKey)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -22,6 +22,8 @@ var (
 	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
 	sshKeyPair string
+	// privateKeyPath is the path of the private key file used to configure the Windows node
+	privateKeyPath string
 	// wmcoPath is the path to the WMCO binary that was used within the operator image
 	wmcoPath string
 	// gc is the global context across the test suites.
@@ -42,6 +44,8 @@ type globalContext struct {
 	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
 	sshKeyPair string
+	// privateKeyPath is the path of the private key file used to configure the Windows node
+	privateKeyPath string
 }
 
 // testContext holds the information related to the individual test suite. This data structure
@@ -108,5 +112,7 @@ func TestMain(m *testing.M) {
 		"the Windows Node password")
 	flag.StringVar(&wmcoPath, "wmco-path", "./build/_output/bin/windows-machine-config-operator",
 		"Path to the WMCO binary, used for version validation")
+	flag.StringVar(&privateKeyPath, "private-key-path", "",
+		"path of the private key file used to configure the Windows node")
 	framework.MainEntry(m)
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +18,9 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
+	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 )
 
 // getInstanceID gets the instanceID of VM for a given cloud provider ID
@@ -108,7 +110,7 @@ func createSigner() (ssh.Signer, error) {
 		return nil, errors.Wrapf(err, "failed to retrieve cloud private key secret")
 	}
 
-	privateKeyBytes := privateKeySecret.Data["private-key.pem"][:]
+	privateKeyBytes := privateKeySecret.Data[secrets.PrivateKeySecretKey][:]
 	if privateKeyBytes == nil {
 		return nil, errors.New("failed to retrieve private key using cloud private key secret")
 	}


### PR DESCRIPTION
This commit is stopping the mounting of the cloud-private-key secret,
and instead fetching it within the Windows Machine and secret
controllers.

This has two main benefits. Firstly, this allows the
operator to be deployed without the cloud-private-key existing. This
will allow the operator to be properly deployed via the OpenShift
console, allowing for a much better UX. Machines will not be configured
until the private key secret is created, as they will not enter the
provisoned state until the userData secret is created by WMCO.
Secondly, this commit allows for our operator to update the userData
secret immediately after a change is made to the private key.

This commit made the private key secret the primary resource of the
secret controller. This is more fitting than the userData being the
primary resource, as we create the userData based off the contents of
the private key. The private key is the source of truth and therefore
should be the primary resource.

Changes were also made to the CSV in order to remove the mounting of
the private key.

This commit only causes future Windows machines to be configured with
a new private key when it is specified, and does not deal with Windows
machines which were configured with a previous private key. That needs
to be handled in a future commit.