### PR TITLE
[build] Move to Go 1.16

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.15
+  tag: golang-1.16

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/openshift/origin-release:golang-1.15 as build
+FROM docker.io/openshift/origin-release:golang-1.16 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -92,7 +92,7 @@ RUN make build
 #├── windows_exporter.exe
 #└── wmcb.exe
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8
 LABEL stage=operator
 
 # Copy wmcb.exe

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.15
+go 1.16
 
 replace github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helm
 

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.15') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.16') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
As of https://github.com/openshift/ocp-build-data/pull/858 OCP will be built with Go 1.16, so move the WMCO builds to match that change.