### PR TITLE
[community-4.6] Delete Machines when SSH auth fails

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -106,7 +106,7 @@ fi
 OSDK_WMCO_test $OSDK "-run=TestWMCO/operator_deployed_without_private_key_secret -v -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
 
 # Run the creation tests of the Windows VMs
-OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=90m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
+OSDK_WMCO_test $OSDK "-run=TestWMCO/create -v -timeout=120m -node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION"
 # Get logs for the creation tests
 printf "\n####### WMCO logs for creation tests #######\n"
 get_WMCO_logs

--- a/pkg/controller/windowsmachine/windowsmachine_controller.go
+++ b/pkg/controller/windowsmachine/windowsmachine_controller.go
@@ -41,8 +41,8 @@ const (
 	// maxUnhealthyCount is the maximum number of nodes that are not ready to serve at a given time.
 	// TODO: https://issues.redhat.com/browse/WINC-524
 	maxUnhealthyCount = 1
-	// windowsOSLabel is the label used to identify the Windows Machines.
-	windowsOSLabel = "machine.openshift.io/os-id"
+	// MachineOSLabel is the label used to identify the Windows Machines.
+	MachineOSLabel = "machine.openshift.io/os-id"
 )
 
 var log = logf.Log.WithName(ControllerName)
@@ -108,7 +108,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not create %s", ControllerName)
 	}
-	// Watch for the Machine objects with label defined by windowsOSLabel
+	// Watch for the Machine objects with label defined by MachineOSLabel
 	machinePredicate := predicate.Funcs{
 		// We need the create event to account for Machines that are in provisioned state but were created
 		// before WMCO started running
@@ -182,7 +182,7 @@ func (m *nodeToMachineMapper) Map(object handler.MapObject) []reconcile.Request 
 	// Map the Node to the associated Machine through the Node's UID
 	machines := &mapi.MachineList{}
 	err := m.client.List(context.TODO(), machines,
-		client.MatchingLabels(map[string]string{windowsOSLabel: "Windows"}))
+		client.MatchingLabels(map[string]string{MachineOSLabel: "Windows"}))
 	if err != nil {
 		log.Error(err, "could not get a list of machines")
 	}
@@ -205,8 +205,7 @@ func (m *nodeToMachineMapper) Map(object handler.MapObject) []reconcile.Request 
 
 // isWindowsMachine checks if the machine is a Windows machine or not
 func isWindowsMachine(labels map[string]string) bool {
-	windowsOSLabel := "machine.openshift.io/os-id"
-	if value, ok := labels[windowsOSLabel]; ok {
+	if value, ok := labels[MachineOSLabel]; ok {
 		if value == "Windows" {
 			return true
 		}
@@ -449,7 +448,7 @@ func (r *ReconcileWindowsMachine) isAllowedDeletion(machine *mapi.Machine) bool 
 
 	machines := &mapi.MachineList{}
 	err := r.client.List(context.TODO(), machines,
-		client.MatchingLabels(map[string]string{windowsOSLabel: "Windows"}))
+		client.MatchingLabels(map[string]string{MachineOSLabel: "Windows"}))
 	if err != nil {
 		return false
 	}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -1,13 +1,19 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"io/ioutil"
 	"log"
 	"math"
 	"testing"
 	"time"
 
+	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -16,17 +22,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/secrets"
+	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine"
 	"github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 )
 
 func creationTestSuite(t *testing.T) {
-	// Ensure that the private key secret is created
-	testCtx, err := NewTestContext(t)
-	require.NoError(t, err)
-	require.NoError(t, testCtx.createPrivateKeySecret(), "could not create private key secret")
-
 	// The order of tests here are important. testValidateSecrets is what populates the windowsVMs slice in the gc.
 	// testNetwork needs that to check if the HNS networks have been installed. Ideally we would like to run testNetwork
 	// before testValidateSecrets and testConfigMapValidation but we cannot as the source of truth for the credentials
@@ -67,10 +70,26 @@ func testWindowsNodeCreation(t *testing.T) {
 	}
 	testCtx, err := NewTestContext(t)
 	require.NoError(t, err)
+	// Create a private key secret with a randomly generated value. This is changed to the provided private key later in
+	// the test.
+	require.NoError(t, testCtx.createPrivateKeySecret(false), "could not create private key secret")
 
 	for _, test := range testCases {
 		if err := testCtx.createWindowsMachineSet(test.replicas, test.isWindows); err != nil {
 			t.Fatalf("failed to create Windows MachineSet %v ", err)
+		}
+		if test.isWindows {
+			// We need to cover the case where a user changes the private key secret before the WMCO has a chance to
+			// configure the Machine. In order to simulate that case we need to wait for the MachineSet to be fully
+			// provisioned and then change the key. The the correct amount of nodes being configured is proof that the
+			// mismatched Machine created with the mismatched key was deleted and replaced.
+			// Depending on timing and configuration flakes this will either cause all Machines, or all Machines after
+			// the first configured Machines to hit this scenario.
+			err := testCtx.waitForWindowsMachines(int(test.replicas), "Provisioned")
+			require.NoError(t, err, "error waiting for Windows Machines to be provisioned")
+			err = testCtx.createPrivateKeySecret(true)
+			require.NoError(t, err, "error replacing private key secret")
+
 		}
 		err := testCtx.waitForWindowsNodes(test.replicas, true, !test.isWindows, false)
 
@@ -92,6 +111,35 @@ func (tc *testContext) createWindowsMachineSet(replicas int32, windowsLabel bool
 	return framework.Global.Client.Create(context.TODO(), machineSet,
 		&framework.CleanupOptions{TestContext: tc.osdkTestCtx,
 			Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+// waitForWindowsMachines waits for a certain amount of Windows Machines to reach a certain phase
+func (tc *testContext) waitForWindowsMachines(machineCount int, phase string) error {
+	machineCreationTimeLimit := time.Minute * 5
+	return wait.Poll(retryInterval, machineCreationTimeLimit, func() (done bool, err error) {
+		var machines mapi.MachineList
+		err = framework.Global.Client.List(context.TODO(), &machines,
+			[]client.ListOption{client.MatchingLabels{windowsmachine.MachineOSLabel: "Windows"},
+				client.InNamespace("openshift-machine-api")}...)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Printf("waiting for %d Windows Machines", machineCount)
+				return false, nil
+			}
+			log.Printf("machine object listing failed: %v", err)
+			return false, nil
+		}
+		if len(machines.Items) != machineCount {
+			log.Printf("waiting for %d/%d Windows Machines", machineCount-len(machines.Items), machineCount)
+			return false, nil
+		}
+		for _, machine := range machines.Items {
+			if machine.Status.Phase == nil || *machine.Status.Phase != phase {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
 }
 
 // waitForWindowsNode waits until there exists nodeCount Windows nodes with the correct set of annotations.
@@ -173,23 +221,42 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, waitForAnnotations, 
 	return err
 }
 
+// generatePrivateKey generates a random RSA private key
+func generatePrivateKey() ([]byte, error) {
+	var keyData []byte
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating key")
+	}
+	var privateKey = &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	buf := bytes.NewBuffer(keyData)
+	err = pem.Encode(buf, privateKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "error encoding generated private key")
+	}
+	return buf.Bytes(), nil
+}
+
 // createPrivateKeySecret ensures that a private key secret exists with the correct data
-func (tc *testContext) createPrivateKeySecret() error {
-	secretsClient := tc.kubeclient.CoreV1().Secrets(tc.namespace)
-	if _, err := secretsClient.Get(context.TODO(), secrets.PrivateKeySecret, metav1.GetOptions{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return errors.Wrap(err, "could not get private key secret")
+func (tc *testContext) createPrivateKeySecret(useKnownKey bool) error {
+	if err := tc.ensurePrivateKeyDeleted(); err != nil {
+		return errors.Wrap(err, "error ensuring any existing private key is removed")
+	}
+	var keyData []byte
+	var err error
+	if useKnownKey {
+		keyData, err = ioutil.ReadFile(gc.privateKeyPath)
+		if err != nil {
+			return errors.Wrapf(err, "unable to read private key data from file %s", gc.privateKeyPath)
 		}
 	} else {
-		// Secret already exists, delete it
-		if err := secretsClient.Delete(context.TODO(), secrets.PrivateKeySecret, metav1.DeleteOptions{}); err != nil {
-			return errors.Wrap(err, "unable to delete existing private key secret")
+		keyData, err = generatePrivateKey()
+		if err != nil {
+			return errors.Wrap(err, "error generating private key")
 		}
-	}
-
-	keyData, err := ioutil.ReadFile(gc.privateKeyPath)
-	if err != nil {
-		return errors.Wrapf(err, "unable to read private key data from file %s", gc.privateKeyPath)
 	}
 
 	privateKeySecret := core.Secret{
@@ -201,4 +268,18 @@ func (tc *testContext) createPrivateKeySecret() error {
 	}
 	_, err = tc.kubeclient.CoreV1().Secrets(tc.namespace).Create(context.TODO(), &privateKeySecret, metav1.CreateOptions{})
 	return err
+}
+
+// ensurePrivateKeyDeleted ensures that the privateKeySecret is deleted
+func (tc *testContext) ensurePrivateKeyDeleted() error {
+	secretsClient := tc.kubeclient.CoreV1().Secrets(tc.namespace)
+	if _, err := secretsClient.Get(context.TODO(), secrets.PrivateKeySecret, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			// secret doesnt exist, do nothing
+			return nil
+		}
+		return errors.Wrap(err, "could not get private key secret")
+	}
+	// Secret exists, delete it
+	return secretsClient.Delete(context.TODO(), secrets.PrivateKeySecret, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
Backport of https://github.com/openshift/windows-machine-config-operator/pull/202

This commit prevents an issue where a user changes the private key used
to configure Windows Machines, after unconfigured Machines have been
created with the original userdata secret. When those unconfigured
Machines are reconciled they will never be able to be SSH'd into and
will infinitely be requeued.

This issue is being fixed by deleting Machines that have had an
authentication error so that they can be re-provisioned with userdata
corresponding with the new private key.