### PR TITLE
[hack] fixed typo in error message

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -125,7 +125,7 @@ EOF
 get_azure_ms() {
 
   if [ "$#" -lt 4 ]; then
-    error-exit incorrect parameter count for get_spec $#
+    error-exit incorrect parameter count for get_azure_ms $#
   fi
 
   local infraID=$1


### PR DESCRIPTION
Correct typo in error message for `get_azure_ms()`