### PR TITLE
[deploy] Add skipRange to csv for 2.0.0 release

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -13,6 +13,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     repository: https://github.com/openshift/windows-machine-config-operator
     support: "Red Hat"
+    olm.skipRange: ">=1.0.0 <2.0.0"
   name: windows-machine-config-operator.v0.0.0
   namespace: openshift-windows-machine-config-operator
 spec:


### PR DESCRIPTION
This PR adds the skipRange option and value `">=1.0.0 <2.0.0" ` to CSV for the 2.0.0 release. Since the 2.0.0 operator
is not in the same index as 1.x operator, we need to use 'skipRange' instead of the 'replaces' field for the upgrade process.