### PR TITLE
Bug 1905716: [release-4.6] Fix WMCO version and info missed in web console

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -4,33 +4,30 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: OpenShift Optional
+    certified: "false"
+    containerImage: REPLACE_IMAGE
+    createdAt: REPLACE_DATE
+    description: An operator that enables Windows container workloads on OCP
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     repository: https://github.com/openshift/windows-machine-config-operator
+    support: "Red Hat"
   name: windows-machine-config-operator.v0.0.0
   namespace: openshift-windows-machine-config-operator
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}
   description: |-
-    Issues with this distribution of WMCO can be opened against the [WMCO component Bugzilla](https://bugzilla.redhat.com/buglist.cgi?product=OpenShift%20Container%20Platform&component=Windows%20Containers&resolution=---).
-    Please read through the [troubleshooting document](https://github.com/openshift/windows-machine-config-operator/blob/community-4.6/docs/TROUBLESHOOTING.md)
-    before opening an issue.
-
-    Please ensure that when installing this operator, the startingCSV you subscribe to is supported on the
-    version of OKD/OCP you are using. This CSV is meant for OKD/OCP 4.6.
-
-    ## Documentation
-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OKD/OCP clusters. The operator is configured to watch for Machines with a `machine.openshift.io/os-id: Windows`
+    be run on OCP clusters. The operator is configured to watch for Machines with a `machine.openshift.io/os-id: Windows`
     label. You can initiate the process by creating a MachineSet that uses a Windows image with the Docker
     container runtime installed. The operator completes all the necessary steps to configure the underlying VM so that it can join
     the cluster as a worker node.
 
     ### Pre-requisites
-    * OKD/OCP 4.6 cluster running on Azure or AWS, configured with hybrid OVN Kubernetes networking
+    * OCP 4.6.8+ cluster running on Azure or AWS, configured with hybrid OVN Kubernetes networking
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -128,6 +125,12 @@ spec:
     ```
     Example MachineSet for other cloud providers:
     - [AWS](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-aws.md)
+
+    ### Reporting issues
+    Issues with this distribution of WMCO can be opened against the [Windows Container Bugzilla component](https://bugzilla.redhat.com/buglist.cgi?product=OpenShift%20Container%20Platform&component=Windows%20Containers&resolution=---).
+    Please read through the [troubleshooting document](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/TROUBLESHOOTING.md)
+    before opening an issue.
+
   displayName: Windows Machine Config Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAJIAAACSCAYAAACue5OOAAAABmJLR0QA/wD/AP+gvaeTAAAPsUlEQVR42u2dC3BU1RnHr0p91M7U6WNaFSuVsPcuGyJjJHvvhjygD0EUtRZBUSEjPjFVWwG1RfCFVR7S8cHYmfpolLbq1CotdhDEtohiNpts3tlnNtmQkARMAgnksXv6nbubZZNs4ubeva+z55v5BiYky+49v5zzne/7n+8wTBpafS57kVvgCjw8t8LNmzZ4bKbX3YJpl1tgD7ptbAP82Ql+DLwXHEW9N/q1zuj3HMQ/I/4sfg3BdLvLNiO/Ns98IUONPPPMmX4JDPYyGPgXwPdFIUGKuo3tcAnsXoB1m4c3LXVbM6bSkTCYufMyvu/m2eXgJTCgTYpDk7wHwP/sEribG7JN36MjpUOr47lpLp5dCwN1CDykI3jG8xAsh597BO5hn818KR1BDc1fOO0CiHGKYfn4AgYmbAB4xvMwhgrirdX4M9GRVSvmETgbXiLA+wwMz3gOn4l7023jBDrSChhimDPdPHctPOjPCIRnvIDdjneC+wsLp1ACZBp+iC4bWwQP1ps2AI11D05ToCXMWZQICTMQ7G5ugYfoSmOARrhHYOtxGgOezRmUkCTMazPNiST7KDzjLnk8m0tJGcdwRhhigp0G34GpuNNjS3zWzB9Qck4vY2fgoFKVjDN5/pXHxt2V9sudd67lR9GyBYVCVvzEfYxLQelZyrCxv4SHcJSCkDLvwqWhtAHImZV1fjShSAdfidkJ1AiHs7O/SXhW2pIBH7aSDrjCzrMVblvGdDLjoVzT1Tg4pAOtmh+D3NMCsmYim+lO+GCDdHBV9yFcDCajRmbjttIB1dZBZLcZj4UxIYLakEswvUEHUi8pAtNOwxWAayyWsyHge48OoO78Q/fCjHMMAxEkyP5JysMPrFqCWh7/NTEwVQlsmV3v6QG8nMGb/RsJD9xbMAsd2/cRCofDCFtPTSXyLs43NkQ8i0qtHCrnueBuvc5MkcCafYsEiA5vewYN9J5Aoy00NISO7tmF3HmzDAvRsFdYOReMmf40TiTszgKrb0O9zQH0dTZw4jg6/NzjhoVo2J08e0BneSLuLiMD5Lvahro+/29sGUvW+toOo8DdNxsSotjMBHIUPWWshwwJUZ4Ftb9TgkKDg0iqYfi6HYeQ75pcw0E07JVwlEsPtTNDlj2CT6xF/d1dKFU2NDggQunONRsKIux2KxeuFDIKNIGoWZh6HhydcRgNoMaVN6ATfg9Syvp7ulHLU48aBqJhL7OyfXU53HfVD64NJgXxXJUjKQ6Sar0BP2pccZ0hIIrbydVpIUozBkSw1Bx581U01N+P1LZwOCTC6/lJtu4hGvYqK7tZHYigs4ZRlI3B9Q+h/q6vkNaGIW7f+ZruIRqOl6rhJI/iQn0jaKwbb12MjjfUIr3ZqaOdqGnNvbqFaNgdVrZD0QMF0Oxgla7joPmzxcxzOBRCerYTHhfyL12gS4hiSxxv3qEIRP45lh9GO5bpEqK2V7ejwVOnkFEMl1uO7fs38s67XHcQDS9xNbkzLQrkjMTDi7oDqOnBVehk+xFkVBs8eRK17diqK4iGvZw3u1NdRxP0dgLW94v5qKe6ApFi+JehqXilbiCK1eNyTKtSV9WPdELTRxxUmCXGQSGdx0FSyy34l8M3gVxFTYjEWcnK9aREphvtCqILiFq3b0IDfb2IdBPlKrvfh1pgpqYQnVYJcFtkC9VwOxXN5R3FK8RKe7rZwPHjqOXZ9ZpCFCmfcP1Y+Sp9Noo0udJOpXj9PNTjLFOtrKFXazuwHzmuKdAMpKh26WU5slmvUeUdpFgPLgK3BFHQ50X12zYh+9wszWYliJWmSEg+sjdpInPd8mRCmWs6QxTvTZXlqHpdMSrlzarDVGk1PSsli/25qmWNohsVlXeQAFG8+/f8C1UsXaTurMSz3ZNMPootiNXJBy3kVZV3kABRzJubkPvtN1DZzwUVZyW2SF9ao2F5x0A/JUcKRHEedDWgut9vQKW5sxQHCTTeDcnV1KD7/KhbgVIfB216DJSEPZSaMRD1TBqieA8c+gxV3nOr4jBV5SfRHQ6WtfuVhKjzw3cpMQpAFO+1TzyibCrAyu1MIpPNfqkkSDgeoiZ/OZvIcZpASZAcVm7ioLs+h/2x0sVZCpKyEKkBEnY4KCBMpMVep3SQTUFSFiK1QILl7YMJdmvilVUUJANDpBZIkOnuSQgRvtVQjUvzKEjKQqQWSHYMExyQTVQSWa5GAlINkEIgNWl/foOY7Jzs+/Nfm4c6X96CwgMDCV63D7VvfgL5FtkkJF4F8T11t7cpCpFaIInLm8BuTwRSCSkgtW1cIz9N8crWMa/bDnVA2Zn8R4uJAamC51yJAu0mEkDCM4knP1P+gENTiNGGu5akQtnQAqdwSQDJzpsHR3YUidwJgkgAabDjSMre62hL2cHNaicRIIlpACuXHS+nvZmCREGSVMTlua3xRdoXKEgUJImNJ+zxgfYnFCQKkqRyCc91xgfaHRQkCpK0xCQbitTXctmL1FRCUpDIAikiK5lhhmWNK6QgUZBkit3uYVw8t5KCREGSleG2sa/gc/0bKUgUJJkz0l68Y3uNgkRBkpcCYOsZtS+goSCRBxIoJltV0SBRkMgGSdQmwVWVbpJACp86iTxzZ6bgvJ0wtmgrQZYyxuG9tfi9pIHUj8sjR0gCCdvhtffJfp9YdzRGRrJ5o3xAH7iDGBnJiKQkfLgu0kAa+uqoCJOUmQlLUI48/YgoYhttWJTme6RYlIJM+nXhvfgevAMF62qIA8luZcMYpD7SQIpf5gZamibliZSRY+SxgUbU7CidlCu9nGkJUqmVRYzaNxsZUbOttMba+DMSR0EiDSItQaJL2zhL27gQ0aUt4dJGXLAdAgBaf/uA5GC77cl1iU97uBuQ7+F7xS28pGD7V0VEB9vEbf9b18u/Xt2/ce3Y5lYpuLad5O2/i6iEJPRbSsUpEs9V1jED5FkgPyHpITgheZCWSBL76AGiJZJxQerGJZJdFCQKkvyiLZWRUJBkX34D7QCpsI2ClBJhm4fnVlCQKEgyZ6RXsB6pgIJEQZJ12lbg7mZq88wXUpAoSHK8odDEDR/ZPkJBoiBJzGqH4jvZ7qUgUZAk5pA643tHbqMgUZAkNiUtPd2knTctpSBRkKS1/+M2n25EKpgupiBRkCRt/edYZo++yCZATuu/WfKLq4tyxxZt4WSJ/NZ/mcS0/oP4aECbG5HUakYKeiLZ98fBiZHRA9T4fApOkRDUjBRu4HZpdpu2GiBhUZofOttiKcikZyJoOCpCBCrIRMrIxuc2iN8jRZaCNU5Br5sYkKDt37bxGrYPGR0kI2qsjdqw3W7LnK7Z9aNKgkQhUg+kCW9IgsTkGqOCRCFSFyRo1v738S/9mzP9EiNes0Uh0gAkwZSj6e3aqQaJQqQ+SCAb6UriYmTTaiVBOvbpxymEqIeCk8DFi5IVXdbMJV8Lkjf7sm8rejky3K7d/k4JCg0N0pkoxR501aO6px5DdsGi9LJ2cZLXtXNvKh10e6+fh7odh1A4HKYQyQWoKYBcr7+Kyn7Gq6PPTtZAxy2oVXtrun8F6j3cTCGS6L6PdqHyJQtV7Bc5o4iZjKl93q112zNooPcEhShJD9gPoaqH7lb52FESQfaYnJKNu1FNkESHE7IdH7yTMH6iEEWXMSixiLuy3FkqN4oQ+2k/PWmQ0BLmLLX7S8YKm4vzUVfZ6fiJQgTe3ITcb7+BHFcJqgM0fCwbMcwURoqpfVRptAfuuw11Oh00DtqzG1UsW6QJQHGZ7BcZqRaZldg6rUCq4tnIpSmri1CgrDTtAGpylqPqdcWolDdrChFcpXVK8mwUm5VspmVaQhTz3EwxR9IMPYqIj4N8XjEOss/N0hSghHJaybMSw5wBA3tAU4ji1+oFNjFngmMG4iAKNiPvu28jxzX5ugAoKl7rAQbOZFJhkI3mlS7mJgPRiDX7lsXIv/cjYiDyf7oPOW+/UTcAxWYj3rSCSaVB15ISvUAUc4gdcC4lUG43bhxUVYFq1/8GlQozdQcRBNguJtUmKigVvLJ00hDFq/XyLxcLlWrIWFMWB0HXtoaXtqKywit0B1BUARmuycuYyShhLhtbpDeIRuwuFs4Vcy041tAzRN4P3kPl1xbqEqDThVl2B6OU4cAbruX6WI8QjXgIy69H/k/26A6gxv/tR86iJboGKCqj7WCUNrc1YyoAcFSvEMXHTzgH01RdpTlAzdASWQ15R6paHTutZp5Rw1JRh1MUovgHUzBbzMkEG33qQ4TlHX98EZXNy9Y9QBMeMVLSIFH5ut4hGjFdL8qLxE8qxkGOxfMNA1BEa2SuZdQ2f+G0cwGKMiNANCIvcscy1PjZf5STd3x5EFXde7uhAIqUQdi+GmHqdxgtzGczXwpwdBoFophDzgbHT821qYufmhvqInGQzWI4iPBW3yFkFDBamkdgFwAkg4aBKP4Bzs8WczmymjrEZK5WwwE07FU57BpGDwZHmFYZDaIRscENPxVrXJOXuX6IKm5aYFiAIo2yTH9h9GRwSnezESEasWO58xbUePDA18dBpV+gytUrDQ1QVMh/gNGb4Qrx6NY4RoIottxBjINrX80JrsMKuhoiZ8Y0kLmmvqrPNqSsqp9ymLAQzsb+1agQjZCrQMwTk6uAGz0OGjUTBXcvzDiH0bPVWCxnV0FagIQHLsYQt14nOimfB7b5rc6srPMZI9hBYep55TznJ+Xhk+KwnAVrCi3fYoxkqJCZUmHlaugA6qSab2W9+wsLz2WMaDiYc/Lcp3QgNZ+JKmSL9/VglVb2T3RANcsT7WRIskqeXWvP4cJ0cNUre5TnmNcyJJqTn2GFM1LH6UArfut1n2POjHyGZAPVwAUgKq+jA66cFKQcnjGTLlZtZZ/E98XTwU+hspHn/sCko9VdwWVDq5QOCoJ8jXUtb76CSXfD8s6yHI7OThJmoUro54gPZTDUIlbFZ5phfXdTQJI/vFify7KUnPHTBMuhHtRNYRlvGTOfqObNqygpyWfEt+B2KhSe061lcFcQ3Uo/dA1UNvMNJ8++jLuFpW9OiOvHTa6IKHHoYIY6C4LK38FvZUcazUDHK62ml2qWMGdTApSp2xXhQJPUskYF9LGedAtiajLKLXB0HG543omvezL88gWbC/jleMuRy15ER1ZDq7jSlAMz1T8wVHbjJBG7K6zm9x057JV0BPW49M2ddZlTYLfj5c/Omwd1FDQP4DtgcfK1jp89jY6UwawGrhOHwdsKW+dSGMijatT38P8BM04nLL2lYhojx3I5HQkCDWeE4ZTLPRDY7oD0wl58NAcGvhUvN3i7DbqpEC4/wN/D8YGw+DX4N/w9+Hvxz+BLXvBr4NfCr1mXw5nS8Zn+HyHt4N9YD/WtAAAAAElFTkSuQmCC
@@ -328,8 +331,9 @@ spec:
   keywords:
   - windows
   maintainers:
-  - {}
-  maturity: alpha
+    - email: team-winc@redhat.com
+      name: Red Hat OpenShift for Windows Containers team
+  maturity: stable
   minKubeVersion: 1.19.0
   provider:
     name: Red Hat

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -127,7 +127,7 @@ cleanup_WMCO() {
 
 # returns the operator version in `Version+GitHash` format
 get_version() {
-  OPERATOR_VERSION=0.0.1
+  OPERATOR_VERSION=1.0.0
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
Update WMCO binary version in hack/common.sh from 0.0.1 to 1.0.0 for the release.
Add the various metadata fields like description, createdAt, maintainers, containerImage, categories etc in CSV that are used to populate the operatorhub UI of WMCO.