### PR TITLE
[test] Wait for machines to be deleted

### DIFF
--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -54,6 +54,8 @@ func testWindowsNodeDeletion(t *testing.T) {
 	for _, machineSet := range e2eMachineSets {
 		assert.NoError(t, testCtx.deleteMachineSet(machineSet), "error deleting MachineSet")
 	}
+	// Phase is ignored during deletion, in this case we are just waiting for Machines to be deleted.
+	require.NoError(t, testCtx.waitForWindowsMachines(int(gc.numberOfNodes), ""), "Windows machine deletion failed")
 
 	// Test if prometheus configuration is updated to have no node entries in the endpoints object
 	testPrometheus(t)


### PR DESCRIPTION
This PR introduces a wait time for the machines to be deleted after deleteMachineSet() has been called in deletionTestSuite()
to make sure we are proceeding to test prometheus endpoints after all the machines have been deleted.