### PR TITLE
[community-4.6][test] Use generateName instead of Name

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -356,7 +356,7 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 	containerUserName := "ContainerAdministrator"
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "-deployment",
+			GenerateName: name + "-deployment-",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicaCount,
@@ -493,7 +493,7 @@ func (tc *testContext) createJob(name, image string, command []string, selector 
 	jobsClient := tc.kubeclient.BatchV1().Jobs(tc.workloadNamespace)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name + "-job",
+			GenerateName: name + "-job-",
 		},
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,7 +37,7 @@ func upgradeTestSuite(t *testing.T) {
 	require.NoError(t, err)
 
 	// test if Windows workloads are running by creating a Job that curls the workloads continuously.
-	err = testCtx.deployWindowsWorkloadTester()
+	testerJob, err := testCtx.deployWindowsWorkloadAndTester()
 	require.NoError(t, err, "error testing Windows workloads")
 
 	// apply configuration steps before running the upgrade tests
@@ -45,6 +46,10 @@ func upgradeTestSuite(t *testing.T) {
 
 	t.Run("Operator version upgrade", testUpgradeVersion)
 	t.Run("Version annotation tampering", testTamperAnnotation)
+
+	// Delete Job
+	err = testCtx.deleteJob(testerJob.Name)
+	require.NoError(t, err)
 }
 
 // testUpgradeVersion tests the upgrade scenario of the operator. The node version annotation is changed when
@@ -68,9 +73,6 @@ func testUpgradeVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(pods.Items), "unable to access Windows workloads for significant amount of time during upgrade")
 
-	// Delete Job
-	err = testCtx.deleteJob(windowsWorkloadTesterJob + "-job")
-	require.NoError(t, err)
 }
 
 // testTamperAnnotation tests if the operator deletes machines and recreates them, if the node annotation is changed to an invalid value
@@ -173,22 +175,22 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 	return err
 }
 
-// deployWindowsWorkloadTester tests if the Windows Webserver deployment is available.
+// deployWindowsWorkloadAndTester tests if the Windows Webserver deployment is available.
 // This is achieved by creating a Job object that continuously curls the webserver every 5 seconds.
-func (tc *testContext) deployWindowsWorkloadTester() error {
-	// Get Windows Webserver deployment
-	deployment, err := tc.kubeclient.AppsV1().Deployments(tc.workloadNamespace).Get(context.TODO(), "win-webserver-deployment",
-		metav1.GetOptions{})
+func (tc *testContext) deployWindowsWorkloadAndTester() (*batchv1.Job, error) {
+	// Create a Windows Webserver deployment
+	deployment, err := tc.deployWindowsWebServer("win-webserver", nil)
 	if err != nil {
-		return errors.Wrap(err, "error getting Windows Webserver deployment")
+		return nil, errors.Wrap(err, "error creating Windows Webserver deployment for upgrade test")
 	}
+	defer tc.deleteDeployment(deployment.Name)
 
 	// Create a clusterIP service which can be used to reach the Windows webserver
 	intermediarySVC, err := tc.createService(deployment.Name, v1.ServiceTypeClusterIP, *deployment.Spec.Selector)
 	if err != nil {
-		return errors.Wrap(err, "could not create service ")
+		return nil, errors.Wrap(err, "could not create service ")
 	}
-
+	defer tc.deleteService(intermediarySVC.Name)
 	// Create a Job to curl Windows webserver
 	// Curl Windows webserver every 5 seconds. If the webserver is not accessible for few minutes
 	// exit the pod with an error.
@@ -196,10 +198,9 @@ func (tc *testContext) deployWindowsWorkloadTester() error {
 		" while true; do curl " + intermediarySVC.Spec.ClusterIP + "; if [ $? != 0 ]; then sleep 60; curl " +
 			intermediarySVC.Spec.ClusterIP + "|| exit 1;" + " fi; sleep 5; done"}
 
-	_, err = tc.createLinuxJob(windowsWorkloadTesterJob, command)
-
+	job, err := tc.createLinuxJob(windowsWorkloadTesterJob, command)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return job, nil
 }


### PR DESCRIPTION
This is a backport of #236 

This commit ensures that we use generateName instead of Name                                        
for deployment and job objects.  

This change also requires changing the way we use win-webserver in the
upgrade test.
In the upgrade test, we are getting the win-webserver deployment object
created in the network test using a get method. We are getting this
deployment using the deployment name.
As we will be using generateName across the board, we need to change the
way we get the windows web server deployment.
As this is a web server deployment, we can create a new one for
upgrade tests just before we start the test and the linux curler which
ensures that the webserver is functioning across an upgrade, and not use
the win-webserver created in network test.
