### PR TITLE
[release-4.6] Update namespace for label component name in bundle.Dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 
 # This block are standard Red Hat container labels
-LABEL name="openshift4/windows-machine-config-operator-bundle" \
+LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator bundle" \
     io.k8s.description="Windows Machine Config Operator's OLM bundle image" \


### PR DESCRIPTION
windows-machine-config-operator-bundle comet container repository in openshift4 namespace has been deprecated and moved to openshift4-wincw namespace. This commit updates the label name to point the repository in openshift4-wincw namespace.