### PR TITLE
Prep for 1.0.4 release

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -129,7 +129,7 @@ cleanup_WMCO() {
 # the files here are selected based on the files that we are transferring while building the
 # operator binary in `build/Dockerfile`
 get_version() {
-  OPERATOR_VERSION=1.0.3
+  OPERATOR_VERSION=1.0.4
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
This PR updates the operator version to 1.0.4 for next 4.6 release.