### PR TITLE
[wmco] Patch node when adding annotations

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,0 +1,45 @@
+package annotations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/patch"
+)
+
+// generateAnnotationPatch creates a patch applying the given operation onto each given annotation key and value
+func generateAnnotationPatch(op string, annotations map[string]string) ([]byte, error) {
+	if len(annotations) == 0 {
+		return nil, errors.New("annotations to format cannot be empty or nil")
+	}
+	var patches []*patch.JSONPatch
+	for key, value := range annotations {
+		patches = append(patches, patch.NewJSONPatch(op, formatPathValue(key), value))
+	}
+	return json.Marshal(patches)
+}
+
+// GenerateAddPatch creates a comma-separated list of operations to add all given annotations from an object
+// An "add" patch overwrites existing value if an annotation already exists
+func GenerateAddPatch(annotations map[string]string) ([]byte, error) {
+	return generateAnnotationPatch("add", annotations)
+}
+
+// GenerateRemovePatch creates a comma-separated list of operations to remove all given annotations from an object
+// A "remove" patch fails transactionally if any of the annotations do not exist
+func GenerateRemovePatch(annotations []string) ([]byte, error) {
+	annotationMap := make(map[string]string)
+	for _, annotation := range annotations {
+		annotationMap[annotation] = ""
+	}
+	return generateAnnotationPatch("remove", annotationMap)
+}
+
+// formatPathValue formats the path value specifying which attribute a JSON Patch operation should be applied to
+func formatPathValue(key string) string {
+	// The `/` in the annotation key needs to be escaped in order to not be considered a "directory" in the path
+	escapedKey := strings.Replace(key, "/", "~1", -1)
+	return fmt.Sprintf("/metadata/annotations/%s", escapedKey)
+}

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -1,0 +1,99 @@
+package annotations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAddPatch(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       map[string]string
+		expectedOut []byte
+		expectedErr bool
+	}{
+		{
+			name:        "Annotations nil",
+			input:       nil,
+			expectedOut: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Annotations empty",
+			input:       map[string]string{},
+			expectedOut: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Single annotation",
+			input:       map[string]string{"annotation-1": "3.0"},
+			expectedOut: []byte("[{\"op\":\"add\",\"path\":\"/metadata/annotations/annotation-1\",\"value\":\"3.0\"}]"),
+			expectedErr: false,
+		},
+		{
+			name:  "Multiple annotations",
+			input: map[string]string{"annotation-1": "3.0", "annotation-2": "17"},
+			expectedOut: []byte("[{\"op\":\"add\",\"path\":\"/metadata/annotations/annotation-1\",\"value\":\"3.0\"}," +
+				"{\"op\":\"add\",\"path\":\"/metadata/annotations/annotation-2\",\"value\":\"17\"}]"),
+			expectedErr: false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := GenerateAddPatch(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, test.expectedOut, out)
+		})
+	}
+}
+func TestGenerateRemovePatch(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []string
+		expectedOut []byte
+		expectedErr bool
+	}{
+		{
+			name:        "Annotations nil",
+			input:       nil,
+			expectedOut: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Annotations empty",
+			input:       []string{},
+			expectedOut: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Single annotation",
+			input:       []string{"annotation-1"},
+			expectedOut: []byte("[{\"op\":\"remove\",\"path\":\"/metadata/annotations/annotation-1\",\"value\":\"\"}]"),
+			expectedErr: false,
+		},
+		{
+			name:  "Multiple annotations",
+			input: []string{"annotation-1", "annotation-2"},
+			expectedOut: []byte("[{\"op\":\"remove\",\"path\":\"/metadata/annotations/annotation-1\",\"value\":\"\"}," +
+				"{\"op\":\"remove\",\"path\":\"/metadata/annotations/annotation-2\",\"value\":\"\"}]"),
+			expectedErr: false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := GenerateRemovePatch(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, test.expectedOut, out)
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 )
 
 //+kubebuilder:rbac:groups="",resources=services;services/finalizers,verbs=create;get;delete
@@ -66,16 +67,6 @@ type Config struct {
 	namespace string
 	// recorder to generate events
 	recorder record.EventRecorder
-}
-
-// patchEndpoint contains information regarding patching metrics Endpoint
-type patchEndpoint struct {
-	// op defines patch operation to be performed on the Endpoints object
-	Op string `json:"op"`
-	// path defines the location of the patch
-	Path string `json:"path"`
-	// value defines the data to be patched
-	Value []v1.EndpointSubset `json:"value"`
 }
 
 // NewPrometheuopsNodeConfig creates a new instance for prometheusNodeConfig  to be used by the caller.
@@ -125,11 +116,7 @@ func (pc *PrometheusNodeConfig) syncMetricsEndpoint(nodeEndpointAdressess []v1.E
 		}}
 	}
 
-	patchData := []patchEndpoint{{
-		Op:    "replace",
-		Path:  "/subsets",
-		Value: subsets,
-	}}
+	patchData := []*patch.JSONPatch{patch.NewJSONPatch("replace", "/subsets", subsets)}
 	// convert patch data to bytes
 	patchDataBytes, err := json.Marshal(patchData)
 	if err != nil {

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,0 +1,20 @@
+package patch
+
+// JSONPatch describes a patch operation
+type JSONPatch struct {
+	// op defines patch operation to be performed on the Endpoints object
+	Op string `json:"op"`
+	// path defines the location of the patch
+	Path string `json:"path"`
+	// value defines the data to be patched
+	Value interface{} `json:"value,omitempty"`
+}
+
+// NewJSONPatch returns a pointer to a JSONPatch
+func NewJSONPatch(op, path string, value interface{}) *JSONPatch {
+	return &JSONPatch{
+		Op:    op,
+		Path:  path,
+		Value: value,
+	}
+}


### PR DESCRIPTION
This PR opts to use a JSON Patch instead of Update when adding/removing 
annotations to node objects. Update calls can result in failures as the node 
object  can be a stale reference (if some other entity changes the Node 
while WMCO is configuring for example). A patch is best used when 
modifying parts of a resource, which fits the node annotation use case;
this is why a patch was favored over a Get -> Update loop.

This PR also introduces new packages to construct and format Patch data for arbitrary k8s resources.