### PR TITLE
[docs] Clarify cluster and image requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ The following template variables need to be replaced as follows with values from
 * *\<vCenter Datastore Name\>*: datastore name
 * *\<vCenter Server FQDN/IP\>*: IP address or FQDN of the vCenter server
 
-Please note that on vSphere, Windows Machine names cannot be more than 15 characters long. The MachineSet name therefore
-cannot be more than 9 characters long, due to the way Machine names are generated from it.
+*IMPORTANT*:
+- The template used in the MachineSet must be a Windows Server 1909
+  image as described in [vSphere prerequisites](docs/vsphere-prerequisites.md).
+- On vSphere, Windows Machine names cannot be more than 15 characters long. The
+  MachineSet name, therefore, cannot be more than 9 characters long, due to the
+  way Machine names are generated from it.
 ```yaml
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet

--- a/docs/machineset-aws.md
+++ b/docs/machineset-aws.md
@@ -1,7 +1,10 @@
 # Creating an AWS Windows MachineSet
 
-_\<windows_container_ami\>_ should be replaced with the AMI ID of a Windows image with a container run-time installed. 
- You must use Windows Server 2019 with a version 10.0.17763.1457 or earlier.
+_\<windows_container_ami\>_ should be replaced with the AMI ID of a Windows
+image with the Docker container run-time installed. You must use Windows Server
+2019 with a version 10.0.17763.1457 or earlier to work around Windows containers
+behind a Kubernetes load balancer becoming unreachable
+[issue](https://github.com/microsoft/Windows-Containers/issues/78).
                                                                            
 _\<infrastructureID\>_ should be replaced with the output of:
 ```shell script

--- a/docs/machineset-azure.md
+++ b/docs/machineset-azure.md
@@ -18,6 +18,8 @@ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
       --sku 2019-Datacenter-with-Containers \
       --query "[?contains(version, '17763.1457.2009030514')]"
 ```
+This is to work around Windows containers behind a Kubernetes load balancer
+becoming unreachable [issue](https://github.com/microsoft/Windows-Containers/issues/78).
 
 Please note that on Azure, Windows Machine names cannot be more than 15 characters long.
 The MachineSet name can therefore not be more than 9 characters long, due to the way Machine names are generated from it.

--- a/docs/setup-hybrid-OVNKubernetes-cluster.md
+++ b/docs/setup-hybrid-OVNKubernetes-cluster.md
@@ -49,6 +49,34 @@ spec:
           hostPrefix: 23
 status: {}
 ```
+The above configuration is recommended for AWS and Azure clusters.
+
+For vSphere clusters, you must add the `hybridOverlayVXLANPort` option to work around the pod-to-pod connectivity
+between hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere):
+```yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+  externalIP:
+    policy: {}
+  serviceNetwork:
+    - 172.30.0.0/16
+  defaultNetwork:
+    type: OVNKubernetes
+    ovnKubernetesConfig:
+      hybridOverlayConfig:
+        hybridClusterNetwork:
+          - cidr: 10.132.0.0/14
+            hostPrefix: 23
+        hybridOverlayVXLANPort: 9898
+status: {}
+```
 
 **Note:** The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR.
 

--- a/docs/vsphere-prerequisites.md
+++ b/docs/vsphere-prerequisites.md
@@ -1,5 +1,9 @@
 # vSphere pre-requisites
 
+The vSphere cluster must be configured with [hybrid OVN Kubernetes networking](docs/setup-hybrid-OVNKubernetes-cluster.md)
+with a custom VXLAN port to work around the pod-to-pod connectivity between
+hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere).
+
 In order to use the Windows MachineConfig Operator to successfully create
 a Windows node, you will first need to create a Windows "golden image"
 VM. These steps are an overview of the required configuration of the
@@ -7,8 +11,9 @@ golden image.
 
 ## vSphere Windows VM golden image creation
 * Create the VM from an updated version of Windows Server 1909 VM image
-which includes patch
-[KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351)
+  that includes the patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351).
+  This is required to get the OS feature that allows setting the VXLAN UDP port.
+  Please note that this patch is not available for `Windows Server 2019`.
 * Configure SSH on the VM:
   * You can install SSH on the Windows VM by using the example
   [powershell script](powershell.ps1), or by following the
@@ -60,7 +65,7 @@ the case of Linux nodes, coreDNS is running
 on every node which helps in resolving the internal API server URL. The
 external API endpoint should have been
 created as part of the
-[cluster install](https://docs.openshift.com/container-platform/4.5/installing/installing_vsphere/installing-vsphere-installer-provisioned.html).
+[cluster install](https://docs.openshift.com/container-platform/4.7/installing/installing_vsphere/installing-vsphere-installer-provisioned.html).
 
 An example to automate the VM golden image creation can be found
 [here](vsphere_ci/README.md)


### PR DESCRIPTION
Clearly call out when and why the custom VXLAN port cluster configuration should be used and how it affects the image picked in the MachineSet.