### PR TITLE
[k8s] Update submodule to current openshift:release-4.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "kubernetes"]
 	path = kubernetes
 	url = https://github.com/openshift/kubernetes
-	branch = release-4.6
+	branch = release-4.7
 [submodule "promu"]
 	path = promu
 	url = git://github.com/openshift/prometheus-promu


### PR DESCRIPTION
Updates the kubernetes submodule to commit ad738ba548b6d6b5cd2e83351951ccd7019afa4c.
Also changes the referenced branch in .gitmodules to release-4.7

Commands run:
```
cd kubernetes
git fetch origin && git checkout ad738ba548b6d6b5cd2e83351951ccd7019afa4c
cd ..
```

That commit includes the kubelet changes that allow for querying the WinEvent logs with `oc adm node-logs`.

~~Blocked by https://github.com/openshift/windows-machine-config-operator/pull/179~~