### PR TITLE
WINC-453: [community-4.6] [hack] Extend OSDK run timeout to 5min

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -35,12 +35,11 @@ OSDK_WMCO_management() {
   local COMMAND=$1
   local OSDK_PATH=$2
 
-  # Currently this fails even on successes, adding this check to ignore the failure
-  # https://github.com/operator-framework/operator-sdk/issues/2938
-  if ! $OSDK_PATH $COMMAND packagemanifests --olm-namespace openshift-operator-lifecycle-manager --operator-namespace openshift-windows-machine-config-operator \
-  --operator-version 0.0.0 ; then
-    echo operator-sdk $1 failed
-  fi
+  $OSDK_PATH $COMMAND packagemanifests \
+    --olm-namespace openshift-operator-lifecycle-manager \
+    --operator-namespace openshift-windows-machine-config-operator \
+    --operator-version 0.0.0 \
+    --timeout 5m
 }
 
 build_WMCO() {


### PR DESCRIPTION
The tests have been failing a lot because
`operator-sdk run packagemanifests` has a default timeout of 2min which
was often missed. This commit extends the timeout to 5min to ensure the
command can return properly even when running on slower infrastructure.

With version 0.19.4 of the operator-sdk, the `run` command should now
return correct values, hence the condition and comment to explicitly
check for that have been removed.

Backport of #195