### PR TITLE
WINC-597: Use controller runtime client where possible

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -414,7 +414,7 @@ func (r *WindowsMachineReconciler) deleteMachine(machine *mapi.Machine) error {
 
 // addWorkerNode configures the given Windows VM, adding it as a node object to the cluster
 func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineName string, platform oconfig.PlatformType) error {
-	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, ipAddress, instanceID, machineName, r.clusterServiceCIDR,
+	nc, err := nodeconfig.NewNodeConfig(r.client, ipAddress, instanceID, machineName, r.clusterServiceCIDR,
 		r.vxlanPort, r.signer, platform)
 	if err != nil {
 		return errors.Wrapf(err, "failed to configure Windows VM %s", instanceID)


### PR DESCRIPTION
Replaces usage of the client-go clientset with the client.Client interface from controller runtime where possible in both nodeconfig and the Windows Machine controller