### PR TITLE
WINC-600: Add system-cluster-critical priority class

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -283,6 +283,7 @@ spec:
               hostNetwork: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
+              priorityClassName: system-cluster-critical
               serviceAccountName: windows-machine-config-operator
               terminationGracePeriodSeconds: 10
               tolerations:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         control-plane: controller-manager
     spec:
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: windows-machine-config-operator
       containers:
       - command:


### PR DESCRIPTION
This PR adds a "system-cluster-critical" priority tag to the operator so
that WMCO pods are not preempted by user workloads. This priority still allows
operator pods to be OOMKilled as WMCO should come up fine if it gets
rescheduled on another node.

Bundle change was generated using `make bundle`.