### PR TITLE
[build] Add `microdnf clean all` to Dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 # to install it.
 FROM registry.access.redhat.com/ubi8/ubi-minimal as build
 LABEL stage=build
-RUN microdnf -y install rsync make git tar findutils diffutils
+RUN microdnf -y install rsync make git tar findutils diffutils && microdnf clean all
 RUN mkdir /build/
 
 # Install go 1.14

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -9,7 +9,7 @@
 # to install it.
 FROM registry.access.redhat.com/ubi8/ubi-minimal as build
 LABEL stage=build
-RUN microdnf -y install rsync make git tar findutils diffutils
+RUN microdnf -y install rsync make git tar findutils diffutils && microdnf clean all
 RUN mkdir /build/
 
 # Install go 1.14
@@ -138,7 +138,7 @@ ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
 # Changes needed for our CI
 
 # install make package
-RUN microdnf -y install make tar gzip wget
+RUN microdnf -y install make tar gzip wget && microdnf clean all
 
 # Copy go from build stage, install within this stage
 COPY --from=build /build/go/go.tar.gz .


### PR DESCRIPTION
This avoids problems when files that cannot be archived with tar, like sockets, are present in the yum cache (container images are tar archives).