### PR TITLE
[deploy] Remove duplicate field in deployment spec

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,6 @@ spec:
     spec:
       hostNetwork: true
       priorityClassName: system-cluster-critical
-      serviceAccountName: windows-machine-config-operator
       containers:
       - command:
         - windows-machine-config-operator


### PR DESCRIPTION
This PR removes the duplicate 'serviceAccountName' field
from the WMCO Deployment resource config.