### PR TITLE
[wmco][e2e] Add test to check Node Status

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -139,6 +139,22 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, waitForAnnotations, 
 			log.Printf("waiting for annotations to be present on %d Windows nodes", nodeCount)
 		}
 		for _, node := range nodes.Items {
+			// check node status
+			readyCondition := false
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == v1.NodeReady {
+					readyCondition = true
+				}
+				if readyCondition && condition.Status != v1.ConditionTrue {
+					log.Printf("node %v is expected to be in Ready state", node.Name)
+					return false, nil
+				}
+			}
+			if !readyCondition {
+				log.Printf("expected node Status to have condition type Ready for node %v", node.Name)
+				return false, nil
+			}
+
 			for _, annotation := range annotations {
 				_, found := node.Annotations[annotation]
 				if !found {


### PR DESCRIPTION
This commit ensures that we test Node Status as a part of our e2e tests.
When the operator reconciles successfully, the Node can be in NotReady
state. This is an unexpected outcome and should be tested as a part of
waitForWindowsNodes function. The changes include checking if the Node
has condition type Ready and if it has a value 'true' for a successful
test.