### PR TITLE
[test] Don't run all tests on all platforms

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -51,6 +51,10 @@ func testWindowsNodeCreation(t *testing.T) {
 	require.NoError(t, testCtx.createPrivateKeySecret(true), "could not create known private key secret")
 
 	t.Run("Windows Machines without the Windows label are not configured", func(t *testing.T) {
+		// Test is platform agnostic so is not needed to be run for every supported platform.
+		if testCtx.CloudProvider.GetType() != config.AzurePlatformType {
+			t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
+		}
 		ms, err := testCtx.createWindowsMachineSet(1, false)
 		require.NoError(t, err, "failed to create Windows MachineSet")
 		defer framework.Global.Client.Delete(context.TODO(), ms)
@@ -82,7 +86,7 @@ func testWindowsNodeCreation(t *testing.T) {
 			// This test cannot be run on vSphere because this random key is not part of the vSphere template image.
 			// Moreover this test is platform agnostic so is not needed to be run for every supported platform.
 			if testCtx.CloudProvider.GetType() != config.AWSPlatformType {
-				t.Skip()
+				t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
 			}
 			// Replace private key and check that new Machines are created using the new private key
 			err = testCtx.createPrivateKeySecret(false)

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -3,13 +3,14 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/types"
 	"strings"
 	"testing"
 
+	config "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	nc "github.com/openshift/windows-machine-config-operator/pkg/controller/windowsmachine/nodeconfig"
 )
@@ -21,6 +22,11 @@ import (
 func reconfigurationTest(t *testing.T) {
 	testCtx, err := NewTestContext(t)
 	require.NoError(t, err)
+
+	// Test is platform agnostic so is not needed to be run for every supported platform.
+	if testCtx.CloudProvider.GetType() != config.AzurePlatformType {
+		t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
+	}
 
 	nodes, err := testCtx.kubeclient.CoreV1().Nodes().List(context.TODO(),
 		metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	config "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
@@ -35,6 +36,11 @@ const (
 func upgradeTestSuite(t *testing.T) {
 	testCtx, err := NewTestContext(t)
 	require.NoError(t, err)
+
+	// Test is platform agnostic so is not needed to be run for every supported platform.
+	if testCtx.CloudProvider.GetType() != config.AWSPlatformType {
+		t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
+	}
 
 	// test if Windows workloads are running by creating a Job that curls the workloads continuously.
 	testerJob, err := testCtx.deployWindowsWorkloadAndTester()


### PR DESCRIPTION
- Run upgrade test only on AWS
- Run reconfiguration test only on Azure
- Run "Windows Machines without the Windows label are not configured"
  only on Azure