### PR TITLE
[docs] Improve troubleshooting for 1809

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,12 +5,16 @@ Please check if you are using an OKD/OCP 4.6 cluster running on Azure or AWS, co
 [hybrid OVN Kubernetes networking](setup-hybrid-OVNKubernetes-cluster.md).
 
 ## Windows Machine does not become a worker node
-There could various reasons as to why a Windows Machine does not become a worker node. Please collect the WMCO logs
+There could be various reasons as to why a Windows Machine does not become a worker node. Please collect the WMCO logs
 by executing:
 ```shell script
 oc logs -f $(oc get pods -o jsonpath={.items[0].metadata.name} -n openshift-windows-machine-config-operator) -n openshift-windows-machine-config-operator
 ```
 File a GitHub issue and attach the logs to the issue along with the *MachineSet* used.
+
+## Windows Server 2019 LTSC (1809) nodes never become Ready
+Ensure that you have not configured the cluster with a
+[custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) as that is not a supported feature in 1809.
 
 ## Accessing a Windows node
 Windows nodes cannot be accessed using `oc debug node` as that requires running a privileged pod on the node which is

--- a/docs/setup-hybrid-OVNKubernetes-cluster.md
+++ b/docs/setup-hybrid-OVNKubernetes-cluster.md
@@ -23,7 +23,6 @@ Now generate the manifests for the previously created *install-config*:
 ```sh
 $ openshift-install create manifests --dir=<cluster_directory>
 ```
-
 This creates a `manifests` and `openshift` folder in your `<cluster_directory>`.
 Now create a `<cluster_directory>/manifests/cluster-network-03-config.yml` file with the following contents:
 ```yml
@@ -41,6 +40,7 @@ spec:
 ```
 The above configuration is recommended for AWS and Azure clusters.
 
+### vSphere
 For vSphere clusters, you must add the `hybridOverlayVXLANPort` option to work around the pod-to-pod connectivity
 between hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere):
 ```yml
@@ -57,8 +57,10 @@ spec:
             hostPrefix: 23
         hybridOverlayVXLANPort: 9898
 ```
-
-**Note:** The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR.
+#### Attention
+- The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR
+- You cannot use Windows Server 2019 LTSC (1809) as it does not have the kernel feature required for using custom VXLAN 
+  ports
 
 ## Create cluster
 


### PR DESCRIPTION
Clarify that you cannot use Windows Server 2019 LTSC (1809) in a cluster configured with a custom VXLAN port.