### PR TITLE
Update operator version and supported OpenShift version label

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -13,9 +13,9 @@ LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
 # delivered via an index image
 LABEL com.redhat.delivery.operator.bundle=true
 
-# This second label tells the pipeline which versions of OpenShift the operator supports (4.6+).
+# This second label tells the pipeline which versions of OpenShift the operator supports (4.7).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="v4.6"
+LABEL com.redhat.openshift.versions="=v4.7"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -129,7 +129,7 @@ cleanup_WMCO() {
 # the files here are selected based on the files that we are transferring while building the
 # operator binary in `build/Dockerfile`
 get_version() {
-  OPERATOR_VERSION=1.0.1
+  OPERATOR_VERSION=2.0.0
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
This PR updates the operator version to 2.0.0 for the 4.7 release in hack/common.sh
It also updates the operator supported OpenShift version label to be set to "=v4.7" in bundle.Dockerfile.
