### PR TITLE
[wmco] Remove explicit use of --skip-deletion

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -17,9 +17,6 @@ import (
 var (
 	// numberOfNodes represent the number of nodes to be dealt with in the test suite.
 	numberOfNodes int
-	// skipNodeDeletion allows the Windows nodes to hang around after the test suite has been run. This skips the deletion
-	// test suite.
-	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
 	sshKeyPair string
 	// privateKeyPath is the path of the private key file used to configure the Windows node
@@ -40,8 +37,6 @@ type globalContext struct {
 	numberOfNodes int32
 	// nodes are the Windows nodes created by the operator
 	nodes []v1.Node
-	// skipNodeDeletion allows the Windows nodes to hang around after the test suite has been run.
-	skipNodeDeletion bool
 	// sshKeyPair is the name of the keypair that we can use to decrypt the Windows node created in AWS cloud
 	sshKeyPair string
 	// privateKeyPath is the path of the private key file used to configure the Windows node
@@ -105,8 +100,6 @@ func (tc *testContext) cleanup() {
 
 func TestMain(m *testing.M) {
 	flag.IntVar(&numberOfNodes, "node-count", 2, "number of nodes to be created for testing")
-	flag.BoolVar(&skipNodeDeletion, "skip-node-deletion", false,
-		"Option to disable deletion of the VMs")
 	// We're using openshift-dev as default value to be used in CI
 	flag.StringVar(&sshKeyPair, "ssh-key-pair", "openshift-dev", "SSH Key Pair to be used for decrypting "+
 		"the Windows Node password")

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -34,7 +34,6 @@ func TestWMCO(t *testing.T) {
 	// Reference:
 	// https://github.com/operator-framework/operator-sdk/blob/b448429687fd7cb2343d022814ed70c9d264612b/pkg/test/main_entry.go#L51
 	gc.numberOfNodes = int32(numberOfNodes)
-	gc.skipNodeDeletion = skipNodeDeletion
 	gc.sshKeyPair = sshKeyPair
 	require.NotEmpty(t, privateKeyPath, "private-key-path is not set")
 	gc.privateKeyPath = privateKeyPath
@@ -48,9 +47,8 @@ func TestWMCO(t *testing.T) {
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
-	if !gc.skipNodeDeletion {
-		t.Run("destroy", deletionTestSuite)
-	}
+	t.Run("destroy", deletionTestSuite)
+
 }
 
 // setupWMCO setups the resources needed to run WMCO tests


### PR DESCRIPTION
Since we are explicitly running every test suite, we dont need --skip-deletion
flag as an option for the different test suites. This commit removes the
explicit use of --skip-deletion option while running the tests.

However, the `--skip-deletion` flag is useful when we want to avoid running
of deletion test suite while running `run-ci-e2e-test.sh`