### PR TITLE
[release-4.6][test] Use generateName instead of Name

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -356,7 +356,7 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 	containerUserName := "ContainerAdministrator"
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "-deployment",
+			GenerateName: name + "-deployment-",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicaCount,
@@ -493,7 +493,7 @@ func (tc *testContext) createJob(name, image string, command []string, selector 
 	jobsClient := tc.kubeclient.BatchV1().Jobs(tc.workloadNamespace)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "-job",
+			GenerateName: name + "-job-",
 		},
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{


### PR DESCRIPTION
This is a backport of #236 

This commit ensures that we use generateName instead of Name                                        
for deployment and job objects.  

This change also requires changing the way we use win-webserver in the
upgrade test.
In the upgrade test, we are getting the win-webserver deployment object
created in the network test using a get method. We are getting this
deployment using the deployment name.
As we will be using generateName across the board, we need to change the
way we get the windows web server deployment.
As this is a web server deployment, we can create a new one for
upgrade tests just before we start the test and the linux curler which
ensures that the webserver is functioning across an upgrade, and not use
the win-webserver created in network test.
