### PR TITLE
[release-4.6][deploy] Fix channel name and description

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -20,10 +20,6 @@ spec:
     Please ensure that when installing this operator, the startingCSV you subscribe to is supported on the
     version of OKD/OCP you are using. This CSV is meant for OKD/OCP 4.6.
 
-    Upgrading the OKD/OCP cluster from version 4.6 to 4.7 while running this operator is not supported. When upgrading
-    a cluster, remove all Windows MachineSets and uninstall this operator. Once the cluster upgrade process has completed,
-    you can reinstall the operator, and recreate all Windows MachineSets.
-
     ## Documentation
 
     ### Introduction

--- a/deploy/olm-catalog/windows-machine-config-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: preview
+  operators.operatorframework.io.bundle.channels.v1: preview
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
- Remove upgrade verbiage from the description in the CSV which only applies to the community operator
- The channel name needs to match the name in the Dockerfile label in the release Dockerfile.