### PR TITLE
[community-4.7][test] Introduce CloudProvider.GetType()

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
+	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -404,4 +405,8 @@ func (a *awsProvider) GenerateMachineSet(withWindowsLabel bool, replicas int32) 
 		},
 	}
 	return machineSet, nil
+}
+
+func (a *awsProvider) GetType() config.PlatformType {
+	return config.AWSPlatformType
 }

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -194,3 +194,7 @@ func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*m
 	}
 	return machineSet, nil
 }
+
+func (p *Provider) GetType() config.PlatformType {
+	return config.AzurePlatformType
+}

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -15,6 +15,8 @@ import (
 
 type CloudProvider interface {
 	GenerateMachineSet(bool, int32) (*mapi.MachineSet, error)
+	// GetType returns the cloud provider type ex: AWS, Azure etc
+	GetType() config.PlatformType
 }
 
 // NewCloudProvider returns a CloudProvider interface or an error

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 
+	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	vsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	core "k8s.io/api/core/v1"
@@ -138,4 +139,8 @@ func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*m
 		},
 	}
 	return machineSet, nil
+}
+
+func (p *Provider) GetType() config.PlatformType {
+	return config.VSpherePlatformType
 }


### PR DESCRIPTION
And use it to only run the "Changing the private key ensures all Windows nodes use the new private key" test on AWS. This cannot be run against a vSphere cluster because this random key is not part of the vSphere template image. Moreover this test is platform agnostic so is not needed to be run for every supported platform.

(cherry picked from commit 34cb58f1828825e54af9381730a3b00a28fe1453)
(backport of #285)