### PR TITLE
[community-4.6][test] fix failing upgrade and delete tests

### DIFF
--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -53,7 +53,7 @@ func testWindowsNodeDeletion(t *testing.T) {
 	if err := framework.Global.Client.Update(context.TODO(), windowsMachineSet); err != nil {
 		t.Fatalf("error updating windowsMachineSet custom resource  %v", err)
 	}
-	// As per testing, each windows VM is taking roughly 12 minutes to be shown up in the cluster
+	// we are waiting 10 minutes for all windows machines to get deleted.
 	err = testCtx.waitForWindowsNodes(gc.numberOfNodes, true, true, false)
 	if err != nil {
 		t.Fatalf("windows node deletion failed  with %v", err)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -215,7 +215,7 @@ func retryGET(url string) (*http.Response, error) {
 func (tc *testContext) createService(name string, serviceType v1.ServiceType, selector metav1.LabelSelector) (*v1.Service, error) {
 	svcSpec := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: name + "-",
 		},
 		Spec: v1.ServiceSpec{
 			Type: serviceType,


### PR DESCRIPTION
the defer deleteService in network test is not able to delete the
service in time. Sometimes it succeeds in deleting the service and
sometimes it takes a lot of time.
we are creating service of same name in upgrade test. In case the
service is not deleted, it throws an error.
This is causing our tests to fail.

The fix includes changing the service name. We are doing
this by using generateName field while creating the service

we are frequently coming across timeout while deleting the nodes
the nodes are usually deleted within a minute but sometimes they
time out.
this PR increases the timeout from 5 minutes to 10 minutes

Backport of #216 