### PR TITLE
WINC-500: [wmco] Improve isValidMachine()

### DIFF
--- a/controllers/windowsmachine_controller_test.go
+++ b/controllers/windowsmachine_controller_test.go
@@ -23,15 +23,6 @@ func TestIsValidMachine(t *testing.T) {
 	invalidMachine3 := mapi.Machine{}
 	invalidMachine3.Name = "invalid_2"
 	invalidMachine3.Status.Phase = strToPtr("running")
-	validMachine1 := mapi.Machine{}
-	validMachine1.Name = "valid_1"
-	validMachine1.Status.Phase = strToPtr("running")
-	validMachine1.Status.Addresses = []core.NodeAddress{
-		{
-			Type:    "Hostname",
-			Address: "valid1.acme.com",
-		},
-	}
 	validMachine2 := mapi.Machine{}
 	validMachine2.Name = "valid_1"
 	validMachine2.Status.Phase = strToPtr("something")
@@ -57,10 +48,6 @@ func TestIsValidMachine(t *testing.T) {
 		{
 			machineObj:     &invalidMachine3,
 			isValidMachine: false,
-		},
-		{
-			machineObj:     &validMachine1,
-			isValidMachine: true,
 		},
 		{
 			machineObj:     &validMachine2,


### PR DESCRIPTION
Introduce `getInternalIPAddress()` that returns the internal IPv4 address of a Machine and use it in all the call sites. This has the good side effect of improving `isValidMachine()` as it was not doing all the necessary checks for IP addresses in Machine objects.