### PR TITLE
[hack] Add private key input to olm.sh

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -27,9 +27,10 @@ export AWS_SHARED_CREDENTIALS_FILE=<path to aws credentials file>
 
 To run the operator on a cluster, use: 
 ```shell script
-hack/olm.sh run -c "<OPERATOR_IMAGE>"
+hack/olm.sh run -c "<OPERATOR_IMAGE>" -k "<PRIVATE_KEY.PEM>"
 ```
-This command builds the operator image and pushes it to remote repository. Executing [Build](#build) step is not required. 
+This command builds the operator image, pushes it to remote repository and uses OLM to launch the operator. Executing
+the [Build](#build) step is not required.
 
 In order to build the operator ignoring the existing build image cache, run the above command with the `-i` option.
 
@@ -57,9 +58,11 @@ Additional flags that can be passed to `hack/run-ci-e2e-test.sh` are
 
        
 Example command to spin up 2 Windows nodes and retain them after test run:
-```
+```shell script
 hack/run-ci-e2e-test.sh -s -n 2      
 ```
+
+Please note that you do not need to run `hack/olm.sh run` before `hack/run-ci-e2e-test.sh`.
 
 ## Bundling the Windows Machine Config Operator
 This directory contains resources related to installing the WMCO onto a cluster using OLM.

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -8,6 +8,7 @@
 #    $1      Action                   run/cleanup the operator installation
 #    -i      Ignore image cache       builds the operator image without using local image build cache
 #    -c=     Operator Image           container url and tag for the operator image
+#    -k=     Private key file         path to the private key file
 
 
 # container tool to use with operator-sdk
@@ -26,10 +27,12 @@ fi
 shift # shift position of the positional parameters for getopts
 
 # Options
-while getopts ":ic:" opt; do
+PRIVATE_KEY=""
+while getopts ":ic:k:" opt; do
     case "$opt" in
 	i) noCache="--image-build-args=\"--no-cache\"";;
 	c) OPERATOR_IMAGE="$OPTARG";;
+	k) PRIVATE_KEY="$OPTARG";;
 	?) error-exit "Unknown option"
     esac
 done
@@ -52,7 +55,7 @@ case "$ACTION" in
   build_WMCO $OSDK
 
   # Setup and run the operator
-  run_WMCO $OSDK
+  run_WMCO $OSDK $PRIVATE_KEY
 
 	;;
     cleanup)


### PR DESCRIPTION
Using the `-k private-key-path` input with the `run` option will result in the cloud-private-key secret being created. This improves the development workflow.