### PR TITLE
WINC-527: [wmco] run WMCO on control plane

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -126,7 +126,21 @@ spec:
                 name: windows-machine-config-operator
                 resources: {}
               hostNetwork: true
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
               serviceAccountName: windows-machine-config-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoExecute
+                key: node.kubernetes.io/unreachable
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoExecute
+                key: node.kubernetes.io/not-ready
+                operator: Exists
+                tolerationSeconds: 120
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -35,3 +35,17 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "windows-machine-config-operator"
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120


### PR DESCRIPTION
WMCO has escalated permissions and we need to run it on 
control-plane hosts. 

This reverts commit 0c33029.