### PR TITLE
WIP: support other networking types

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -76,6 +76,9 @@ type WindowsMachineReconciler struct {
 	// 		 in vSphere
 	//		 https://bugzilla.redhat.com/show_bug.cgi?id=1876987
 	platform oconfig.PlatformType
+
+	// networkType is the detected network type
+	networkType string
 }
 
 // NewWindowsMachineReconciler returns a pointer to a WindowsMachineReconciler
@@ -428,7 +431,7 @@ func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineN
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, ipAddress, hostname, r.clusterServiceCIDR,
-		r.vxlanPort, username, r.signer)
+		r.vxlanPort, r.networkType, username, r.signer)
 	if err != nil {
 		return errors.Wrapf(err, "failed to configure Windows VM %s", instanceID)
 	}

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -194,19 +194,9 @@ func networkConfigurationFactory(oclient configclient.Interface, operatorClient 
 	}
 	switch network {
 	case OVNKubernetesNetwork:
-		return &ovnKubernetes{
-			networkType{
-				name:           network,
-				operatorClient: operatorClient,
-			},
-			clusterNetworkCfg,
-		}, nil
+		return newOVNKubernetesNetwork(network, operatorClient, clusterNetworkCfg), nil
 	default:
-		return &thirdPartyNetworking{
-			clusterNetworkCfg,
-			"c:\\k\\cni",
-		}, nil
-
+		return newThirdPartyNetwork(clusterNetworkCfg), nil
 	}
 }
 
@@ -220,6 +210,16 @@ func NewClusterNetworkCfg(serviceCIDR, vxlanPort string) (*clusterNetworkCfg, er
 		serviceCIDR: serviceCIDR,
 		vxlanPort:   vxlanPort,
 	}, nil
+}
+
+func newOVNKubernetesNetwork(network string, operatorClient operatorv1.OperatorV1Interface, clusterNetworkConfig *clusterNetworkCfg) Network {
+	return &ovnKubernetes{
+		networkType{
+			name:           network,
+			operatorClient: operatorClient,
+		},
+		clusterNetworkConfig,
+	}
 }
 
 // GetServiceCIDR returns the serviceCIDR string
@@ -250,6 +250,14 @@ func (ovn *ovnKubernetes) Validate() error {
 	}
 	return nil
 }
+
+func newThirdPartyNetwork(clusterNetworkConfig *clusterNetworkCfg) Network {
+	return &thirdPartyNetworking{
+		clusterNetworkConfig,
+		"c:\\k\\cni",
+	}
+}
+
 func (tp *thirdPartyNetworking) Validate() error {
 	return nil
 }

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -20,7 +20,7 @@ import (
 //+kubebuilder:rbac:groups=config.openshift.io;operator.openshift.io,resources=networks,verbs=get
 
 const (
-	OvnKubernetesNetwork = "OVNKubernetes"
+	OVNKubernetesNetwork = "OVNKubernetes"
 	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
 	// 1.20.x are supported for baseK8sVersion 1.20)
 	baseK8sVersion = "v1.21"
@@ -194,7 +194,7 @@ func networkConfigurationFactory(oclient configclient.Interface, operatorClient 
 		return nil, errors.Wrapf(err, "error getting cluster network config")
 	}
 	switch network {
-	case OvnKubernetesNetwork:
+	case OVNKubernetesNetwork:
 		return &ovnKubernetes{
 			networkType{
 				name:           network,

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -53,7 +53,6 @@ type networkType struct {
 
 type thirdPartyNetworking struct {
 	clusterNetworkConfig *clusterNetworkCfg
-	cniDir               string
 }
 
 // config encapsulates cluster configuration
@@ -254,7 +253,6 @@ func (ovn *ovnKubernetes) Validate() error {
 func newThirdPartyNetwork(clusterNetworkConfig *clusterNetworkCfg) Network {
 	return &thirdPartyNetworking{
 		clusterNetworkConfig,
-		"c:\\k\\cni",
 	}
 }
 

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -52,7 +52,6 @@ type networkType struct {
 }
 
 type thirdPartyNetworking struct {
-	networkType
 	clusterNetworkConfig *clusterNetworkCfg
 	cniDir               string
 }
@@ -204,11 +203,6 @@ func networkConfigurationFactory(oclient configclient.Interface, operatorClient 
 		}, nil
 	default:
 		return &thirdPartyNetworking{
-			networkType{
-				// This will be some non-OpenShift network type
-				name:           network,
-				operatorClient: operatorClient,
-			},
 			clusterNetworkCfg,
 			"c:\\k\\cni",
 		}, nil

--- a/pkg/nodeconfig/network.go
+++ b/pkg/nodeconfig/network.go
@@ -46,6 +46,9 @@ type value struct {
 
 // network struct contains the node network information
 type network struct {
+	// networkType is the type of network
+	networkType string
+
 	// hostSubnet holds the node host subnet value
 	hostSubnet string
 	log        logr.Logger

--- a/pkg/nodeconfig/network.go
+++ b/pkg/nodeconfig/network.go
@@ -55,8 +55,11 @@ type network struct {
 }
 
 // newNetwork returns a pointer to the network struct
-func newNetwork(logger logr.Logger) *network {
-	return &network{log: logger}
+func newNetwork(logger logr.Logger, networkType string) *network {
+	return &network{
+		networkType: networkType,
+		log:         logger,
+	}
 }
 
 // setHostSubnet sets the value for hostSubnet field in the network struct

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -210,7 +210,7 @@ func (nc *nodeConfig) Configure() error {
 // we are assuming that the WindowsVM and node objects are valid
 func (nc *nodeConfig) configureNetwork() error {
 	// OVN kubernetes specific
-	if nc.network.networkType == cluster.OvnKubernetesNetwork {
+	if nc.network.networkType == cluster.OVNKubernetesNetwork {
 		// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
 		// start
 		if err := nc.waitForNodeAnnotation(HybridOverlaySubnet); err != nil {
@@ -322,7 +322,7 @@ func (nc *nodeConfig) configureCNI() error {
 	var err error
 
 	// OVN kubernetes specific
-	if nc.network.networkType == cluster.OvnKubernetesNetwork {
+	if nc.network.networkType == cluster.OVNKubernetesNetwork {
 		// set the hostSubnet value in the network struct
 		if err := nc.network.setHostSubnet(nc.node.Annotations[HybridOverlaySubnet]); err != nil {
 			return errors.Wrapf(err, "error populating host subnet in node network")

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -115,10 +115,7 @@ func NewNodeConfig(clientset *kubernetes.Clientset, ipAddress, hostname, cluster
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")
 	}
 
-	network := newNetwork(log)
-	network.networkType = networkType
-
-	return &nodeConfig{k8sclientset: clientset, Windows: win, network: newNetwork(log),
+	return &nodeConfig{k8sclientset: clientset, Windows: win, network: newNetwork(log, networkType),
 		clusterServiceCIDR: clusterServiceCIDR, publicKeyHash: CreatePubKeyHashAnnotation(signer.PublicKey()),
 		log: log}, nil
 }

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -86,7 +86,7 @@ func discoverKubeAPIServerEndpoint() (string, error) {
 // NewNodeConfig creates a new instance of nodeConfig to be used by the caller.
 // hostName having a value will result in the VM's hostname being changed to the given value.
 func NewNodeConfig(clientset *kubernetes.Clientset, ipAddress, hostname, clusterServiceCIDR,
-	vxlanPort, username string, signer ssh.Signer) (*nodeConfig, error) {
+	vxlanPort, networkType, username string, signer ssh.Signer) (*nodeConfig, error) {
 	var err error
 	if nodeConfigCache.workerIgnitionEndPoint == "" {
 		var kubeAPIServerEndpoint string
@@ -109,10 +109,14 @@ func NewNodeConfig(clientset *kubernetes.Clientset, ipAddress, hostname, cluster
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nodeconfig %s", ipAddress))
 	win, err := windows.New(ipAddress, hostname, nodeConfigCache.workerIgnitionEndPoint, vxlanPort,
-		username, signer)
+		networkType, username, signer)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")
 	}
+
+	network := newNetwork(log)
+	network.networkType = networkType
 
 	return &nodeConfig{k8sclientset: clientset, Windows: win, network: newNetwork(log),
 		clusterServiceCIDR: clusterServiceCIDR, publicKeyHash: CreatePubKeyHashAnnotation(signer.PublicKey()),
@@ -205,26 +209,29 @@ func (nc *nodeConfig) Configure() error {
 // configureNetwork configures k8s networking in the node
 // we are assuming that the WindowsVM and node objects are valid
 func (nc *nodeConfig) configureNetwork() error {
-	// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
-	// start
-	if err := nc.waitForNodeAnnotation(HybridOverlaySubnet); err != nil {
-		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlaySubnet,
-			nc.node.GetName())
-	}
+	// OVN kubernetes specific
+	if nc.network.networkType == cluster.OvnKubernetesNetwork {
+		// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
+		// start
+		if err := nc.waitForNodeAnnotation(HybridOverlaySubnet); err != nil {
+			return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlaySubnet,
+				nc.node.GetName())
+		}
 
-	// NOTE: Investigate if we need to introduce a interface wrt to the VM's networking configuration. This will
-	// become more clear with the outcome of https://issues.redhat.com/browse/WINC-343
+		// NOTE: Investigate if we need to introduce a interface wrt to the VM's networking configuration. This will
+		// become more clear with the outcome of https://issues.redhat.com/browse/WINC-343
 
-	// Configure the hybrid overlay in the Windows VM
-	if err := nc.Windows.ConfigureHybridOverlay(nc.node.GetName()); err != nil {
-		return errors.Wrapf(err, "error configuring hybrid overlay for %s", nc.node.GetName())
-	}
+		// Configure the hybrid overlay in the Windows VM
+		if err := nc.Windows.ConfigureHybridOverlay(nc.node.GetName()); err != nil {
+			return errors.Wrapf(err, "error configuring hybrid overlay for %s", nc.node.GetName())
+		}
 
-	// Wait until the node object has the hybrid overlay MAC annotation. This is required for the CNI configuration to
-	// start.
-	if err := nc.waitForNodeAnnotation(HybridOverlayMac); err != nil {
-		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlayMac,
-			nc.node.GetName())
+		// Wait until the node object has the hybrid overlay MAC annotation. This is required for the CNI configuration to
+		// start.
+		if err := nc.waitForNodeAnnotation(HybridOverlayMac); err != nil {
+			return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlayMac,
+				nc.node.GetName())
+		}
 	}
 
 	// Configure CNI in the Windows VM
@@ -311,15 +318,22 @@ func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
 // configureCNI populates the CNI config template and sends the config file location
 // for completing CNI configuration in the windows VM
 func (nc *nodeConfig) configureCNI() error {
-	// set the hostSubnet value in the network struct
-	if err := nc.network.setHostSubnet(nc.node.Annotations[HybridOverlaySubnet]); err != nil {
-		return errors.Wrapf(err, "error populating host subnet in node network")
+	var configFile string
+	var err error
+
+	// OVN kubernetes specific
+	if nc.network.networkType == cluster.OvnKubernetesNetwork {
+		// set the hostSubnet value in the network struct
+		if err := nc.network.setHostSubnet(nc.node.Annotations[HybridOverlaySubnet]); err != nil {
+			return errors.Wrapf(err, "error populating host subnet in node network")
+		}
+		// populate the CNI config file with the host subnet and the service network CIDR
+		configFile, err = nc.network.populateCniConfig(nc.clusterServiceCIDR, payload.CNIConfigTemplatePath)
+		if err != nil {
+			return errors.Wrapf(err, "error populating CNI config file %s", configFile)
+		}
 	}
-	// populate the CNI config file with the host subnet and the service network CIDR
-	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, payload.CNIConfigTemplatePath)
-	if err != nil {
-		return errors.Wrapf(err, "error populating CNI config file %s", configFile)
-	}
+
 	// configure CNI in the Windows VM
 	if err = nc.Windows.ConfigureCNI(configFile); err != nil {
 		return errors.Wrapf(err, "error configuring CNI for %s", nc.node.GetName())

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -344,7 +344,7 @@ func (vm *windows) ConfigureHybridOverlay(nodeName string) error {
 }
 
 func (vm *windows) ConfigureCNI(configFile string) error {
-	if vm.networkType == cluster.OvnKubernetesNetwork {
+	if vm.networkType == cluster.OVNKubernetesNetwork {
 		// copy the CNI config file to the Windows VM
 		file, err := payload.NewFileInfo(configFile)
 		if err != nil {
@@ -385,7 +385,7 @@ func (vm *windows) ConfigureCNI(configFile string) error {
 
 func (vm *windows) ConfigureKubeProxy(nodeName, hostSubnet string) error {
 	var kubeProxyServiceArgs string
-	if vm.networkType == cluster.OvnKubernetesNetwork {
+	if vm.networkType == cluster.OVNKubernetesNetwork {
 		sVIP, err := vm.getSourceVIP()
 		if err != nil {
 			return errors.Wrap(err, "error getting source VIP")


### PR DESCRIPTION
Hi everyone,

This PR is some WIP code that adds support for 3rd-party networking (old issue here: https://github.com/openshift/windows-machine-config-operator/issues/134). I'd like to use this as a starting point for discussion on how we could support other networking types.

The overall flow here is:
- User creates a machineset for their Windows nodes
- On those Windows nodes, the user sets up the networking and install the CNI config and binaries (e.g. Calico).
- WMCO sets up the node but does not configure networking since networking isn't OVN-Kubernetes.
- (One missing bit of code is for WMCO to uncordon the node once it's ready)

I'd love to get some input on this, thanks!