### PR TITLE
[release-4.8] [Dockerfile] Set index image label version to 4.8

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports (4.7).
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.7"
+LABEL com.redhat.openshift.versions="=v4.8"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically


### PR DESCRIPTION
This PR updates the label version of the index image in the bundle.Dockerfile to 4.8 for release-4.8.