### PR TITLE
[build] Improve development build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,6 @@ lint:
 unit:
 	hack/unit.sh ${GO_MOD_FLAGS}
 
-# Operator-sdk is smart enough to detect vendor directory
 .PHONY: run-ci-e2e-test
 run-ci-e2e-test:
 	hack/run-ci-e2e-test.sh -t basic
@@ -189,3 +188,12 @@ run-ci-e2e-upgrade-test:
 .PHONY: clean
 clean:
 	rm -rf ${OUTPUT_DIR}
+
+.PHONY: base-img
+base-img:
+	podman build . -t wmco-base -f build/Dockerfile.base
+
+.PHONY: wmco-img
+wmco-img:
+	podman build . -t $(IMG) -f build/Dockerfile.wmco
+	podman push $(IMG)

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,0 +1,71 @@
+FROM docker.io/openshift/origin-release:golang-1.16 as build
+LABEL stage=build
+
+WORKDIR /build/windows-machine-config-operator/
+COPY .git .git
+
+# Build WMCB
+WORKDIR /build/windows-machine-config-operator/windows-machine-config-bootstrapper/
+COPY windows-machine-config-bootstrapper/ .
+RUN make build
+
+# Build hybrid-overlay
+WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/
+COPY ovn-kubernetes/ .
+WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
+RUN make windows
+
+# Build promu utility tool, needed to build the windows_exporter.exe metrics binary
+WORKDIR /build/windows-machine-config-operator/promu/
+COPY promu/ .
+# Explicitly set the $GOBIN path for promu installation
+RUN GOBIN=/build/windows-machine-config-operator/windows_exporter/ go install .
+
+# Build windows_exporter
+WORKDIR /build/windows-machine-config-operator/windows_exporter/
+COPY windows_exporter/ .
+RUN GOOS=windows ./promu build -v
+
+# Build kubelet
+WORKDIR /build/windows-machine-config-operator/kubelet/
+COPY kubelet/ .
+ENV KUBE_BUILD_PLATFORMS windows/amd64
+RUN make WHAT=cmd/kubelet
+
+# Build kube-proxy
+WORKDIR /build/windows-machine-config-operator/kube-proxy/
+COPY kube-proxy/ .
+ENV KUBE_BUILD_PLATFORMS windows/amd64
+RUN make WHAT=cmd/kube-proxy
+
+# Build CNI plugins
+WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
+COPY containernetworking-plugins/ .
+ENV CGO_ENABLED=0
+RUN ./build_windows.sh
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+LABEL stage=base
+
+# Copy wmcb.exe
+WORKDIR /payload/
+COPY --from=build /build/windows-machine-config-operator/windows-machine-config-bootstrapper/wmcb.exe .
+
+# Copy hybrid-overlay-node.exe
+COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .
+
+# Copy windows_exporter.exe
+COPY --from=build /build/windows-machine-config-operator/windows_exporter/windows_exporter.exe .
+
+# Copy kubelet.exe and kube-proxy.exe
+WORKDIR /payload/kube-node/
+COPY --from=build /build/windows-machine-config-operator/kubelet/_output/local/bin/windows/amd64/kubelet.exe .
+COPY --from=build /build/windows-machine-config-operator/kube-proxy/_output/local/bin/windows/amd64/kube-proxy.exe .
+
+# Copy CNI plugin binaries and CNI config template cni-conf-template.json
+WORKDIR /payload/cni/
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/flannel.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/host-local.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-bridge.exe .
+COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-overlay.exe .
+COPY pkg/internal/cni-conf-template.json .

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,0 +1,46 @@
+FROM docker.io/openshift/origin-release:golang-1.16 as build
+LABEL stage=build
+
+WORKDIR /build/windows-machine-config-operator/
+
+# Copy files and directories needed to build the WMCO binary
+# `make build` uses `get_version()` in `hack/common.sh` to determine the version of binary created.
+# Any new file added here should be reflected in `hack/common.sh` if it dirties the git working tree.
+COPY version version
+COPY tools.go tools.go
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor vendor
+COPY .gitignore .gitignore
+COPY Makefile Makefile
+COPY build build
+COPY main.go .
+COPY controllers controllers
+COPY hack hack
+COPY pkg pkg
+COPY .git .git
+RUN make build
+
+FROM wmco-base:latest
+LABEL stage=operator
+
+# Copy required powershell scripts
+WORKDIR /payload/powershell/
+COPY pkg/internal/wget-ignore-cert.ps1 .
+COPY pkg/internal/hns.psm1 .
+
+WORKDIR /
+
+ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
+    USER_UID=1001 \
+    USER_NAME=windows-machine-config-operator
+
+# install operator binary
+COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-machine-config-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -7,7 +7,6 @@
 # OPTIONS
 #    $1      Action                   run/cleanup the operator installation
 #    -i      Ignore image cache       builds the operator image without using local image build cache
-#    -c=     Operator Image           container url and tag for the operator image
 #    -k=     Private key file         path to the private key file
 
 
@@ -26,12 +25,15 @@ if [[ ! "$ACTION" =~ ^build|run|cleanup$ ]]; then
 fi
 shift # shift position of the positional parameters for getopts
 
+if [ -z "$OPERATOR_IMAGE" ]; then
+    error-exit "OPERATOR_IMAGE is not set"
+fi
+
 # Options
 PRIVATE_KEY=""
 while getopts ":ic:k:" opt; do
     case "$opt" in
 	i) noCache="--no-cache";;
-	c) OPERATOR_IMAGE="$OPTARG";;
 	k) PRIVATE_KEY="$OPTARG";;
 	?) error-exit "Unknown option"
     esac
@@ -51,8 +53,6 @@ case "$ACTION" in
 
     ;;
     run)
-  build_WMCO $OSDK
-
   # Setup and run the operator
   run_WMCO $OSDK $PRIVATE_KEY
 


### PR DESCRIPTION
Introduce Dockerfile.base that builds only the submodules. This base image is used in Dockerfile.wmco which results in only the WMCO being built.

Now that we have simplified the image build process normalize on using `$OPERATOR_IMAGE` as the source of truth for the WMCO image.