### PR TITLE
[wmco] Handle ignition file download errors

### DIFF
--- a/pkg/internal/wget-ignore-cert.ps1
+++ b/pkg/internal/wget-ignore-cert.ps1
@@ -27,6 +27,9 @@ public static class Dummy {
 }
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [dummy]::GetDelegate()
 
+# This makes it so all future errors cause the script to return and throw an error
+$ErrorActionPreference = "Stop"
+
 # $null is needed to prevent wget from attempting read the standard input or
 # output streams when attached to the console.
 $null | wget $server -Headers @{'Accept' = $acceptHeader;} -o $output > $null


### PR DESCRIPTION
This commit makes it so that the powershell script we use to download
the ignition file properly returns an error when it fails. Previously
the actual error was also being set to nil, and we only had
stdout/stderr to tell if something went wrong