### PR TITLE
Bug 1929579: [wmco] Fix issue with dereferencing nil signer

### DIFF
--- a/controllers/windowsmachine/windowsmachine_controller.go
+++ b/controllers/windowsmachine/windowsmachine_controller.go
@@ -266,6 +266,11 @@ func (r *ReconcileWindowsMachine) Reconcile(request reconcile.Request) (reconcil
 		}
 		return reconcile.Result{}, errors.Wrapf(err, "unable to get secret %s", request.NamespacedName)
 	}
+	// Update the signer with the current privateKey
+	r.signer, err = signer.Create(privateKey)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "error creating signer")
+	}
 
 	// Fetch the Machine instance
 	machine := &mapi.Machine{}
@@ -340,11 +345,6 @@ func (r *ReconcileWindowsMachine) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	// Update the signer with the current privateKey
-	r.signer, err = signer.Create(privateKey)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "error creating signer")
-	}
 	// validate userData secret
 	if err := r.validateUserData(privateKey); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "error validating userData secret")


### PR DESCRIPTION
This commit fixes an issue where a the `signer` of the Windows Machine
reconciler could be used when nil. This was not being caught in our e2e
tests because if the signer's value was set in a previous reconcile that
stale value would be used.

This is being fixed by moving where the signer is set to before its
usage, where it should have been in the first place.