### PR TITLE
[hack] refactor consistent use of parameter

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -2,7 +2,9 @@
 
 # Location of the manifests file
 MANIFEST_LOC=bundle/
-WMCO_DEPLOY_NAMESPACE=openshift-windows-machine-config-operator
+
+# define namespace
+declare -r WMCO_DEPLOY_NAMESPACE=openshift-windows-machine-config-operator
 
 error-exit() {
     echo "Error: $*" >&2
@@ -109,7 +111,7 @@ run_WMCO() {
 
   # create the deploy namespace if it does not exist
   if ! oc get ns $WMCO_DEPLOY_NAMESPACE; then
-      if ! oc create ns openshift-windows-machine-config-operator; then
+      if ! oc create ns $WMCO_DEPLOY_NAMESPACE; then
           return 1
       fi
   fi
@@ -120,19 +122,19 @@ run_WMCO() {
   fi
 
   if [ -n "$PRIVATE_KEY" ]; then
-      if ! oc get secret cloud-private-key -n openshift-windows-machine-config-operator; then
+      if ! oc get secret cloud-private-key -n $WMCO_DEPLOY_NAMESPACE; then
           echo "Creating private-key secret"
-          if ! oc create secret generic cloud-private-key --from-file=private-key.pem="$PRIVATE_KEY" -n openshift-windows-machine-config-operator; then
+          if ! oc create secret generic cloud-private-key --from-file=private-key.pem="$PRIVATE_KEY" -n $WMCO_DEPLOY_NAMESPACE; then
               return 1
           fi
       fi
   fi
 
-  # Run the operator in the openshift-windows-machine-config-operator namespace
+  # Run the operator in the given namespace
   OSDK_WMCO_management run $OSDK
 
   # Additional guard that ensures that operator was deployed given the SDK flakes in error reporting
-  if ! oc rollout status deployment windows-machine-config-operator -n openshift-windows-machine-config-operator --timeout=5s; then
+  if ! oc rollout status deployment windows-machine-config-operator -n $WMCO_DEPLOY_NAMESPACE --timeout=5s; then
     return 1
   fi
 }
@@ -150,7 +152,7 @@ cleanup_WMCO() {
   fi
   transform_csv $OPERATOR_IMAGE REPLACE_IMAGE
 
-  # Remove the openshift-windows-machine-config-operator namespace
+  # Remove the declared namespace
   oc delete ns $WMCO_DEPLOY_NAMESPACE
 }
 


### PR DESCRIPTION
This PR align the usage of the WMCO_DEPLOY_NAMESPACE parameter
within the `hack/common.sh` script.

See: https://github.com/openshift/windows-machine-config-operator/pull/419#discussion_r621435105