### PR TITLE
[release-4.6] [deploy] Update WMCO channel and version

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -29,8 +29,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
     operators.operatorframework.io.bundle.manifests.v1=manifests/ \
     operators.operatorframework.io.bundle.metadata.v1=metadata/ \
     operators.operatorframework.io.bundle.package.v1=windows-machine-config-operator \
-    operators.operatorframework.io.bundle.channels.v1=preview \
-    operators.operatorframework.io.bundle.channel.default.v1=preview
+    operators.operatorframework.io.bundle.channels.v1=preview,stable \
+    operators.operatorframework.io.bundle.channel.default.v1=stable
 
 # This label gets replaced by render_templates, so it is safer to keep it on its own
 LABEL version="v0.0.0"

--- a/deploy/olm-catalog/windows-machine-config-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: preview
-  operators.operatorframework.io.bundle.channels.v1: preview
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: preview,stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -127,7 +127,7 @@ cleanup_WMCO() {
 
 # returns the operator version in `Version+GitHash` format
 get_version() {
-  OPERATOR_VERSION=1.0.0
+  OPERATOR_VERSION=1.0.1
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
This PR updates the WMCO default channel in annotations.yaml and the bundle.Dockerfile to "stable" 
on the release-4.6 branch. 
In addition we add both "preview" and "stable" channels to the list of available channels for release 1.0.1.
This also updates the WMCO version to 1.0.1 in hack script.

(cherry picked from commit 4d0f08383f52daa62b643900c03149b646e82974)