### PR TITLE
WINC-525: [WMCO] Handle OpenSSHUtils deprecation

### DIFF
--- a/pkg/controller/secrets/secrets.go
+++ b/pkg/controller/secrets/secrets.go
@@ -64,23 +64,23 @@ func GenerateUserData(privateKey []byte) (*core.Secret, error) {
 			$firewallRuleName = "ContainerLogsPort"
 			$containerLogsPort = "10250"
 			New-NetFirewallRule -DisplayName $firewallRuleName -Direction Inbound -Action Allow -Protocol TCP -LocalPort $containerLogsPort -EdgeTraversalPolicy Allow
-			Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-			Install-Module -Force OpenSSHUtils
-			Set-Service -Name ssh-agent -StartupType ‘Automatic’
 			Set-Service -Name sshd -StartupType ‘Automatic’
-			Start-Service ssh-agent
 			Start-Service sshd
 			$pubKeyConf = (Get-Content -path C:\ProgramData\ssh\sshd_config) -replace '#PubkeyAuthentication yes','PubkeyAuthentication yes'
 			$pubKeyConf | Set-Content -Path C:\ProgramData\ssh\sshd_config
  			$passwordConf = (Get-Content -path C:\ProgramData\ssh\sshd_config) -replace '#PasswordAuthentication yes','PasswordAuthentication yes'
 			$passwordConf | Set-Content -Path C:\ProgramData\ssh\sshd_config
-			$authFileConf = (Get-Content -path C:\ProgramData\ssh\sshd_config) -replace 'AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys','#AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys'
-			$authFileConf | Set-Content -Path C:\ProgramData\ssh\sshd_config
-			$pubKeyLocationConf = (Get-Content -path C:\ProgramData\ssh\sshd_config) -replace 'Match Group administrators','#Match Group administrators'
-			$pubKeyLocationConf | Set-Content -Path C:\ProgramData\ssh\sshd_config
+			$authorizedKeyFilePath = "$env:ProgramData\ssh\administrators_authorized_keys"
+			New-Item -Force $authorizedKeyFilePath
+			echo "` + string(pubKeyBytes[:]) + `"| Out-File $authorizedKeyFilePath -Encoding ascii
+			$acl = Get-Acl C:\ProgramData\ssh\administrators_authorized_keys
+			$acl.SetAccessRuleProtection($true, $false)
+			$administratorsRule = New-Object system.security.accesscontrol.filesystemaccessrule("Administrators","FullControl","Allow")
+			$systemRule = New-Object system.security.accesscontrol.filesystemaccessrule("SYSTEM","FullControl","Allow")
+			$acl.SetAccessRule($administratorsRule)
+			$acl.SetAccessRule($systemRule)
+			$acl | Set-Acl
 			Restart-Service sshd
-			New-item -Path $env:USERPROFILE -Name .ssh -ItemType Directory -force
-			echo "` + string(pubKeyBytes[:]) + `"| Out-File $env:USERPROFILE\.ssh\authorized_keys -Encoding ascii
 			</powershell>
 			<persist>true</persist>`),
 		},


### PR DESCRIPTION
OpenSSHUtils is getting deprecated
MicrosoftDocs/windowsserverdocs#3806
We need to move away from using OpenSSHUtils to configure ssh
access to Windows VMs

Remove installing OpenSSHUtils and its usage for setting the
authorized keys and uses the built-in ssh mechanism supported
by Windows Server 1709 and above