### PR TITLE
[hack] Explicitly apply monitoring label

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -114,6 +114,11 @@ run_WMCO() {
       fi
   fi
 
+  # Add the "openshift.io/cluster-monitoring:"true"" label to the operator namespace to enable monitoring
+  if ! oc label ns $WMCO_DEPLOY_NAMESPACE openshift.io/cluster-monitoring=true --overwrite; then
+      return 1
+  fi
+
   if [ -n "$PRIVATE_KEY" ]; then
       if ! oc get secret cloud-private-key -n openshift-windows-machine-config-operator; then
           echo "Creating private-key secret"


### PR DESCRIPTION
This PR explicitly applies the monitoring label to be used when deploying the operator through OLM using the hack/olm.sh script to enable metrics configuration. This change needs to be made to align with the changes made as part of OSDK migration.
Prior to the migration this label was applied through the deploy/namespace.yaml which has now been replaced by a section of config/manager/manager.yaml.