### PR TITLE
[community-4.7][wmco] Delete existing service monitor object on WMCO restart

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -313,6 +313,7 @@ spec:
           - update
           - list
           - patch
+          - delete
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -53,6 +53,7 @@ rules:
   - update
   - list
   - patch
+  - delete
 # deployment/finalizers permissions needed for the metrics server
 - apiGroups:
   - apps


### PR DESCRIPTION
This commit checks for an existing service monitor object on a WMCO restart.
If a service monitor object does exist, it is deleted and a new one is created.
We are deleting to ensure that the SM always exists with the correct spec. Otherwise,
metrics may exhibit unexpected behavior if created by a previous version of WMCO.

(cherry picked from commit 2209daf0d0c6d5ebe7a0a986c509854539355780)