### PR TITLE
WINC-580: Upgrade BYOH Nodes configured by previous WMCO versions

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -38,8 +38,8 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/instances"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/metrics"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/signer"
 )
@@ -213,7 +213,7 @@ func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, windowsInstanc
 func (r *ConfigMapReconciler) ensureInstanceIsConfigured(instance *instances.InstanceInfo) error {
 	if instance.Node != nil {
 		// Version annotation being present means that the node has been fully configured
-		if _, present := instance.Node.Annotations[nodeconfig.VersionAnnotation]; present {
+		if _, present := instance.Node.Annotations[metadata.VersionAnnotation]; present {
 			// TODO: Check version for upgrade case https://issues.redhat.com/browse/WINC-580 and remove and re-add the node
 			//       if needed. Possibly also do this if the node is not in the `Ready` state.
 			return nil

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -122,10 +122,16 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, r.reconcileNodes(ctx, configMap)
 }
 
-// parseHosts gets the lists of hosts specified in the configmap's data
-func (r *ConfigMapReconciler) parseHosts(configMapData map[string]string) ([]*instances.InstanceInfo, error) {
-	hosts := make([]*instances.InstanceInfo, 0)
-	// Get information about the hosts from each entry. The expected key/value format for each entry is:
+// parseInstances gets the list of instances specified in the ConfigMap's data. This function should be passed a list
+// of Nodes in the cluster, as each instance returned will contain a reference to its associated Node, if it has one
+// in the given NodeList. If an instance does not have an associated node from the NodeList, the node reference will
+// be nil.
+func (r *ConfigMapReconciler) parseInstances(configMapData map[string]string, nodes *core.NodeList) ([]*instances.InstanceInfo, error) {
+	if nodes == nil {
+		return nil, errors.New("nodes cannot be nil")
+	}
+	instanceList := make([]*instances.InstanceInfo, 0)
+	// Get information about the instances from each entry. The expected key/value format for each entry is:
 	// <address>: username=<username>
 	for address, data := range configMapData {
 		if err := validateAddress(address); err != nil {
@@ -133,12 +139,14 @@ func (r *ConfigMapReconciler) parseHosts(configMapData map[string]string) ([]*in
 		}
 		splitData := strings.SplitN(data, "=", 2)
 		if len(splitData) == 0 || splitData[0] != "username" {
-			return hosts, errors.Errorf("data for entry %s has an incorrect format", address)
+			return instanceList, errors.Errorf("data for entry %s has an incorrect format", address)
 		}
 
-		hosts = append(hosts, instances.NewInstanceInfo(address, splitData[1], ""))
+		// Get the associated node if the described instance has one
+		node, _ := findNode(address, nodes)
+		instanceList = append(instanceList, instances.NewInstanceInfo(address, splitData[1], "", node))
 	}
-	return hosts, nil
+	return instanceList, nil
 }
 
 // validateAddress checks that the given address is either an ipv4 address, or resolves to any ip address
@@ -162,17 +170,17 @@ func validateAddress(address string) error {
 	return nil
 }
 
-// reconcileNodes corrects the discrepancy between the "expected" hosts slice, and the "actual" nodelist
-func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, instances *core.ConfigMap) error {
-	// Get the list of instances that are expected to be Nodes
-	hosts, err := r.parseHosts(instances.Data)
-	if err != nil {
-		return errors.Wrapf(err, "unable to parse hosts from configmap")
-	}
-
+// reconcileNodes corrects the discrepancy between the "expected" instances, and the "actual" Node list
+func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, windowsInstances *core.ConfigMap) error {
 	nodes := &core.NodeList{}
 	if err := r.client.List(ctx, nodes); err != nil {
 		return errors.Wrap(err, "error listing nodes")
+	}
+
+	// Get the list of instances that are expected to be Nodes
+	instances, err := r.parseInstances(windowsInstances.Data, nodes)
+	if err != nil {
+		return errors.Wrap(err, "unable to parse hosts from ConfigMap")
 	}
 
 	// For each host, ensure that it is configured into a node. On error of any host joining, return error and requeue.
@@ -180,17 +188,17 @@ func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, instances *cor
 	// reconcile call, as it simplifies error collection. The order the map is read from is psuedo-random, so the
 	// configuration effort for configurable hosts will not be blocked by a specific host that has issues with
 	// configuration.
-	for _, host := range hosts {
-		err := r.ensureInstanceIsConfigured(host, nodes)
+	for _, instance := range instances {
+		err := r.ensureInstanceIsConfigured(instance)
 		if err != nil {
-			r.recorder.Eventf(instances, core.EventTypeWarning, "InstanceSetupFailure",
-				"unable to join instance with address %s to the cluster", host.Address)
-			return errors.Wrapf(err, "error configuring host with address %s", host.Address)
+			r.recorder.Eventf(windowsInstances, core.EventTypeWarning, "InstanceSetupFailure",
+				"unable to join instance with address %s to the cluster", instance.Address)
+			return errors.Wrapf(err, "error configuring host with address %s", instance.Address)
 		}
 	}
 
 	// Ensure that only instances currently specified by the ConfigMap are joined to the cluster as nodes
-	if err = r.deconfigureInstances(hosts, nodes); err != nil {
+	if err = r.deconfigureInstances(instances, nodes); err != nil {
 		return errors.Wrap(err, "error removing undesired nodes from cluster")
 	}
 
@@ -202,11 +210,10 @@ func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, instances *cor
 }
 
 // ensureInstanceIsConfigured ensures that the given instance has an associated Node
-func (r *ConfigMapReconciler) ensureInstanceIsConfigured(instance *instances.InstanceInfo, nodes *core.NodeList) error {
-	node, found := findNode(instance.Address, nodes)
-	if found {
+func (r *ConfigMapReconciler) ensureInstanceIsConfigured(instance *instances.InstanceInfo) error {
+	if instance.Node != nil {
 		// Version annotation being present means that the node has been fully configured
-		if _, present := node.Annotations[nodeconfig.VersionAnnotation]; present {
+		if _, present := instance.Node.Annotations[nodeconfig.VersionAnnotation]; present {
 			// TODO: Check version for upgrade case https://issues.redhat.com/browse/WINC-580 and remove and re-add the node
 			//       if needed. Possibly also do this if the node is not in the `Ready` state.
 			return nil

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -66,7 +66,7 @@ func (r *instanceReconciler) instanceFromNode(node *core.Node) (*instances.Insta
 	if err != nil {
 		return nil, err
 	}
-	return instances.NewInstanceInfo(addr, node.Annotations[UsernameAnnotation], ""), nil
+	return instances.NewInstanceInfo(addr, node.Annotations[UsernameAnnotation], "", node), nil
 }
 
 // GetAddress returns a non-ipv6 address that can be used to reach a Windows node. This can be either an ipv4

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/instances"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/metrics"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/version"
@@ -118,7 +119,7 @@ func windowsNodePredicate(byoh bool) predicate.Funcs {
 				(!byoh && e.Object.GetAnnotations()[BYOHAnnotation] == "true") {
 				return false
 			}
-			if e.Object.GetAnnotations()[nodeconfig.VersionAnnotation] != version.Get() {
+			if e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get() {
 				return true
 			}
 			return false
@@ -131,7 +132,7 @@ func windowsNodePredicate(byoh bool) predicate.Funcs {
 				(!byoh && e.ObjectNew.GetAnnotations()[BYOHAnnotation] == "true") {
 				return false
 			}
-			if e.ObjectNew.GetAnnotations()[nodeconfig.VersionAnnotation] != version.Get() ||
+			if e.ObjectNew.GetAnnotations()[metadata.VersionAnnotation] != version.Get() ||
 				e.ObjectNew.GetAnnotations()[nodeconfig.PubKeyHashAnnotation] !=
 					e.ObjectOld.GetAnnotations()[nodeconfig.PubKeyHashAnnotation] {
 				return true

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"net"
 
 	"github.com/go-logr/logr"
@@ -95,7 +96,14 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}
-	return nc.Deconfigure()
+
+	if err = nc.Deconfigure(); err != nil {
+		return err
+	}
+	if err = r.client.Delete(context.TODO(), instance.Node); err != nil {
+		return errors.Wrapf(err, "error deleting node %s", instance.Node.GetName())
+	}
+	return nil
 }
 
 // windowsNodePredicate returns a predicate which filters out all node objects that are not Windows nodes.

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"net"
 	"strings"
 
@@ -250,10 +251,10 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.R
 			return ctrl.Result{}, errors.Wrapf(err, "could not get node associated with machine %s", machine.GetName())
 		}
 
-		if _, present := node.Annotations[nodeconfig.VersionAnnotation]; present {
+		if _, present := node.Annotations[metadata.VersionAnnotation]; present {
 			// If either the version annotation doesn't match the current operator version, or the private key used
 			// to configure the machine is out of date, the machine should be deleted
-			if node.Annotations[nodeconfig.VersionAnnotation] != version.Get() ||
+			if node.Annotations[metadata.VersionAnnotation] != version.Get() ||
 				node.Annotations[nodeconfig.PubKeyHashAnnotation] != nodeconfig.CreatePubKeyHashAnnotation(r.signer.PublicKey()) {
 				log.Info("deleting machine")
 				deletionAllowed, err := r.isAllowedDeletion(machine)
@@ -269,7 +270,7 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.R
 				}
 				return ctrl.Result{}, r.deleteMachine(machine)
 			}
-			log.Info("machine has current version", "version", node.Annotations[nodeconfig.VersionAnnotation])
+			log.Info("machine has current version", "version", node.Annotations[metadata.VersionAnnotation])
 			// version annotation exists with a valid value, node is fully configured.
 			// configure Prometheus when we have already configured Windows Nodes. This is required to update Endpoints object if
 			// it gets reverted when the operator pod restarts.
@@ -471,7 +472,7 @@ func (r *WindowsMachineReconciler) isWindowsMachineHealthy(machine *mapi.Machine
 	if err != nil {
 		return false
 	}
-	_, present := node.Annotations[nodeconfig.VersionAnnotation]
+	_, present := node.Annotations[metadata.VersionAnnotation]
 	if !present {
 		return false
 	}

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"net"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/instances"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/metrics"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
@@ -377,7 +377,7 @@ func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineN
 		username = "Administrator"
 	}
 
-	if err := r.configureInstance(instances.NewInstanceInfo(ipAddress, username, hostname, nil), nil); err != nil {
+	if err := r.ensureInstanceIsUpToDate(instances.NewInstanceInfo(ipAddress, username, hostname, nil), nil); err != nil {
 		return errors.Wrapf(err, "unable to configure instance %s", instanceID)
 	}
 

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -376,7 +376,7 @@ func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineN
 		username = "Administrator"
 	}
 
-	if err := r.configureInstance(instances.NewInstanceInfo(ipAddress, username, hostname), nil); err != nil {
+	if err := r.configureInstance(instances.NewInstanceInfo(ipAddress, username, hostname, nil), nil); err != nil {
 		return errors.Wrapf(err, "unable to configure instance %s", instanceID)
 	}
 

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -8,6 +8,7 @@ GOFLAGS=${1:-}
 
 # Run tests from all packages excluding e2e package, as it consists of e2e tests.
 go test -v ./pkg/... ${GOFLAGS} -count=1
-go test -v ./controllers/... ${GOFLAGS} -count=1
+# version.Get() is required for unit tests, and will return "" unless a value is passed in a build time
+go test -v ./controllers/... ${GOFLAGS} -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=TEST'" -count=1
 go test -v ./main.go ./main_test.go ${GOFLAGS} -count=1
 exit 0

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -1,14 +1,21 @@
 package instances
 
+import core "k8s.io/api/core/v1"
+
 // InstanceInfo represents a host that is meant to be joined to the cluster
 type InstanceInfo struct {
-	Address     string
-	Username    string
+	// Address is the network address of the instance
+	Address string
+	// Username is the name of a user that can be ssh'd into.
+	Username string
+	// NewHostname being set means that the instance's hostname should be changed. An empty value is a no-op.
 	NewHostname string
+	// Node is an optional pointer to the Node object associated with the instance, if it has one.
+	Node *core.Node
 }
 
 // NewInstanceInfo returns a new instanceInfo. newHostname being set means that the instance's hostname should be
 // changed. An empty value is a no-op.
-func NewInstanceInfo(address, username, newHostname string) *InstanceInfo {
-	return &InstanceInfo{Address: address, Username: username, NewHostname: newHostname}
+func NewInstanceInfo(address, username, newHostname string, node *core.Node) *InstanceInfo {
+	return &InstanceInfo{Address: address, Username: username, NewHostname: newHostname, Node: node}
 }

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -1,6 +1,11 @@
 package instances
 
-import core "k8s.io/api/core/v1"
+import (
+	core "k8s.io/api/core/v1"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
+	"github.com/openshift/windows-machine-config-operator/version"
+)
 
 // InstanceInfo represents a host that is meant to be joined to the cluster
 type InstanceInfo struct {
@@ -18,4 +23,37 @@ type InstanceInfo struct {
 // changed. An empty value is a no-op.
 func NewInstanceInfo(address, username, newHostname string, node *core.Node) *InstanceInfo {
 	return &InstanceInfo{Address: address, Username: username, NewHostname: newHostname, Node: node}
+}
+
+// UpToDate returns true if the instance was configured by the current WMCO version
+func (i *InstanceInfo) UpToDate() bool {
+	if i.Node == nil {
+		return false
+	}
+	versionAnnotation, present := i.Node.GetAnnotations()[metadata.VersionAnnotation]
+	return present && versionAnnotation == version.Get()
+}
+
+// UpgradeRequired returns true if the instance needs to go through the upgrade process
+func (i *InstanceInfo) UpgradeRequired() bool {
+	// instance being up to date implies instance is fully upgraded
+	if i.UpToDate() {
+		return false
+	}
+
+	// Instance has no node and should not go through the upgrade process
+	if i.Node == nil {
+		return false
+	}
+
+	// Version annotation not being present means that the node has been created but not fully configured.
+	// The upgrade process is not required, the node should just be configured normally.
+	_, present := i.Node.GetAnnotations()[metadata.VersionAnnotation]
+	if !present {
+		return false
+	}
+
+	// Version annotation has an incorrect value, this was configured by an older version of WMCO and should be
+	// fully deconfigured before being configured by the current version.
+	return true
 }

--- a/pkg/instances/instances_test.go
+++ b/pkg/instances/instances_test.go
@@ -1,0 +1,107 @@
+package instances
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
+	"github.com/openshift/windows-machine-config-operator/version"
+)
+
+func TestUpToDate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       InstanceInfo
+		expectedOut bool
+	}{
+		{
+			name:        "No associated Node",
+			input:       InstanceInfo{Node: nil},
+			expectedOut: false,
+		},
+		{
+			name: "Version annotation missing",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{"wrong-annotation": version.Get()}},
+				},
+			},
+			expectedOut: false,
+		},
+		{
+			name: "Version annotation mismatch",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{metadata.VersionAnnotation: "incorrect"}},
+				},
+			},
+			expectedOut: false,
+		},
+		{
+			name: "Version annotation correct",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{metadata.VersionAnnotation: version.Get()}},
+				},
+			},
+			expectedOut: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := test.input.UpToDate()
+			assert.Equal(t, test.expectedOut, out)
+		})
+	}
+}
+func TestUpgradeRequired(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       InstanceInfo
+		expectedOut bool
+	}{
+		{
+			name:        "No associated Node",
+			input:       InstanceInfo{Node: nil},
+			expectedOut: false,
+		},
+		{
+			name: "Version annotation missing",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{"wrong-annotation": version.Get()}},
+				},
+			},
+			expectedOut: false,
+		},
+		{
+			name: "Version annotation mismatch",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{metadata.VersionAnnotation: "incorrect"}},
+				},
+			},
+			expectedOut: true,
+		},
+		{
+			name: "Version annotation correct",
+			input: InstanceInfo{
+				Node: &core.Node{
+					ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{metadata.VersionAnnotation: version.Get()}},
+				},
+			},
+			expectedOut: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := test.input.UpgradeRequired()
+			assert.Equal(t, test.expectedOut, out)
+		})
+	}
+}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,0 +1,4 @@
+package metadata
+
+// VersionAnnotation indicates the version of WMCO that configured the node
+const VersionAnnotation = "windowsmachineconfig.openshift.io/version"

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/drain"
@@ -380,10 +381,15 @@ func (nc *nodeConfig) Deconfigure() error {
 		return errors.Wrap(err, "error deconfiguring instance")
 	}
 
-	// Delete the Node object
-	err := nc.k8sclientset.CoreV1().Nodes().Delete(context.TODO(), nc.node.GetName(), meta.DeleteOptions{})
+	// Clear the version annotation from the node object to indicate the node is not configured
+	escapedVersionAnnotation := strings.Replace(VersionAnnotation, "/", "~1", -1)
+	patchData := fmt.Sprintf(`[{"op":"add","path":"/metadata/annotations/%s","value":""}]`,
+		escapedVersionAnnotation)
+	nc.node.Annotations[VersionAnnotation] = ""
+	_, err := nc.k8sclientset.CoreV1().Nodes().Patch(context.TODO(), nc.node.GetName(), kubeTypes.JSONPatchType,
+		[]byte(patchData), meta.PatchOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "error deleting node %s", nc.node.GetName())
+		return errors.Wrapf(err, "error removing version annotation from node %s", nc.node.GetName())
 	}
 	return nil
 }

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/instances"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig/payload"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
@@ -38,8 +39,6 @@ const (
 	WindowsOSLabel = "node.openshift.io/os_id=Windows"
 	// WorkerLabel is the label that needs to be applied to the Windows node to make it worker node
 	WorkerLabel = "node-role.kubernetes.io/worker"
-	// VersionAnnotation indicates the version of WMCO that configured the node
-	VersionAnnotation = "windowsmachineconfig.openshift.io/version"
 	// PubKeyHashAnnotation corresponds to the public key present on the VM
 	PubKeyHashAnnotation = "windowsmachineconfig.openshift.io/pub-key-hash"
 )
@@ -258,7 +257,7 @@ func (nc *nodeConfig) configureNetwork() error {
 
 // addVersionAnnotation adds the version annotation to nc.node
 func (nc *nodeConfig) addVersionAnnotation() {
-	nc.node.Annotations[VersionAnnotation] = version.Get()
+	nc.node.Annotations[metadata.VersionAnnotation] = version.Get()
 }
 
 // addPubKeyHashAnnotation adds the public key annotation to nc.node
@@ -382,10 +381,10 @@ func (nc *nodeConfig) Deconfigure() error {
 	}
 
 	// Clear the version annotation from the node object to indicate the node is not configured
-	escapedVersionAnnotation := strings.Replace(VersionAnnotation, "/", "~1", -1)
+	escapedVersionAnnotation := strings.Replace(metadata.VersionAnnotation, "/", "~1", -1)
 	patchData := fmt.Sprintf(`[{"op":"add","path":"/metadata/annotations/%s","value":""}]`,
 		escapedVersionAnnotation)
-	nc.node.Annotations[VersionAnnotation] = ""
+	nc.node.Annotations[metadata.VersionAnnotation] = ""
 	_, err := nc.k8sclientset.CoreV1().Nodes().Patch(context.TODO(), nc.node.GetName(), kubeTypes.JSONPatchType,
 		[]byte(patchData), meta.PatchOptions{})
 	if err != nil {

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 )
@@ -251,7 +252,7 @@ func (tc *testContext) waitForWindowsMachines(machineCount int, phase string, wi
 // else 5 minutes for the nodes as the error would be thrown immediately, else we will wait for the duration given by
 // nodeCreationTime variable which is 20 minutes increasing the overall wait time in test suite
 func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVersion bool, isBYOH bool) error {
-	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac, nodeconfig.VersionAnnotation,
+	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac, metadata.VersionAnnotation,
 		nodeconfig.PubKeyHashAnnotation}
 	var creationTime time.Duration
 	startTime := time.Now()
@@ -327,9 +328,9 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVe
 					log.Printf("error getting operator version : %v", err)
 					return false, nil
 				}
-				if node.Annotations[nodeconfig.VersionAnnotation] != operatorVersion {
+				if node.Annotations[metadata.VersionAnnotation] != operatorVersion {
 					log.Printf("node %s has mismatched version annotation %s. expected: %s", node.GetName(),
-						node.Annotations[nodeconfig.VersionAnnotation], operatorVersion)
+						node.Annotations[metadata.VersionAnnotation], operatorVersion)
 					return false, nil
 				}
 			}
@@ -387,7 +388,7 @@ func (tc *testContext) listFullyConfiguredWindowsNodes(isBYOH bool) ([]v1.Node, 
 	var windowsNodes []v1.Node
 	for _, node := range nodes.Items {
 		// filter out nodes that haven't been fully configured
-		if _, present := node.Annotations[nodeconfig.VersionAnnotation]; !present {
+		if _, present := node.Annotations[metadata.VersionAnnotation]; !present {
 			continue
 		}
 		if (isBYOH && node.Annotations[controllers.BYOHAnnotation] == "true") ||

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	nc "github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 )
 
 // reconfigurationTest tests that the correct behavior occurs when a previously configured instance is configured
@@ -29,7 +28,7 @@ func reconfigurationTest(t *testing.T) {
 
 	// Remove the version annotation of one of each type of node
 	// Forward slash within a path is escaped as '~1'
-	escapedVersionAnnotation := strings.Replace(nc.VersionAnnotation, "/", "~1", -1)
+	escapedVersionAnnotation := strings.Replace(metadata.VersionAnnotation, "/", "~1", -1)
 	patchData := fmt.Sprintf("[{\"op\": \"remove\", \"path\": \"/metadata/annotations/%s\"}]", escapedVersionAnnotation)
 	_, err = testCtx.client.K8s.CoreV1().Nodes().Patch(context.TODO(), machineNodes[0].Name, types.JSONPatchType,
 		[]byte(patchData), metav1.PatchOptions{})

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
@@ -14,8 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	nc "github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 )
 
 const (
@@ -96,13 +95,13 @@ func (tc *testContext) configureUpgradeTest() error {
 	}
 
 	for _, node := range machineNodes {
-		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, nc.VersionAnnotation, "badVersion")
+		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, metadata.VersionAnnotation, "badVersion")
 		_, err := tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType,
 			[]byte(patchData), metav1.PatchOptions{})
 		if err != nil {
 			return err
 		}
-		log.Printf("Node Annotation changed to %v", node.Annotations[nc.VersionAnnotation])
+		log.Printf("Node Annotation changed to %v", node.Annotations[metadata.VersionAnnotation])
 	}
 
 	// Scale up the WMCO deployment to 1

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -18,6 +18,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	nc "github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
@@ -54,9 +55,9 @@ func testNodeMetadata(t *testing.T) {
 					nc.WorkerLabel, node.GetName())
 			})
 			t.Run("Version Annotation", func(t *testing.T) {
-				require.Containsf(t, node.Annotations, nc.VersionAnnotation, "node %s missing version annotation",
+				require.Containsf(t, node.Annotations, metadata.VersionAnnotation, "node %s missing version annotation",
 					node.GetName())
-				assert.Equal(t, operatorVersion, node.Annotations[nc.VersionAnnotation],
+				assert.Equal(t, operatorVersion, node.Annotations[metadata.VersionAnnotation],
 					"WMCO version annotation mismatch")
 			})
 			t.Run("Public Key Annotation", func(t *testing.T) {
@@ -72,7 +73,7 @@ func testNodeMetadata(t *testing.T) {
 			LabelSelector: core.LabelOSStable + "=linux"})
 		require.NoError(t, err, "error listing Linux nodes")
 		for _, node := range nodes.Items {
-			assert.NotContainsf(t, node.Annotations, nc.VersionAnnotation,
+			assert.NotContainsf(t, node.Annotations, metadata.VersionAnnotation,
 				"version annotation applied to Linux node %s", node.GetName())
 			assert.NotContainsf(t, node.Annotations, nc.PubKeyHashAnnotation,
 				"public key annotation applied to Linux node %s", node.GetName())


### PR DESCRIPTION
Deconfigures and then configures any instances associated with a node
that has an mismatched WMCO version annotation.