### PR TITLE
Switch build base image to Red Hat hosted image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/openshift/origin-release:golang-1.15 as build
+FROM registry.svc.ci.openshift.org/origin/builder:golang-1.15 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/


### PR DESCRIPTION
This commit switches from a dockerhub hosted image to a Red Hat hosted
image. This will fix an issue with dockerhub rate limiting when building
the community operator.