### PR TITLE
[deploy] Use openshift-windows-machine-config-operator namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,14 @@ This deployment method is currently not supported. Please use the [CLI](#cli)
 
 #### CLI
 
-Create the windows-machine-config-operator namespace:
+Create the openshift-windows-machine-config-operator namespace:
 ```shell script
 oc apply -f deploy/namespace.yaml
 ```
 
-Switch to the windows-machine-config-operator project:
+Switch to the openshift-windows-machine-config-operator project:
 ```shell script
-oc project windows-machine-config-operator
+oc project openshift-windows-machine-config-operator
 ```
 
 ##### Create private key Secret

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: windows-machine-config-operator
+  name: openshift-windows-machine-config-operator

--- a/deploy/olm-catalog/operatorgroup.yaml
+++ b/deploy/olm-catalog/operatorgroup.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     olm.providedAPIs: WindowsMachineConfig.v1alpha1.wmc.openshift.io
   name: windows-machine-config-operator
-  namespace: windows-machine-config-operator
+  namespace: openshift-windows-machine-config-operator
 spec:
   targetNamespaces:
-  - windows-machine-config-operator
+  - openshift-windows-machine-config-operator

--- a/deploy/olm-catalog/subscription.yaml
+++ b/deploy/olm-catalog/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: windows-machine-config-operator
-  namespace: windows-machine-config-operator
+  namespace: openshift-windows-machine-config-operator
 spec:
   channel: alpha
   installPlanApproval: Automatic

--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -5,10 +5,10 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/cluster-monitoring: "true"
-    operatorframework.io/suggested-namespace: windows-machine-config-operator
+    operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     repository: https://github.com/openshift/windows-machine-config-operator
   name: windows-machine-config-operator.v0.0.0
-  namespace: windows-machine-config-operator
+  namespace: openshift-windows-machine-config-operator
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: windows-machine-config-operator
-  namespace: windows-machine-config-operator
+  namespace: openshift-windows-machine-config-operator
 rules:
 - apiGroups:
   - ""

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -39,7 +39,7 @@ OSDK_WMCO_management() {
 
   # Currently this fails even on successes, adding this check to ignore the failure
   # https://github.com/operator-framework/operator-sdk/issues/2938
-  if ! $OSDK_PATH $COMMAND packagemanifests --olm-namespace openshift-operator-lifecycle-manager --operator-namespace windows-machine-config-operator \
+  if ! $OSDK_PATH $COMMAND packagemanifests --olm-namespace openshift-operator-lifecycle-manager --operator-namespace openshift-windows-machine-config-operator \
   --operator-version 0.0.0 $INCLUDE; then
     echo operator-sdk $1 failed
   fi
@@ -84,11 +84,11 @@ run_WMCO() {
   fi
 
   oc apply -f deploy/namespace.yaml
-  # Run the operator in the windows-machine-config-operator namespace
+  # Run the operator in the openshift-windows-machine-config-operator namespace
   OSDK_WMCO_management run $OSDK $MANIFEST_LOC
 
   # Additional guard that ensures that operator was deployed given the SDK flakes in error reporting
-  if ! oc rollout status deployment windows-machine-config-operator -n windows-machine-config-operator --timeout=5s; then
+  if ! oc rollout status deployment windows-machine-config-operator -n openshift-windows-machine-config-operator --timeout=5s; then
     return 1
   fi
 }
@@ -98,7 +98,7 @@ run_WMCO() {
 # 1: path to the operator-sdk binary to use
 cleanup_WMCO() {
   local OSDK=$1
-  # Remove the operator from windows-machine-config-operator namespace
+  # Remove the operator from openshift-windows-machine-config-operator namespace
   OSDK_WMCO_management cleanup $OSDK
   oc delete -f deploy/namespace.yaml
 }

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -13,7 +13,7 @@ WMCO_PATH_OPTION=""
 export CGO_ENABLED=0
 
 get_WMCO_logs() {
-  oc logs -l name=windows-machine-config-operator -n windows-machine-config-operator --tail=-1
+  oc logs -l name=windows-machine-config-operator -n openshift-windows-machine-config-operator --tail=-1
 }
 
 # This function runs operator-sdk test with certain go test arguments
@@ -29,7 +29,7 @@ OSDK_WMCO_test() {
   local OSDK_PATH=$1
   local TEST_FLAGS=$2
 
-  if ! $OSDK_PATH test local ./test/e2e --no-setup --debug --operator-namespace=windows-machine-config-operator --go-test-flags "$TEST_FLAGS"; then
+  if ! $OSDK_PATH test local ./test/e2e --no-setup --debug --operator-namespace=openshift-windows-machine-config-operator --go-test-flags "$TEST_FLAGS"; then
     get_WMCO_logs
     return 1
   fi

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -71,7 +71,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 	err = framework.Global.KubeClient.CoreV1().Secrets("openshift-machine-api").Delete(context.TODO(), "windows-user-data", meta.DeleteOptions{})
 	require.NoError(t, err, "could not delete userData secret")
 
-	err = framework.Global.KubeClient.CoreV1().Secrets("windows-machine-config-operator").Delete(context.TODO(), secrets.PrivateKeySecret, meta.DeleteOptions{})
+	err = framework.Global.KubeClient.CoreV1().Secrets("openshift-windows-machine-config-operator").Delete(context.TODO(), secrets.PrivateKeySecret, meta.DeleteOptions{})
 	require.NoError(t, err, "could not delete privateKey secret")
 
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -23,6 +23,8 @@ const (
 	deploymentTimeout = time.Minute * 1
 	// resourceName is the name of a resource in the watched namespace (e.g pod name, deployment name)
 	resourceName = "windows-machine-config-operator"
+	// resourceNamespace is the namespace the resources are deployed in
+	resourceNamespace = "openshift-windows-machine-config-operator"
 )
 
 // upgradeTestSuite tests behaviour of the operator when an upgrade takes place.
@@ -122,7 +124,7 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 
 		patchData := fmt.Sprintf(`{"spec":{"replicas":%v}}`, desiredReplicas)
 
-		_, err = tc.kubeclient.AppsV1().Deployments(resourceName).Patch(context.TODO(), resourceName,
+		_, err = tc.kubeclient.AppsV1().Deployments(resourceNamespace).Patch(context.TODO(), resourceName,
 			types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
 			log.Printf("error patching operator deployment : %v", err)
@@ -137,7 +139,7 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 
 	// wait for the windows-machine-config-operator to scale up/down
 	err = wait.Poll(deploymentRetryInterval, deploymentTimeout, func() (done bool, err error) {
-		deployment, err := tc.kubeclient.AppsV1().Deployments(resourceName).Get(context.TODO(), resourceName,
+		deployment, err := tc.kubeclient.AppsV1().Deployments(resourceNamespace).Get(context.TODO(), resourceName,
 			metav1.GetOptions{})
 		if err != nil {
 			log.Printf("error getting operator deployment: %v", err)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -106,7 +106,7 @@ func testNodeTaint(t *testing.T) {
 // createSigner creates a signer using the private key retrieved from the secret
 func createSigner() (ssh.Signer, error) {
 	privateKeySecret := &core.Secret{}
-	err := framework.Global.Client.Get(context.TODO(), kubeTypes.NamespacedName{Name: "cloud-private-key", Namespace: "windows-machine-config-operator"}, privateKeySecret)
+	err := framework.Global.Client.Get(context.TODO(), kubeTypes.NamespacedName{Name: "cloud-private-key", Namespace: "openshift-windows-machine-config-operator"}, privateKeySecret)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve cloud private key secret")
 	}


### PR DESCRIPTION
This commit changes the namespace the operator is deployed to by default
to `openshift-windows-machine-config-operator`, instead of the
`windows-machine-config-operator` namespace used before.

This is a requirement for Prometheus monitoring.