### PR TITLE
[docs] Remove AWS describe-image command 

### DIFF
--- a/docs/machineset-aws.md
+++ b/docs/machineset-aws.md
@@ -1,14 +1,7 @@
 # Creating an AWS Windows MachineSet
 
 _\<windows_container_ami\>_ should be replaced with the AMI ID of a Windows image with a container run-time installed. 
- You must use Windows Server 2019 with a version 10.0.17763.1457 or earlier. Run the following command to list AWS image info:
-  ```shell script
-  $ aws ec2 describe-images \
-    --filters Name=name,Values=Windows_Server-2019-English-Full-ContainersLatest-2020.09.09 \
-    --region <region> \
-    --query 'Images[*].[ImageId]' \
-    --output=json | jq .[0][0]
-```
+ You must use Windows Server 2019 with a version 10.0.17763.1457 or earlier.
                                                                            
 _\<infrastructureID\>_ should be replaced with the output of:
 ```shell script

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -78,7 +78,7 @@ get_aws_ms() {
   local provider=$4
 
   # get the AMI id for the Windows VM
-  ami_date="2020.10.14"
+  ami_date="2021.01.13"
   ami_id=$(aws ec2 describe-images --filters Name=name,Values=Windows_Server-2019-English-Full-ContainersLatest-${ami_date} --region ${region} --query 'Images[*].[ImageId]' --output text)
   if [ -z "$ami_id" ]; then
         error-exit "unable to find AMI ID for $ami_date"


### PR DESCRIPTION
This commit removes the AWS describe-image command 
from the docs as we will be changing the script in a follow-up 
PR to grab the latest tag for getting the ami since the date is 
constantly being changed by AWS. It also updates the
ami_date in the hackscript from 2020.10.14 to 2021.01.13 
to be used in the meantime, since the earlier date is no longer 
available in AWS regions.