### PR TITLE
[hack] fix noCache command in olm.sh

### DIFF
--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -30,7 +30,7 @@ shift # shift position of the positional parameters for getopts
 PRIVATE_KEY=""
 while getopts ":ic:k:" opt; do
     case "$opt" in
-	i) noCache="--image-build-args=\"--no-cache\"";;
+	i) noCache="--no-cache";;
 	c) OPERATOR_IMAGE="$OPTARG";;
 	k) PRIVATE_KEY="$OPTARG";;
 	?) error-exit "Unknown option"


### PR DESCRIPTION
Fix the `noCache` command in olm.sh hack script to build the
operator image without cache.
This change is required as we are no longer using
`operator-sdk build` to create the operator image

\cc: @alinaryan 