### PR TITLE
Bug 1905280: [wmco] Delete existing service monitor object on WMCO restart

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -314,6 +314,7 @@ spec:
           - update
           - list
           - patch
+          - delete
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -53,6 +53,7 @@ rules:
   - update
   - list
   - patch
+  - delete
 # deployment/finalizers permissions needed for the metrics server
 - apiGroups:
   - apps

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	monclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -86,6 +87,20 @@ func Add(ctx context.Context, cfg *rest.Config, namespace string) error {
 
 	// the name for the metrics resources is set during creation of metrics service and is equivalent to the service name
 	windowsMetricsResource = service.GetName()
+
+	// Create a monitoring client to interact with the ServiceMonitor object
+	mclient, err := monclient.NewForConfig(cfg)
+	if err != nil {
+		return errors.Wrap(err, "could not create monitoring client")
+	}
+
+	// In the case of an operator restart, a previous SM object will be deleted and a new one will
+	// be created. We are deleting to ensure that the SM always exists with the correct spec. Otherwise,
+	// metrics may exhibit unexpected behavior if created by a previous version of WMCO.
+	err = mclient.ServiceMonitors(namespace).Delete(context.TODO(), windowsMetricsResource, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrap(err, "could not delete existing ServiceMonitor object")
+	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.


### PR DESCRIPTION
This change checks for an existing service monitor object on a WMCO restart.
If a service monitor object does exist, it is deleted and a new one is created.
We are deleting to ensure that the SM always exists with the correct spec. Otherwise,
metrics may exhibit unexpected behavior if created by a previous version of WMCO.