### PR TITLE
WINC-582: [wmco] BYOH node removal

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -1,0 +1,64 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+)
+
+func TestGetAddress(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []core.NodeAddress
+		expectedOut []string
+		expectedErr bool
+	}{
+		{
+			name:        "no addresses",
+			input:       []core.NodeAddress{{}},
+			expectedOut: []string{""},
+			expectedErr: true,
+		},
+		{
+			name:        "ipv6",
+			input:       []core.NodeAddress{{Type: core.NodeInternalIP, Address: "::1"}},
+			expectedOut: []string{""},
+			expectedErr: true,
+		},
+		{
+			name:        "ipv4",
+			input:       []core.NodeAddress{{Type: core.NodeInternalIP, Address: "127.0.0.1"}},
+			expectedOut: []string{"127.0.0.1"},
+			expectedErr: false,
+		},
+		{
+			name:        "dns",
+			input:       []core.NodeAddress{{Type: core.NodeInternalDNS, Address: "localhost"}},
+			expectedOut: []string{"localhost"},
+			expectedErr: false,
+		},
+		{
+			name: "dns and ipv4",
+			input: []core.NodeAddress{
+				{Type: core.NodeInternalDNS, Address: "localhost"},
+				{Type: core.NodeInternalIP, Address: "127.0.0.1"}},
+			expectedOut: []string{"localhost", "127.0.0.1"},
+			expectedErr: false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := GetAddress(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			// The output can be any valid address in the expected list, so check that the output is one of the possible
+			// correct ones
+			assert.Contains(t, test.expectedOut, out)
+		})
+	}
+}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -65,21 +65,6 @@ func (tc *testContext) deleteWindowsInstanceConfigMap() error {
 	return nil
 }
 
-// getAddress returns a non-ipv6 address that can be used to reach a Windows node. This can be either an ipv4
-// or dns address.
-func (tc *testContext) getAddress(addresses []v1.NodeAddress) (string, error) {
-	for _, addr := range addresses {
-		if addr.Type == v1.NodeInternalIP || addr.Type == v1.NodeInternalDNS {
-			// filter out ipv6
-			if net.ParseIP(addr.Address) != nil && net.ParseIP(addr.Address).To4() == nil {
-				continue
-			}
-			return addr.Address, nil
-		}
-	}
-	return "", errors.New("no usable address")
-}
-
 // createWindowsInstanceConfigMap creates a ConfigMap for the ConfigMap controller to act on, comprised of the Machines
 // in the given MachineList
 func (tc *testContext) createWindowsInstanceConfigMap(machines *mapi.MachineList) error {
@@ -90,7 +75,7 @@ func (tc *testContext) createWindowsInstanceConfigMap(machines *mapi.MachineList
 		Data: make(map[string]string),
 	}
 	for _, machine := range machines.Items {
-		addr, err := tc.getAddress(machine.Status.Addresses)
+		addr, err := controllers.GetAddress(machine.Status.Addresses)
 		if err != nil {
 			return errors.Wrap(err, "unable to get usable address")
 		}

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -91,10 +91,7 @@ func testPrometheus(t *testing.T) {
 
 	if len(gc.allNodes()) == 0 {
 		// check if all entries in subset are deleted when there are no Windows Nodes
-		// TODO: BYOH metrics cleanup isn't done yet so only check that Nodes from Machines are properly removed
-		//       total endpoints - machine endpoints = byoh endpoints
-		//       Change back to expecting 0 as part of https://issues.redhat.com/browse/WINC-582
-		require.Equal(t, int(gc.numberOfBYOHNodes), len(windowsEndpoints.Subsets))
+		require.Equal(t, 0, len(windowsEndpoints.Subsets))
 	} else {
 		// Total length of list for subsets is always equal to the list of Windows Nodes.
 		require.Equal(t, len(gc.allNodes()), len(windowsEndpoints.Subsets[0].Addresses))

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -53,8 +53,8 @@ var (
 type operatingSystem string
 
 const (
-	linux   operatingSystem = "linux"
-	windows operatingSystem = "windows"
+	linux     operatingSystem = "linux"
+	windowsOS operatingSystem = "windows"
 )
 
 // testEastWestNetworking deploys Windows and Linux pods, and tests that the pods can communicate
@@ -74,7 +74,7 @@ func testEastWestNetworking(t *testing.T) {
 		},
 		{
 			name:            "windows and windows",
-			curlerOS:        windows,
+			curlerOS:        windowsOS,
 			useClusterIPSVC: false,
 		},
 		{
@@ -84,7 +84,7 @@ func testEastWestNetworking(t *testing.T) {
 		},
 		{
 			name:            "windows and windows through a clusterIP svc",
-			curlerOS:        windows,
+			curlerOS:        windowsOS,
 			useClusterIPSVC: true,
 		},
 	}
@@ -134,7 +134,7 @@ func testEastWestNetworking(t *testing.T) {
 						curlerCommand := []string{"bash", "-c", "curl " + endpointIP}
 						curlerJob, err = testCtx.createLinuxJob("linux-curler-"+strings.ToLower(node.Status.NodeInfo.MachineID), curlerCommand)
 						require.NoError(t, err, "could not create Linux job")
-					} else if tt.curlerOS == windows {
+					} else if tt.curlerOS == windowsOS {
 						// Always deploy the Windows curler pod on the first node. Because we test scaling multiple
 						// Windows nodes, this allows us to test that Windows pods can communicate with other Windows
 						// pods located on both the same node, and other nodes.


### PR DESCRIPTION
This commit enables the removal of BYOH nodes from a cluster. A new
username annotation has been added to BYOH nodes in order to help
accomplish this.

Instances that are removed from the windows-instances ConfigMap will be
cordoned, drained, and deconfigured, returning them to the state they
were in before WMCO configured them.