### PR TITLE
[test] Only run "basic" tests for *-e2e-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ unit:
 # Operator-sdk is smart enough to detect vendor directory
 .PHONY: run-ci-e2e-test
 run-ci-e2e-test:
-	hack/run-ci-e2e-test.sh
+	hack/run-ci-e2e-test.sh -t basic
 
 .PHONY: run-ci-e2e-upgrade-test
 run-ci-e2e-upgrade-test:

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,11 +21,6 @@ import (
 func reconfigurationTest(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
-
-	// Test is platform agnostic so is not needed to be run for every supported platform.
-	if testCtx.CloudProvider.GetType() != config.AzurePlatformType {
-		t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
-	}
 
 	nodes, err := testCtx.client.K8s.CoreV1().Nodes().List(context.TODO(),
 		metav1.ListOptions{LabelSelector: nc.WindowsOSLabel})

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	config "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
@@ -36,11 +35,6 @@ const (
 func upgradeTestSuite(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
-
-	// Test is platform agnostic so is not needed to be run for every supported platform.
-	if testCtx.CloudProvider.GetType() != config.AWSPlatformType {
-		t.Skipf("Skipping for %s", testCtx.CloudProvider.GetType())
-	}
 
 	// test if Windows workloads are running by creating a Job that curls the workloads continuously.
 	testerJob, err := testCtx.deployWindowsWorkloadAndTester()


### PR DESCRIPTION
Remove the platform type checks for the upgrade and reconfiguration tests as the upgrade test is configured to only run on AWS. This allows us to run the upgrade tests locally against other platforms.