### PR TITLE
[git] Normalize gitmodules URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "windows-machine-config-bootstrapper"]
 	path = windows-machine-config-bootstrapper
-	url = https://github.com/openshift/windows-machine-config-bootstrapper.git
+	url = https://github.com/openshift/windows-machine-config-bootstrapper
 	branch = release-4.6
 [submodule "ovn-kubernetes"]
 	path = ovn-kubernetes
@@ -8,7 +8,7 @@
 	branch = release-4.6
 [submodule "containernetworking-plugins"]
 	path = containernetworking-plugins
-	url = https://github.com/openshift/containernetworking-plugins/
+	url = https://github.com/openshift/containernetworking-plugins
 	branch = release-4.6
 [submodule "kubernetes"]
 	path = kubernetes


### PR DESCRIPTION
Convention is that .git is used for bare repositories and it is left off for repositories with a working tree. Note that not having a trailing / will help folks using the following
```
git config:
[url "git@github.com:"]
    insteadOf = https://github.com/
```