### PR TITLE
[ci] Remove microdnf update

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -106,7 +106,6 @@ ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
 
 # install make package
 RUN microdnf -y install make tar gzip wget
-RUN microdnf -y update
 
 # Copy go from build stage, install within this stage
 COPY --from=build /build/go/go.tar.gz .


### PR DESCRIPTION
Do not update the packages for base image, since it might lead to failures with conflicting packages. If there are updates to the image, they should be picked up with the image itself.
