### PR TITLE
Revert "Switch build base image to Red Hat hosted image"

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/origin/builder:golang-1.15 as build
+FROM docker.io/openshift/origin-release:golang-1.15 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/


### PR DESCRIPTION
Reverts openshift/windows-machine-config-operator#258 as registry.svc.ci.openshift.org/origin/builder:golang-1.15 image requires access credentials. Moreover openshift/windows-machine-config-operator#258 never actually fixed the rate limiting as it was not backported to the `community-*` branches.