### PR TITLE
WINC-460: [ci] Define build_root_image within repo

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,5 @@
+# Defining this here allows us to atomically change both the code and the go version used to build the code in CI.
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.14


### PR DESCRIPTION
This commit allows us to change the build_root_image with commits to
this repo. Previously we would hit an issue with breaking builds due to
bumping the required go version within this repository and then having
to update the used go version within the openshift/release repo.

https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image