### PR TITLE
WINC-565: [wmco] Relax k8s version strict dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
+	golang.org/x/mod v0.3.0
 	k8s.io/api v0.20.0
 	k8s.io/apimachinery v0.20.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	oconfig "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
@@ -18,7 +20,7 @@ const (
 	ovnKubernetesNetwork = "OVNKubernetes"
 	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
 	// 1.20.x are supported for baseK8sVersion 1.20)
-	baseK8sVersion = "1.20"
+	baseK8sVersion = "v1.20"
 )
 
 // Network interface contains methods to interact with cluster network objects
@@ -107,23 +109,29 @@ func NewConfig(restConfig *rest.Config) (Config, error) {
 	}, nil
 }
 
-// validateK8sVersion checks for valid k8s version in the cluster. It returns an error for all versions not equal
-// to supported major version. This is being done this way, and not by directly getting the cluster version, as OpenShift CI
-// returns version in the format 0.0.x and not the actual version attached to its clusters.
+// validateK8sVersion checks for valid k8s version in the cluster. It returns an error for all versions that are not in
+// range of given base version(x.y.z) and x.y+1.z version.
 func (c *config) validateK8sVersion() error {
 	versionInfo, err := c.oclient.Discovery().ServerVersion()
 	if err != nil {
 		return errors.Wrap(err, "error retrieving server version ")
 	}
-	// split the version in the form Major.Minor. For e.g v1.18.0-rc.1 -> 1.18
-	k8sVersion := strings.TrimLeft(versionInfo.GitVersion, "v")
-	clusterBaseVersion := strings.Join(strings.SplitN(k8sVersion, ".", 3)[:2], ".")
-
-	if strings.Compare(clusterBaseVersion, baseK8sVersion) != 0 {
-		return errors.Errorf("Unsupported server version: v%v. Supported version is v%v.x", k8sVersion,
-			baseK8sVersion)
+	// split the version in the form Major.Minor. For e.g v1.18.0-rc.1 -> v1.18
+	clusterBaseVersion := semver.MajorMinor(versionInfo.GitVersion)
+	// Convert base version to float and add 1 to Minor version
+	baseVersion, err := strconv.ParseFloat(strings.TrimPrefix(baseK8sVersion, "v"), 64)
+	if err != nil {
+		return errors.Wrapf(err, "error converting %s k8s version to float", baseK8sVersion)
 	}
-	return nil
+	maxK8sVersion := fmt.Sprintf("v%.2f", baseVersion+0.01)
+
+	// validate cluster version is in the range of baseK8sVersion and maxK8sVersion
+	if semver.Compare(clusterBaseVersion, baseK8sVersion) >= 0 && semver.Compare(clusterBaseVersion, maxK8sVersion) <= 0 {
+		return nil
+	}
+
+	return errors.Errorf("Unsupported server version: %v. Supported versions are %v.x to %v.x", versionInfo.GitVersion,
+		baseK8sVersion, maxK8sVersion)
 }
 
 // Validate method checks if the cluster configurations are as required. It throws an error if the configuration could not

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -120,13 +120,14 @@ func createFakeClients(networkType string) (configclient.Interface, operatorclie
 func TestIsValidKubernetesVersion(t *testing.T) {
 	fakeConfigClient := fakeconfigclient.NewSimpleClientset()
 	var tests = []struct {
-		name         string
-		version      string
-		errorMessage string
+		name    string
+		version string
+		error   bool
 	}{
-		{"cluster version lower than supported version ", "v1.17.1", "Unsupported server version: v1.17.1. Supported version is v1.20.x"},
-		{"cluster version equals supported version", "v1.20.0", ""},
-		{"cluster version greater than supported version", "v1.21.0", "Unsupported server version: v1.21.0. Supported version is v1.20.x"},
+		{"cluster version lower than supported version ", "v1.17.1", true},
+		{"cluster version equals supported version", "v1.20.0", false},
+		{"cluster version equals supported version", "v1.21.4", false},
+		{"cluster version greater than supported version ", "v1.22.2", true},
 	}
 
 	for _, tt := range tests {
@@ -137,12 +138,11 @@ func TestIsValidKubernetesVersion(t *testing.T) {
 			}
 			clusterconfig := config{oclient: fakeConfigClient}
 			err := clusterconfig.validateK8sVersion()
-			if tt.errorMessage == "" {
-				require.Nil(t, err, "Successful check for valid network type")
-			} else {
+			if tt.error {
 				require.Error(t, err, "Function getK8sVersion did not throw an error "+
 					"when it was expected to")
-				assert.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				require.Nil(t, err, "Successful check for valid network type")
 			}
 		})
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -248,6 +248,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.3.0
+## explicit
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20201110031124-69a78807bb2b


### PR DESCRIPTION
 This commit ensures that we no longer are tied to exact version
 OpenShift. The changes allow WMCO to run on N and N+1 versions of
 OpenShift. This is required to perform seamless upgrade between
N to N+1 versions.