### PR TITLE
WINC-460: Switch to using go1.15 

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.14
+  tag: golang-1.15

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,12 +5,12 @@ LABEL stage=build
 RUN microdnf -y install rsync make git tar findutils diffutils
 RUN mkdir /build/
 
-# Install go 1.14
+# Install go 1.15
 RUN mkdir /build/go
 WORKDIR /build/go
-RUN curl https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -L -o go.tar.gz
+RUN curl https://golang.org/dl/go1.15.4.linux-amd64.tar.gz -L -o go.tar.gz
 # Check sha256
-RUN echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go.tar.gz" |sha256sum -c
+RUN echo "eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5  go.tar.gz" |sha256sum -c
 RUN tar -C /usr/local -xzf go.tar.gz
 ENV PATH=${PATH}:/usr/local/go/bin
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -12,12 +12,12 @@ LABEL stage=build
 RUN microdnf -y install rsync make git tar findutils diffutils
 RUN mkdir /build/
 
-# Install go 1.14
+# Install go 1.15
 RUN mkdir /build/go
 WORKDIR /build/go
-RUN curl https://golang.org/dl/go1.14.7.linux-amd64.tar.gz -L -o go.tar.gz
+RUN curl https://golang.org/dl/go1.15.4.linux-amd64.tar.gz -L -o go.tar.gz
 # Check sha256
-RUN echo "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5  go.tar.gz" |sha256sum -c
+RUN echo "eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5  go.tar.gz" |sha256sum -c
 RUN tar -C /usr/local -xzf go.tar.gz
 ENV PATH=${PATH}:/usr/local/go/bin
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,19 +7,10 @@
 
 # We cannot use a golang image as building the kubelet requires rsync and that is not present plus there is no easy way
 # to install it.
-FROM registry.access.redhat.com/ubi8/ubi-minimal as build
+FROM golang-builder:rhel_8_1.15 as build
 LABEL stage=build
-RUN microdnf -y install rsync make git tar findutils diffutils
+RUN yum -y install rsync make go git tar findutils diffutils
 RUN mkdir /build/
-
-# Install go 1.15
-RUN mkdir /build/go
-WORKDIR /build/go
-RUN curl https://golang.org/dl/go1.15.4.linux-amd64.tar.gz -L -o go.tar.gz
-# Check sha256
-RUN echo "eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5  go.tar.gz" |sha256sum -c
-RUN tar -C /usr/local -xzf go.tar.gz
-ENV PATH=${PATH}:/usr/local/go/bin
 
 # Build WMCO
 # The source here corresponds to the code in the PR and is placed here by the CI infrastructure.

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.14') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.15') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
This PR switches to building with go1.15.
The kubernetes node binaries we are using are also being updated, as the update was blocked by being on go1.14