### PR TITLE
[community-4.7] WINC-600: Add system-cluster-critical priority class

### DIFF
--- a/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/windows-machine-config-operator/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -250,6 +250,7 @@ spec:
               hostNetwork: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
+              priorityClassName: system-cluster-critical
               serviceAccountName: windows-machine-config-operator
               tolerations:
               - effect: NoSchedule

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,7 @@ spec:
         name: windows-machine-config-operator
     spec:
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: windows-machine-config-operator
       containers:
         - name: windows-machine-config-operator


### PR DESCRIPTION
This PR adds a 'system-cluster-critical' priority tag to the operator so
that WMCO pods are not preempted by user workloads. This priority still allows
operator pods to be OOMKilled as WMCO should come up fine if it gets
rescheduled on another node.

Backport of #463.