### PR TITLE
[build] Fix version and remove operator-sdk build 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -38,6 +38,23 @@ COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
+WORKDIR /build/windows-machine-config-operator/
+# Copy files and directories needed to build the WMCO binary
+# `make build` uses `get_version()` in `hack/common.sh` to determine the version of binary created.
+# Any new file added here should be reflected in `hack/common.sh` if it dirties the git working tree.
+COPY version version
+COPY tools.go tools.go
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor vendor
+COPY .gitignore .gitignore
+COPY Makefile Makefile
+COPY build build
+COPY cmd cmd
+COPY hack hack
+COPY pkg pkg
+RUN make build
+
 # Build the operator image with following payload structure
 # /payload/
 #├── cni
@@ -94,7 +111,7 @@ ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_NAME=windows-machine-config-operator
 
 # install operator binary
-COPY build/_output/bin/windows-machine-config-operator ${OPERATOR}
+COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-machine-config-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -14,25 +14,10 @@ RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.4/o
     && tar -xzf openshift-origin-client-tools.tar.gz \
     && rm -rf ./{openshift*,README.md}
 
-# Build WMCO
 # The source here corresponds to the code in the PR and is placed here by the CI infrastructure.
 WORKDIR /build/windows-machine-config-operator/
 # Copy .git metadata so that we can generate the version for the WMCO binary
 COPY .git .git
-# Copy files and directories needed to build the WMCO binary
-COPY build build
-COPY cmd cmd
-COPY deploy deploy
-COPY hack hack
-COPY pkg pkg
-COPY test test
-COPY vendor vendor
-COPY version version
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY Makefile Makefile
-COPY tools.go tools.go
-RUN make build
 
 # Build WMCB
 WORKDIR /build/windows-machine-config-operator/windows-machine-config-bootstrapper/
@@ -67,6 +52,24 @@ WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
+
+# Build WMCO
+WORKDIR /build/windows-machine-config-operator
+# Copy files and directories needed to build the WMCO binary
+COPY build build
+COPY cmd cmd
+COPY deploy deploy
+COPY hack hack
+COPY pkg pkg
+COPY test test
+COPY vendor vendor
+COPY version version
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY Makefile Makefile
+COPY tools.go tools.go
+COPY .gitignore .gitignore
+RUN make build
 
 # Build the operator image with following payload structure
 # /payload/

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -5,7 +5,7 @@
 ## Build
 To build the operator image, execute:
 ```shell script
-operator-sdk build quay.io/<insert username>/wmco:$VERSION_TAG --image-builder podman
+podman build . -t quay.io/<insert username>/wmco:$VERSION_TAG -f build/Dockerfile
 ```
 
 The operator image needs to be pushed to a remote repository:

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -49,8 +49,7 @@ build_WMCO() {
       error-exit "OPERATOR_IMAGE not set"
   fi
 
-  $OSDK build "$OPERATOR_IMAGE" --image-builder $CONTAINER_TOOL $noCache \
-    --go-build-args "-ldflags -X=github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}"
+  $CONTAINER_TOOL build . -t "$OPERATOR_IMAGE" -f build/Dockerfile $noCache
   if [ $? -ne 0 ] ; then
       error-exit "failed to build operator image"
   fi
@@ -126,12 +125,15 @@ cleanup_WMCO() {
 }
 
 # returns the operator version in `Version+GitHash` format
+# we are just checking the status of files that affect the building of the operator binary
+# the files here are selected based on the files that we are transferring while building the
+# operator binary in `build/Dockerfile`
 get_version() {
   OPERATOR_VERSION=1.0.1
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 
-  if [ -n "$(git status --porcelain)" ]; then
+  if [ -n "$(git status version tools.go go.mod go.sum vendor Makefile build cmd hack pkg --porcelain)" ]; then
     VERSION="${VERSION}-dirty"
   fi
 

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -42,7 +42,6 @@ source $WMCO_ROOT/hack/common.sh
 
 cd $WMCO_ROOT
 OSDK=$(get_operator_sdk)
-VERSION=$(get_version)
 
 # Builds the container image and pushes it to remote repository. Uses this built image to run the operator on the cluster.
 # It is user's responsibility to clean old/unused containers in container repository as well as local system.

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -86,6 +86,11 @@ fi
 # https://steps.svc.ci.openshift.org/help/ci-operator#release
 OPERATOR_IMAGE=${OPERATOR_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//stable:windows-machine-config-operator-test}}
 
+# generate the WMCO binary if we are not running the test through CI. This binary is used to validate WMCO version
+# while running the validation test. For CI, we use different `wmcoPath` based on how we generate the container image.
+if [ -z "$OPENSHIFT_CI" ]; then
+  make build
+fi
 # Setup and run the operator
 if ! run_WMCO $OSDK; then
   # Try to get the WMCO logs if possible


### PR DESCRIPTION
this commit removes the usage of `operator-sdk build`
command to build the operator image.
We are now building the operator binary in dockerfile
similar to what we are doing in dockerfile.ci and
using `make build` which uses `build/build.sh` to set
the version for operator binary. Removed other
references of setting version in `hack/olm.sh`

Also included building the WMCO binary using
`make build` while launching the tests through local
machine.
We use this binary for validating the version
annotation on the operator.
This change is needed as `operator-sdk build`
used to generate the operator binary before building
the container image. Now that we are using
`podman build`, we need to explicitly use
`make build` to generate operator binary for e2e test.
Only e2e tests launched through local machine needs
this change. We use different `wmcoPath` while running
the test through CI based on how we generate the
container image.

Removing `operator-sdk build` dependency is important
because `operator-sdk build` is being depreciated in
operator-sdk version 1.x.

Also, this enables us to trigger automatic builds on
quay