### PR TITLE
WINC-523: [wmco] Update Node deletion during upgrade

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -146,25 +146,19 @@ func testNorthSouthNetworking(t *testing.T) {
 	testCtx, err := NewTestContext(t)
 	require.NoError(t, err)
 
-	// Use the 0th node to test
+	// Require at least one node to test
 	require.NotEmpty(t, gc.nodes)
-	node := gc.nodes[0]
-
-	affinity, err := getAffinityForNode(&node)
-	require.NoError(t, err, "Could not get affinity for node")
 
 	// Deploy a webserver pod on the new node. This is prone to timing out due to having to pull the Windows image
 	// So trying multiple times
 	var winServerDeployment *appsv1.Deployment
 	for i := 0; i < deploymentRetries; i++ {
-		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver-"+
-			strings.ToLower(node.Status.NodeInfo.MachineID), affinity)
+		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver", nil)
 		if err == nil {
 			break
 		}
 	}
 	require.NoError(t, err, "could not create Windows Server deployment")
-	defer testCtx.deleteDeployment(winServerDeployment.Name)
 
 	// Assert that we can successfully GET the webserver
 	err = testCtx.getThroughLoadBalancer(winServerDeployment)


### PR DESCRIPTION
Previously, during an upgrade, wmco defined minHealthy count. This count was
taken into consideration while deleting the nodes with mismatched version.
This commit updates the deletion process to take into account maxUnhealthy
count. This count ensures that we have only limited number of nodes that
are in Not Ready state during an upgrade

It also adds tests for workload availability during Upgrade process.

[WINC-523](https://issues.redhat.com/browse/WINC-523)