### PR TITLE
WINC-513: Ensure all transfered files have the correct hash

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/apis"
 	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller"
-	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/payload"
 	"github.com/openshift/windows-machine-config-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -120,18 +120,18 @@ func main() {
 
 	// Checking if required files exist before starting the operator
 	requiredFiles := []string{
-		wkl.FlannelCNIPluginPath,
-		wkl.HostLocalCNIPlugin,
-		wkl.WinBridgeCNIPlugin,
-		wkl.WinOverlayCNIPlugin,
-		wkl.HybridOverlayPath,
-		wkl.KubeletPath,
-		wkl.KubeProxyPath,
-		wkl.IgnoreWgetPowerShellPath,
-		wkl.WmcbPath,
-		wkl.CNIConfigTemplatePath,
-		wkl.HNSPSModule,
-		wkl.WindowsExporterPath,
+		payload.FlannelCNIPluginPath,
+		payload.HostLocalCNIPlugin,
+		payload.WinBridgeCNIPlugin,
+		payload.WinOverlayCNIPlugin,
+		payload.HybridOverlayPath,
+		payload.KubeletPath,
+		payload.KubeProxyPath,
+		payload.IgnoreWgetPowerShellPath,
+		payload.WmcbPath,
+		payload.CNIConfigTemplatePath,
+		payload.HNSPSModule,
+		payload.WindowsExporterPath,
 	}
 	if err := checkIfRequiredFilesExist(requiredFiles); err != nil {
 		log.Error(err, "could not start the operator")

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -109,6 +109,9 @@ get_WMCO_logs
 # Run the upgrade tests and skip deletion of the Windows VMs
 OSDK_WMCO_test $OSDK "-run=TestWMCO/upgrade -v -timeout=90m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
 
+# Run the reconfiguration test
+OSDK_WMCO_test $OSDK "-run=TestWMCO/reconfigure -v -timeout=90m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
+
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then

--- a/pkg/controller/payload/payload.go
+++ b/pkg/controller/payload/payload.go
@@ -1,5 +1,14 @@
-package wellknownlocations
+package payload
 
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// Payload files
 const (
 	// payloadDirectory is the directory in the operator image where are all the binaries live
 	payloadDirectory = "/payload/"
@@ -44,3 +53,21 @@ const (
 	// this binary mounted
 	WindowsExporterPath = payloadDirectory + WindowsExporterName
 )
+
+// FileInfo contains information about a file
+type FileInfo struct {
+	Path   string
+	SHA256 string
+}
+
+// NewFileInfo returns a pointer to a FileInfo object created from the specified file
+func NewFileInfo(path string) (*FileInfo, error) {
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get contents of file")
+	}
+	return &FileInfo{
+		Path:   path,
+		SHA256: fmt.Sprintf("%x", sha256.Sum256(contents)),
+	}, nil
+}

--- a/pkg/controller/windowsmachine/nodeconfig/nodeconfig.go
+++ b/pkg/controller/windowsmachine/nodeconfig/nodeconfig.go
@@ -8,8 +8,8 @@ import (
 
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/windows-machine-config-operator/pkg/clusternetwork"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/payload"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/retry"
-	wkl "github.com/openshift/windows-machine-config-operator/pkg/controller/wellknownlocations"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/windows"
 	"github.com/openshift/windows-machine-config-operator/version"
 	"github.com/pkg/errors"
@@ -260,7 +260,7 @@ func (nc *nodeConfig) configureCNI() error {
 		return errors.Wrapf(err, "error populating host subnet in node network")
 	}
 	// populate the CNI config file with the host subnet and the service network CIDR
-	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, wkl.CNIConfigTemplatePath)
+	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, payload.CNIConfigTemplatePath)
 	if err != nil {
 		return errors.Wrapf(err, "error populating CNI config file %s", configFile)
 	}

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
+)
+
+// reconfigurationTest tests that the correct behavior occurs when a previously configured Machine is configured
+// again. In practice, this exact scenario should not happen, however it simulates a similar scenario where a Machine
+// was almost completely configured, an error occurred, and the Machine is requeued. This is a scenario that should be
+// expected to be ran into often enough, for reasons such as network instability. For that reason this test is warranted.
+func reconfigurationTest(t *testing.T) {
+	testCtx, err := NewTestContext(t)
+	require.NoError(t, err)
+
+	nodes, err := testCtx.kubeclient.CoreV1().Nodes().List(context.TODO(),
+		metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})
+	require.NoError(t, err)
+
+	// Remove the version annotation of one of the nodes
+	// Forward slash within a path is escaped as '~1'
+	escapedVersionAnnotation := strings.Replace(nc.VersionAnnotation, "/", "~1", -1)
+	patchData := fmt.Sprintf("[{\"op\": \"remove\", \"path\": \"/metadata/annotations/%s\"}]", escapedVersionAnnotation)
+	_, err = testCtx.kubeclient.CoreV1().Nodes().Patch(context.TODO(), nodes.Items[0].Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	// The Windows node should eventually be returned to the state we expect it to be in
+	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, false, true)
+	assert.NoError(t, err, "error waiting for Windows nodes to be reconfigured")
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -47,6 +47,7 @@ func TestWMCO(t *testing.T) {
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
 	t.Run("upgrade", upgradeTestSuite)
+	t.Run("reconfigure", reconfigurationTest)
 	t.Run("destroy", deletionTestSuite)
 }
 


### PR DESCRIPTION
This commit makes it so that we check the sha256 checksum of files that
were previously transfered to Windows nodes. If the checksum does not
match what we expect it to, the correct file will be transfered over.