### PR TITLE
[test] Use servercore:2009 image

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -366,7 +366,7 @@ func (tc *testContext) getWindowsServerContainerImage() string {
 	if tc.hasCustomVXLAN {
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1909"
 	} else if tc.CloudProvider.GetType() == config.AzurePlatformType {
-		windowsServerImage = "mcr.microsoft.com/windows/servercore:20H2"
+		windowsServerImage = "mcr.microsoft.com/windows/servercore:2009"
 	} else {
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1809"
 	}


### PR DESCRIPTION
Given we are seeing issues pulling `mcr.microsoft.com/windows/servercore:20H2`, switch to using `mcr.microsoft.com/windows/servercore:2009` which is already present on Azure VMs.