### PR TITLE
[test] Explicitly apply monitoring label

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -255,4 +256,12 @@ func (tc *testContext) getPrometheusToken() (string, error) {
 		return "", fmt.Errorf("could not get bearer token for secret %v", secretName)
 	}
 	return string(token), nil
+}
+
+// applyMonitoringLabelToOperatorNamespace adds the "openshift.io/cluster-monitoring:"true"" label to the
+// openshift-windows-machine-config-operator namespace
+func (tc *testContext) applyMonitoringLabelToOperatorNamespace() error {
+	_, err := tc.client.K8s.CoreV1().Namespaces().Patch(context.TODO(), tc.namespace, types.MergePatchType,
+		[]byte(`{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true"}}}`), metav1.PatchOptions{})
+	return err
 }

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -35,6 +35,10 @@ func TestWMCO(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace), "error creating test namespace")
 
+	// When the upgrade test is run from CI, the namespace that gets created does not have the required monitoring
+	// label, so we apply that here.
+	require.NoError(t, testCtx.applyMonitoringLabelToOperatorNamespace(), "error applying monitoring label")
+
 	// test that the operator can deploy without the secret already created, we can later use a secret created by the
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)


### PR DESCRIPTION
When the upgrade test is launched as a separate job, https://github.com/openshift/release/pull/17227, the monitoring label does not get applied to the operator namespace. Handle that difference by explicitly applying the label.