### PR TITLE
[deploy] Fix e2e log collection by switching back to more descriptive WMCO label

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -279,12 +279,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              name: windows-machine-config-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                name: windows-machine-config-operator
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
-    control-plane: controller-manager
+    name: windows-machine-config-operator
   name: system
 ---
 apiVersion: apps/v1
@@ -12,16 +12,16 @@ metadata:
   name: windows-machine-config-operator
   namespace: system
   labels:
-    control-plane: controller-manager
+    name: windows-machine-config-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: windows-machine-config-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        name: windows-machine-config-operator
     spec:
       hostNetwork: true
       priorityClassName: system-cluster-critical

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    name: windows-machine-config-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: windows-machine-config-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    name: windows-machine-config-operator
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    name: windows-machine-config-operator


### PR DESCRIPTION
Changes the label 'control-plane: controller-manager', to
'name: windows-machine-config-operator'. This change happened as part of
the switch to the kubebuilder style repo, and has broken the WMCO pod
log collection in the e2e tests.
The monitor.yaml and auth_proxy_service.yaml are not included in the
bundle that we ship, but changing them in order to be consistent.