### PR TITLE
[wmco] Remove error from GetServiceCIDR() returns

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -91,11 +91,6 @@ func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Conf
 		return nil, errors.Wrap(err, "error creating kubernetes clientset")
 	}
 
-	serviceCIDR, err := clusterConfig.Network().GetServiceCIDR()
-	if err != nil {
-		return nil, errors.Wrap(err, "error getting service CIDR")
-	}
-
 	// Initialize prometheus configuration
 	pc, err := metrics.NewPrometheusNodeConfig(clientset, watchNamespace)
 	if err != nil {
@@ -107,7 +102,7 @@ func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Conf
 		log:                  ctrl.Log.WithName("controller").WithName("windowsmachine"),
 		scheme:               mgr.GetScheme(),
 		k8sclientset:         clientset,
-		clusterServiceCIDR:   serviceCIDR,
+		clusterServiceCIDR:   clusterConfig.Network().GetServiceCIDR(),
 		vxlanPort:            clusterConfig.Network().VXLANPort(),
 		recorder:             mgr.GetEventRecorderFor("windowsmachine"),
 		watchNamespace:       watchNamespace,

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -29,7 +29,7 @@ const (
 // Network interface contains methods to interact with cluster network objects
 type Network interface {
 	Validate() error
-	GetServiceCIDR() (string, error)
+	GetServiceCIDR() string
 	VXLANPort() string
 }
 
@@ -214,8 +214,8 @@ func NewClusterNetworkCfg(serviceCIDR, vxlanPort string) (*clusterNetworkCfg, er
 }
 
 // GetServiceCIDR returns the serviceCIDR string
-func (ovn *ovnKubernetes) GetServiceCIDR() (string, error) {
-	return ovn.clusterNetworkConfig.serviceCIDR, nil
+func (ovn *ovnKubernetes) GetServiceCIDR() string {
+	return ovn.clusterNetworkConfig.serviceCIDR
 }
 
 // GetVXLANPort gets the VXLAN port to be used for VXLAN tunnel establishment


### PR DESCRIPTION
An error does not need to be returned, so remove it from the signature
and correct its call sites.