### PR TITLE
[DOCS] Add a quick start example to prep base windows server

### DIFF
--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -1,0 +1,28 @@
+# Quick Start MS Windows Server Datacenter Core with Containers 
+This guide assumes the user has a current version of MS Windows Server 2019
+Datacenter (core) with containers ready to prepare as a worker node for
+OpenShift.
+
+## Enable ssh service
+  - Run in admin powershell
+```sh
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
+
+Start-Service ssh-agent
+Start-Service sshd
+
+Set-Service -Name ssh-agent -StartupType ‘Automatic’
+Set-Service -Name sshd -StartupType ‘Automatic’
+```
+## Configure administrators rsa key authentication
+  - Run in admin powershell
+```sh
+$acl = Get-Acl C:\ProgramData\ssh\administrators_authorized_keys
+$acl.SetAccessRuleProtection($true, $false)
+$administratorsRule = New-Object system.security.accesscontrol.filesystemaccessrule("Administrators","FullControl","Allow")
+$systemRule = New-Object system.security.accesscontrol.filesystemaccessrule("SYSTEM","FullControl","Allow")
+$acl.SetAccessRule($administratorsRule)
+$acl.SetAccessRule($systemRule)
+$acl | Set-Acl
+```

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -38,11 +38,16 @@ $acl | Set-Acl
   - Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script
   - Run in admin powershell
     
+  1. Create Listener
 ```sh
 $url = "https://git.io/fNG9x"
 $file = "$env:temp\ConfigureRemotingForAnsible.ps1"
 (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
 powershell.exe -ExecutionPolicy ByPass -File $file
+```
+  2. Verify Listener
+```sh
+winrm enumerate winrm/config/Listener
 ```
 
 [ConfigureRemotingForAnsible.ps1]:https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -11,12 +11,19 @@ Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
 
 Start-Service sshd
 Set-Service -Name sshd -StartupType Automatic
-
-Start-Service ssh-agent
-Set-Service -Name ssh-agent -StartupType Automatic
 ```
 ## Configure administrators rsa key authentication
   - Run in admin powershell
+    
+  1. Write ssh public key to file
+```sh
+$sshPubKey = 'ssh-rsa AAAAB3NzaC...TRUNCATED...AQAAAAB23V6s/L/yU= admin@bastion' 
+$sshPubKeyFile = 'administrators_authorized_keys'
+$sshDataDir = 'C:\ProgramData\ssh'
+New-Item -Path $sshDataDir -Name $sshPubKeyFile -ItemType "file" -Value $sshPubKey  
+```
+
+  2. Set permissions on public key file
 ```sh
 $acl = Get-Acl C:\ProgramData\ssh\administrators_authorized_keys
 $acl.SetAccessRuleProtection($true, $false)

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -9,11 +9,11 @@ OpenShift.
 Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
 
-Start-Service ssh-agent
 Start-Service sshd
-
-Set-Service -Name ssh-agent -StartupType ‘Automatic’
 Set-Service -Name sshd -StartupType ‘Automatic’
+
+Start-Service ssh-agent
+Set-Service -Name ssh-agent -StartupType ‘Automatic’
 ```
 ## Configure administrators rsa key authentication
   - Run in admin powershell

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -10,10 +10,10 @@ Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
 
 Start-Service sshd
-Set-Service -Name sshd -StartupType ‘Automatic’
+Set-Service -Name sshd -StartupType Automatic
 
 Start-Service ssh-agent
-Set-Service -Name ssh-agent -StartupType ‘Automatic’
+Set-Service -Name ssh-agent -StartupType Automatic
 ```
 ## Configure administrators rsa key authentication
   - Run in admin powershell

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -4,7 +4,9 @@ Datacenter (core) with containers ready to prepare as a worker node for
 OpenShift.
 
 ## Enable ssh service
-  - Run in admin powershell
+>  Run in admin powershell
+>    
+
 ```sh
 Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
@@ -13,7 +15,8 @@ Start-Service sshd
 Set-Service -Name sshd -StartupType Automatic
 ```
 ## Configure administrators rsa key authentication
-  - Run in admin powershell
+>  Run in admin powershell
+>    
     
   1. Write ssh public key to file
 ```sh
@@ -35,8 +38,9 @@ $acl | Set-Acl
 ```
 
 ## Configure [WinRM Listener for Ansible] Connection
-  - Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script
-  - Run in admin powershell
+>  Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script
+>  Run in admin powershell
+>    
     
   1. Create Listener
 ```sh

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -33,3 +33,17 @@ $acl.SetAccessRule($administratorsRule)
 $acl.SetAccessRule($systemRule)
 $acl | Set-Acl
 ```
+
+## Configure [WinRM Listener for Ansible] Connection
+  - Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script
+  - Run in admin powershell
+    
+```sh
+$url = "https://git.io/fNG9x"
+$file = "$env:temp\ConfigureRemotingForAnsible.ps1"
+(New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
+powershell.exe -ExecutionPolicy ByPass -File $file
+```
+
+[ConfigureRemotingForAnsible.ps1]:https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
+[WinRM Listener for Ansible]:https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html#winrm-setup

--- a/docs/ms-server-core-docker-quickstart.md
+++ b/docs/ms-server-core-docker-quickstart.md
@@ -38,7 +38,7 @@ $acl | Set-Acl
 ```
 
 ## Configure [WinRM Listener for Ansible] Connection
->  Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script
+>  Uses this Ansible project [ConfigureRemotingForAnsible.ps1] Script    
 >  Run in admin powershell
 >    
     


### PR DESCRIPTION
Proposal:
Provide a quick start guide providing minimum viable prototype steps to prepare a windows server core node.

This pull request contains rough sketched notes from my own experience stumbling through rough lessons learned while collecting cross industry docs and peer tribal knowledge and may serve as a starting point for accumulating content from other invested individuals as well.