### PR TITLE
WINC-612: [wmco] Introduce isValidConfigMap()

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -277,16 +277,10 @@ func (r *ConfigMapReconciler) mapToConfigMap(_ client.Object) []reconcile.Reques
 func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	configMapPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetNamespace() == r.watchNamespace && e.Object.GetName() == InstanceConfigMap {
-				return true
-			}
-			return false
+			return r.isValidConfigMap(e.Object)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetNamespace() == r.watchNamespace && e.ObjectNew.GetName() == InstanceConfigMap {
-				return true
-			}
-			return false
+			return r.isValidConfigMap(e.ObjectNew)
 		},
 	}
 	return ctrl.NewControllerManagedBy(mgr).
@@ -294,4 +288,9 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &core.Node{}}, handler.EnqueueRequestsFromMapFunc(r.mapToConfigMap),
 			builder.WithPredicates(windowsNodePredicate(true))).
 		Complete(r)
+}
+
+// isValidConfigMap returns true if the ConfigMap object is the InstanceConfigMap
+func (r *ConfigMapReconciler) isValidConfigMap(o client.Object) bool {
+	return o.GetNamespace() == r.watchNamespace && o.GetName() == InstanceConfigMap
 }

--- a/controllers/configmap_controller_test.go
+++ b/controllers/configmap_controller_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/instances"
 )
@@ -70,6 +73,70 @@ func TestParseHosts(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.ElementsMatch(t, test.expectedOut, out)
+		})
+	}
+}
+
+func TestIsValidConfigMap(t *testing.T) {
+	watchNamespace := "test"
+	r := ConfigMapReconciler{instanceReconciler: instanceReconciler{watchNamespace: watchNamespace}}
+
+	var tests = []struct {
+		name             string
+		configMapObj     client.Object
+		isValidConfigMap bool
+	}{
+		{
+			name: "valid ConfigMap",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      InstanceConfigMap,
+					Namespace: watchNamespace,
+				},
+			},
+			isValidConfigMap: true,
+		},
+		{
+			name:             "empty ConfigMap",
+			configMapObj:     &core.ConfigMap{},
+			isValidConfigMap: false,
+		},
+		{
+			name: "invalid ConfigMap",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "invalid",
+					Namespace: "invalid",
+				},
+			},
+			isValidConfigMap: false,
+		},
+		{
+			name: "invalid namespace",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      InstanceConfigMap,
+					Namespace: "invalid",
+				},
+			},
+			isValidConfigMap: false,
+		},
+		{
+			name: "invalid name",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "invalid",
+					Namespace: watchNamespace,
+				},
+			},
+			isValidConfigMap: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isValidConfigMap := r.isValidConfigMap(test.configMapObj)
+			require.Equal(t, test.isValidConfigMap, isValidConfigMap)
 		})
 	}
 }


### PR DESCRIPTION
isValidConfigMap() checks if the given configMap is the `windows-instances` ConfigMap. This is used when filtering objects in the ConfigMap predicate.