### PR TITLE
[release-4.6][test] fix failing upgrade and delete tests

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -96,26 +96,30 @@ func (tc *testContext) createWindowsMachineSet(replicas int32, windowsLabel bool
 // waitForWindowsNode waits until there exists nodeCount Windows nodes with the correct set of annotations.
 // if waitForAnnotations = false, the function will return when the node object is first seen and not wait until
 // the expected annotations are present.
-// if expectError = true, the function will wait for duration of 5 minutes for the nodes as the error would be thrown
-// immediately, else we will wait for the duration given by nodeCreationTime variable which is 20 minutes increasing
-// the overall wait time in test suite
+// if expectError = true, the function will wait for duration of 10 minutes if we are deleting all nodes i.e. 0 nodesCount
+// else 5 minutes for the nodes as the error would be thrown immediately, else we will wait for the duration given by
+// nodeCreationTime variable which is 20 minutes increasing the overall wait time in test suite
 func (tc *testContext) waitForWindowsNodes(nodeCount int32, waitForAnnotations, expectError, checkVersion bool) error {
 	var nodes *v1.NodeList
 	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac, nodeconfig.VersionAnnotation}
 	var creationTime time.Duration
 	startTime := time.Now()
 	if expectError {
-		// The time we expect to wait, if the windowsLabel is
-		// not used while creating nodes.
-		creationTime = time.Minute * 5
+		if nodeCount == 0 {
+			creationTime = time.Minute * 10
+		} else {
+			// The time we expect to wait, if the windowsLabel is
+			// not used while creating nodes.
+			creationTime = time.Minute * 5
+		}
 	} else {
 		creationTime = nodeCreationTime
 	}
 
-	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster, so to be on safe
-	// side, let's make it as 20 minutes per node. The value comes from nodeCreationTime variable.  If we are testing a
-	// scale down from n nodes to 0, then we should not take the number of nodes into account. If we are testing node
-	// creation without applying Windows label, we should throw error within 5 mins.
+	// We are waiting 20 minutes for each windows VM to be shown up in the cluster. The value comes from
+	// nodeCreationTime variable.  If we are testing a scale down from n nodes to 0, then we should
+	// not take the number of nodes into account. If we are testing node creation without applying Windows label, we
+	// should throw error within 5 mins.
 	err := wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*creationTime, func() (done bool, err error) {
 		nodes, err = tc.kubeclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: nodeconfig.WindowsOSLabel})
 		if err != nil {

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -53,7 +53,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 	if err := framework.Global.Client.Update(context.TODO(), windowsMachineSet); err != nil {
 		t.Fatalf("error updating windowsMachineSet custom resource  %v", err)
 	}
-	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster
+	// we are waiting 10 minutes for all windows machines to get deleted.
 	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, true, false)
 	if err != nil {
 		t.Fatalf("windows node deletion failed  with %v", err)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -215,7 +215,7 @@ func retryGET(url string) (*http.Response, error) {
 func (tc *testContext) createService(name string, serviceType v1.ServiceType, selector metav1.LabelSelector) (*v1.Service, error) {
 	svcSpec := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: name + "-",
 		},
 		Spec: v1.ServiceSpec{
 			Type: serviceType,


### PR DESCRIPTION
the defer deleteService in network test is not able to delete the
service in time. Sometimes it succeeds in deleting the service and
sometimes it takes a lot of time.
we are creating service of same name in upgrade test. In case the
service is not deleted, it throws an error.
This is causing our tests to fail.

The fix includes changing the service name. We are doing
this by using generateName field while creating the service

we are frequently coming across timeout while deleting the nodes
the nodes are usually deleted within a minute but sometimes they
time out.
this PR increases the timeout from 5 minutes to 10 minutes

Backport of #216 