### PR TITLE
[test] Use ubi-minimal image for Linux curlers

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -119,7 +119,7 @@ func testEastWestNetworking(t *testing.T) {
 
 					// create the curler job based on the specified curlerOS
 					if tt.curlerOS == linux {
-						curlerCommand := []string{"bash", "-c", "yum update; yum install curl -y; curl " + endpointIP}
+						curlerCommand := []string{"bash", "-c", "curl " + endpointIP}
 						curlerJob, err = testCtx.createLinuxJob("linux-curler-"+strings.ToLower(node.Status.NodeInfo.MachineID), curlerCommand)
 						require.NoError(t, err, "could not create Linux job")
 					} else if tt.curlerOS == windows {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -30,7 +30,7 @@ func testNetwork(t *testing.T) {
 
 var (
 	// ubi8Image is the name/location of the linux image we will use for testing
-	ubi8Image = "registry.access.redhat.com/ubi8/ubi:latest"
+	ubi8Image = "registry.access.redhat.com/ubi8/ubi-minimal:latest"
 	// retryCount is the amount of times we will retry an api operation
 	retryCount = 60
 	// retryInterval is the interval of time until we retry after a failure


### PR DESCRIPTION
I noticed warnings on the linux curler pods:
```
2020-09-30 16:42:01,690 [ERROR] yum:8:MainThread @logutil.py:194 - [Errno 13] Permission denied: '/var/log/rhsm/rhsm.log' - Further logging output will be written to stderr
Not root, Subscription Management repositories not updated
Error: This command has to be run under the root user.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0<html><body><H1>Windows Container Web Server</H1></body></html>100    63  100    63    0     0   2100   
```

This fixes the warning thrown on linux curler pods by not calling yum (curl is already present).