### PR TITLE
[test] Separate out the network tests

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -120,10 +120,14 @@ go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secre
 
 # Run the creation tests of the Windows VMs
 printf "\n####### Testing creation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/create -v -timeout=120m -args --node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args --node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
 # Get logs for the creation tests
 printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
 get_WMCO_logs
+
+# Run the network tests
+printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
+go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args --node-count=$NODE_COUNT --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
 
 # Run the upgrade tests and skip deletion of the Windows VMs
 printf "\n####### Testing upgrade #######\n" >> "$ARTIFACT_DIR"/wmco.log

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -23,17 +23,12 @@ import (
 )
 
 func creationTestSuite(t *testing.T) {
-	// The order of tests here are important. testValidateSecrets is what populates the windowsVMs slice in the gc.
-	// testNetwork needs that to check if the HNS networks have been installed. Ideally we would like to run testNetwork
-	// before testValidateSecrets and testConfigMapValidation but we cannot as the source of truth for the credentials
-	// are the secrets but they are created only after the VMs have been fully configured.
-	// Any node object related tests should be run only after testNodeCreation as that initializes the node objects in
-	// the global context.
+	// The order of tests here are important. Any node object related tests should be run only after
+	// testWindowsNodeCreation as that initializes the node objects in the global context.
 	if !t.Run("Creation", func(t *testing.T) { testWindowsNodeCreation(t) }) {
 		// No point in running the other tests if creation failed
 		return
 	}
-	t.Run("Network validation", testNetwork)
 	t.Run("Node Metadata", func(t *testing.T) { testNodeMetadata(t) })
 	t.Run("NodeTaint validation", func(t *testing.T) { testNodeTaint(t) })
 	t.Run("UserData validation", func(t *testing.T) { testUserData(t) })

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -31,10 +31,15 @@ func TestWMCO(t *testing.T) {
 		wmcoPath = "/usr/local/bin/windows-machine-config-operator"
 	}
 
+	testCtx, err := NewTestContext()
+	require.NoError(t, err)
+	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace), "error creating test namespace")
+
 	// test that the operator can deploy without the secret already created, we can later use a secret created by the
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
+	t.Run("network", testNetwork)
 	t.Run("upgrade", upgradeTestSuite)
 	t.Run("reconfigure", reconfigurationTest)
 	t.Run("destroy", deletionTestSuite)


### PR DESCRIPTION
Move the network tests out from the creation tests. This is in preparation for separating out the upgrade and reconfiguration tests into a separate CI job.