### PR TITLE
[community-4.7] Explicitly set GOBIN path for promu installation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,12 +18,13 @@ RUN make windows
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/
 COPY promu/ .
-RUN go install .
+# Explicitly set the $GOBIN path for promu installation
+RUN GOBIN=/build/windows-machine-config-operator/windows_exporter/ go install .
 
 # Build windows_exporter
 WORKDIR /build/windows-machine-config-operator/windows_exporter/
 COPY windows_exporter/ .
-RUN GOOS=windows promu build -v
+RUN GOOS=windows ./promu build -v
 
 # Build Kubernetes node binaries
 WORKDIR /build/windows-machine-config-operator/kubernetes/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -33,12 +33,13 @@ RUN make windows
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/
 COPY promu/ .
-RUN go install .
+# Explicitly set the $GOBIN path for promu installation
+RUN GOBIN=/build/windows-machine-config-operator/windows_exporter/ go install .
 
 # Build windows_exporter
 WORKDIR /build/windows-machine-config-operator/windows_exporter/
 COPY windows_exporter/ .
-RUN GOOS=windows promu build -v
+RUN GOOS=windows ./promu build -v
 
 # Build Kubernetes node binaries
 WORKDIR /build/windows-machine-config-operator/kubernetes/


### PR DESCRIPTION
This commit explicitly sets the GOBIN path
to specify where the promu binary should be
installed, promu installed in the windows_exporter
directory is then utilized for its installation.
This change was necessary because cachito changes
the GOPATH during image build and if the path is
not specified promu is installed to some location
from which it is not accessible to build
windows_exporter executable.

(cherry picked from commit 6f65fced396dcfb17c73a97aebd0119740c85cb6)