### PR TITLE
[test] Fix flakey configmap unit test

### DIFF
--- a/controllers/configmap_controller_test.go
+++ b/controllers/configmap_controller_test.go
@@ -69,7 +69,7 @@ func TestParseHosts(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedOut, out)
+			assert.ElementsMatch(t, test.expectedOut, out)
 		})
 	}
 }


### PR DESCRIPTION
Random ordering of elements caused this unit test to fail occasionally.
ElementsMatch should be used instead so that the order does not matter.

Co-authored-by: Aravindh Puthiyaparambil <aravindh@redhat.com>