### PR TITLE
WINC-519: [release-4.6] skip operator deployment in e2e tests

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -86,12 +86,26 @@ fi
 # https://steps.svc.ci.openshift.org/help/ci-operator#release
 OPERATOR_IMAGE=${OPERATOR_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//stable:windows-machine-config-operator-test}}
 
-# Setup and run the operator
-if ! run_WMCO $OSDK; then
-  # Try to get the WMCO logs if possible
-  get_WMCO_logs
-  cleanup_WMCO $OSDK
-  exit 1
+# OO_INDEX points to the WMCO bundle index image created through https://docs.ci.openshift.org/docs/how-tos/testing-operator-sdk-operators/ workflow in CI.
+# Setup and run the operator only if $OO_INDEX is not set in CI, and the operator deployment is not available.
+OO_INDEX=${OO_INDEX:-}
+
+# SKIP_OPERATOR_RUN_CLEANUP will skip operator deployment and cleanup if set to true
+SKIP_OPERATOR_RUN_CLEANUP=${SKIP_OPERATOR_RUN_CLEANUP:-"false"}
+
+# TODO: Remove the deployment status check once optional operator testing workflow is implemented
+if [ ! -z "$OO_INDEX" ] && oc rollout status deployment windows-machine-config-operator -n openshift-windows-machine-config-operator; then
+   SKIP_OPERATOR_RUN_CLEANUP="true"
+fi
+
+if ! $SKIP_OPERATOR_RUN_CLEANUP; then
+  # Setup and run the operator
+  if ! run_WMCO $OSDK; then
+    # Try to get the WMCO logs if possible
+    get_WMCO_logs
+    cleanup_WMCO $OSDK
+    exit 1
+  fi
 fi
 
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
@@ -119,8 +133,10 @@ if ! $SKIP_NODE_DELETION; then
   # Get logs on success before cleanup
   printf "\n####### WMCO logs for upgrade and deletion tests #######\n"
   get_WMCO_logs
-  # Cleanup the operator resources
-  cleanup_WMCO $OSDK
+  if ! $SKIP_OPERATOR_RUN_CLEANUP; then
+    # Cleanup the operator resources
+    cleanup_WMCO $OSDK
+  fi
 else
   # Get logs on success
   printf "\n####### WMCO logs for upgrade tests #######\n"


### PR DESCRIPTION
This commit checks if the OO_INDEX env
var is set and the opeartor deployment
is rolled out to skip deployment in
WMCO e2e tests.

Backport of #183 