### PR TITLE
[hack] Update WMCO version to 1.0.2

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -127,7 +127,7 @@ cleanup_WMCO() {
 
 # returns the operator version in `Version+GitHash` format
 get_version() {
-  OPERATOR_VERSION=1.0.1
+  OPERATOR_VERSION=1.0.2
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
This PR updates the WMCO version to 1.0.2 in hack/common.sh script.
