### PR TITLE
[test] Restart WMCO after monitoring label is applied

### DIFF
--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -36,8 +36,8 @@ func TestWMCO(t *testing.T) {
 	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace), "error creating test namespace")
 
 	// When the upgrade test is run from CI, the namespace that gets created does not have the required monitoring
-	// label, so we apply that here.
-	require.NoError(t, testCtx.applyMonitoringLabelToOperatorNamespace(), "error applying monitoring label")
+	// label, so we ensure that it gets applied and the WMCO deployment is restarted.
+	require.NoError(t, testCtx.ensureMonitoringIsEnabled(), "error ensuring monitoring is enabled")
 
 	// test that the operator can deploy without the secret already created, we can later use a secret created by the
 	// individual test suites after the operator is running


### PR DESCRIPTION
While #372 ensured that the `openshift.io/cluster-monitoring` is applied, that was not sufficient as WMCO is already running at that point and assumes monitoring is not enabled. Work around this by restarting WMCO after the label is applied.

This is needed for https://github.com/openshift/release/pull/17227/.