### PR TITLE
[release-4.7][hack] Move error-exit to common.sh

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -3,6 +3,11 @@
 # Location of the manifests file
 MANIFEST_LOC=deploy/olm-catalog/windows-machine-config-operator
 
+error-exit() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
 get_operator_sdk() {
   # Download the operator-sdk binary only if it is not already available
   # We do not validate the version of operator-sdk if it is available already

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -12,12 +12,10 @@
 #    aws                  to fetch Windows AMI id for AWS platform (only required for clusters running on AWS)
 set -euo pipefail
 
-ACTION=${1:-}
+WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
+source $WMCO_ROOT/hack/common.sh
 
-error-exit() {
-    echo "Error: $*" >&2
-    exit 1
-}
+ACTION=${1:-}
 
 # get_spec returns the template yaml common for all cloud providers
 get_spec() {


### PR DESCRIPTION
error-exit is being called in run-ci-e2e-test.sh but it is defined in machineset.sh. Fix this by moving it to common.sh.

(cherry picked from commit 92065011e2329f697d714e668e178bae7af97f8f)
(backport of #306)
