### PR TITLE
[release-4.8] [bundle] Update pre-requisite to OCP 4.8

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -34,8 +34,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift subscription
-    * OCP 4.7 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [vSphere prequisites](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/vsphere-prerequisites.md)
+    * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -32,8 +32,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift subscription
-    * OCP 4.7 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [vSphere prequisites](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/vsphere-prerequisites.md)
+    * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing


### PR DESCRIPTION
This PR updates the required OCP platform to 4.8 in the pre-requisites section of the CSV for the 4.8 release.