### PR TITLE
[community-4.7] Enable and rename metric windows_cpu_info

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/prometheusRule.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/prometheusRule.yaml
@@ -36,3 +36,6 @@ spec:
         - expr: |
             windows_cs_physical_memory_bytes
           record: node_memory_MemTotal_bytes
+        - expr: |
+            windows_cpu_info
+          record: node_cpu_info

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -63,7 +63,7 @@ const (
 	// windowsExporterServiceArgs specifies metrics for the windows_exporter service to collect
 	// and expose metrics at endpoint with default port :9182 and default URL path /metrics
 	windowsExporterServiceArgs = "--collectors.enabled " +
-		"cpu,cs,logical_disk,net,os,service,system,textfile,container,memory\""
+		"cpu,cs,logical_disk,net,os,service,system,textfile,container,memory,cpu_info\""
 	// remotePowerShellCmdPrefix holds the PowerShell prefix that needs to be prefixed  for every remote PowerShell
 	// command executed on the remote Windows VM
 	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "


### PR DESCRIPTION
After the windows_exporter update to v0.16.0, it is possible to collect metric windows_cpu_info that is equivalent to node_cpu_info on the linux side. This PR enables cpu_info collector since it is not enabled by default.
Additionally renaming the metric windows_cpu_info to node_cpu_info through the PrometheusRule object, this will help in retrieving the telemetry info for Windows nodes collected using the recording rule node_role_os_version_machine:cpu_capacity_cores:sum based on node_cpu_info.