### PR TITLE
WINC-555: [test] Use Windows Server 20H2 for Azure e2e tests

### DIFF
--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -19,7 +19,7 @@ const (
 	defaultCredentialsSecretName = "azure-cloud-credentials"
 	defaultImageOffer            = "WindowsServer"
 	defaultImagePublisher        = "MicrosoftWindowsServer"
-	defaultImageSKU              = "2019-Datacenter-with-Containers"
+	defaultImageSKU              = "datacenter-core-20h2-with-containers-smalldisk"
 	defaultImageVersion          = "latest"
 	defaultOSDiskSizeGB          = 128
 	defaultStorageAccountType    = "Premium_LRS"


### PR DESCRIPTION
- Use the corresponding container image for the deployments
- Use the appropriate PowerShell executable based on container image