### PR TITLE
[release-4.7] Prep for 2.0.2 release

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -134,7 +134,7 @@ cleanup_WMCO() {
 # the files here are selected based on the files that we are transferring while building the
 # operator binary in `build/Dockerfile`
 get_version() {
-  OPERATOR_VERSION=2.0.1
+  OPERATOR_VERSION=2.0.2
   GIT_COMMIT=$(git rev-parse --short HEAD)
   VERSION="${OPERATOR_VERSION}+${GIT_COMMIT}"
 


### PR DESCRIPTION
This PR updates the WMCO version to
v2.0.2 for the next 4.7 release.