### PR TITLE
[ci] Add write permissions to WMCO repo directory

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -156,5 +156,8 @@ RUN chmod g=u /etc
 RUN mkdir -m 777 -p /etc/cloud/
 RUN mkdir -m 777 -p /etc/private-key/
 
+# Open up permissions within WMCO directory
+RUN chmod -R g=u+w /go/src/github.com/openshift/windows-machine-config-operator/
+
 ENTRYPOINT [ "/bin/bash" ]
 USER ${USER_UID}


### PR DESCRIPTION
This is being done to resolve an issue with operator-sdk not having
the proper permissions to create a directory within the `deploy` folder.