### PR TITLE
[test] Remove passing of SSH Key Pair env var

### DIFF
--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"fmt"
 
-	"github.com/openshift/api/config/v1"
+	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	oc "github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	awsProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/aws"
@@ -14,7 +14,8 @@ type CloudProvider interface {
 	GenerateMachineSet(bool, int32) (*mapi.MachineSet, error)
 }
 
-func NewCloudProvider(sshKeyPair string, hasCustomVXLANPort bool) (CloudProvider, error) {
+// NewCloudProvider returns a CloudProvider interface or an error
+func NewCloudProvider(hasCustomVXLANPort bool) (CloudProvider, error) {
 	openshift, err := oc.GetOpenShift()
 	if err != nil {
 		return nil, errors.Wrap(err, "Getting OpenShift client failed")
@@ -24,9 +25,9 @@ func NewCloudProvider(sshKeyPair string, hasCustomVXLANPort bool) (CloudProvider
 		return nil, errors.Wrap(err, "Getting cloud provider type")
 	}
 	switch provider := cloudProvider.Type; provider {
-	case v1.AWSPlatformType:
+	case config.AWSPlatformType:
 		// 	Setup the AWS cloud provider in the same region where the cluster is running
-		return awsProvider.SetupAWSCloudProvider(cloudProvider.AWS.Region, sshKeyPair, hasCustomVXLANPort)
+		return awsProvider.SetupAWSCloudProvider(cloudProvider.AWS.Region, hasCustomVXLANPort)
 	default:
 		return nil, fmt.Errorf("the '%v' cloud provider is not supported", provider)
 	}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -34,7 +34,6 @@ func TestWMCO(t *testing.T) {
 	// Reference:
 	// https://github.com/operator-framework/operator-sdk/blob/b448429687fd7cb2343d022814ed70c9d264612b/pkg/test/main_entry.go#L51
 	gc.numberOfNodes = int32(numberOfNodes)
-	gc.sshKeyPair = sshKeyPair
 	require.NotEmpty(t, privateKeyPath, "private-key-path is not set")
 	gc.privateKeyPath = privateKeyPath
 	// When the OPENSHIFT_CI env var is set to true, the test is running within CI


### PR DESCRIPTION
It's not necessary to pass an SSH key pair name into the
MachineProviderConfig specs as an additional means of access.

The MachineProviderConfig already contains a UserDataSecret
specifying instructions for the Windows VM to set up and enable SSH
access.