### PR TITLE
WIP: WINC-512: Ensure APIServerInternal IP address at configuration

### DIFF
--- a/pkg/windows/hosts.go
+++ b/pkg/windows/hosts.go
@@ -1,0 +1,41 @@
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// HostsFilePath is the relative path to the hosts file in Windows OS
+const HostsFilePath = "$env:windir\\System32\\drivers\\etc\\hosts"
+
+func (vm *windows) addHostsEntry(ipAddress, hostname, comment string) error {
+	// validations
+	if ipAddress == "" {
+		return errors.New("ipAddress cannot be empty")
+	}
+	if hostname == "" {
+		return errors.New("hostname cannot be empty")
+	}
+	// check comment
+	if comment != "" && !strings.HasPrefix(comment, "#") {
+		// format
+		comment = fmt.Sprintf("# %s", comment)
+	}
+	// build entry
+	entry := fmt.Sprintf("%s  %s  %s", ipAddress, hostname, comment)
+	// log
+	vm.log.Info("adding entry to hosts file", "entry", entry)
+	// single-quote and surround entry with a new line (`n)
+	entry = fmt.Sprintf("`n'%s'`n", entry)
+	// append entry to hosts file
+	_, err := vm.Run("Add-Content "+
+		"-Path "+HostsFilePath+" "+
+		"-Value "+entry+" "+
+		"-Force", true)
+	if err != nil {
+		return err
+	}
+	// return no error
+	return nil
+}

--- a/pkg/windows/hosts_test.go
+++ b/pkg/windows/hosts_test.go
@@ -1,0 +1,61 @@
+package windows
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestWindows_addHostsEntry(t *testing.T) {
+	type vm struct {
+		address                string
+		workerIgnitionEndpoint string
+		signer                 ssh.Signer
+		interact               connectivity
+		vxlanPort              string
+		hostName               string
+		log                    logr.Logger
+	}
+	type args struct {
+		ipAddress string
+		hostname  string
+		comment   string
+	}
+	tests := []struct {
+		name    string
+		vm      vm
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "given empty ipAddress should error",
+			vm:      vm{},
+			args:    args{ipAddress: "", hostname: "hostname", comment: "comment"},
+			wantErr: true,
+		},
+		{
+			name:    "given empty hostname should error",
+			vm:      vm{},
+			args:    args{ipAddress: "ipAddress", hostname: "", comment: "comment"},
+			wantErr: true,
+		},
+		// TODO: mock/stub vm.Run() to fully test
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := &windows{
+				address:                tt.vm.address,
+				workerIgnitionEndpoint: tt.vm.workerIgnitionEndpoint,
+				signer:                 tt.vm.signer,
+				interact:               tt.vm.interact,
+				vxlanPort:              tt.vm.vxlanPort,
+				hostName:               tt.vm.hostName,
+				log:                    tt.vm.log,
+			}
+			if err := vm.addHostsEntry(tt.args.ipAddress, tt.args.hostname, tt.args.comment); (err != nil) != tt.wantErr {
+				t.Errorf("addHostsEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -1,0 +1,139 @@
+package windows
+
+import (
+	"testing"
+
+	config "github.com/openshift/api/config/v1"
+)
+
+func TestWindows_parseHostname(t *testing.T) {
+	type args struct {
+		urlString string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "given empty urlString should error",
+			args:    args{urlString: ""},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "given invalid urlString should error",
+			args:    args{urlString: "invalid https://api.cluster.openshift.com:6443"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "given urlString without scheme should error",
+			args:    args{urlString: "api.cluster.openshift.com:6443"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "given valid urlString should pass",
+			args:    args{urlString: "https://api.cluster.openshift.com:6443"},
+			want:    "api.cluster.openshift.com",
+			wantErr: false,
+		},
+		{
+			name:    "given valid urlString without port should pass",
+			args:    args{urlString: "https://api.cluster.openshift.com"},
+			want:    "api.cluster.openshift.com",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseHostname(tt.args.urlString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseHostname() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseHostname() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWindows_getApiServerInternalIpForPlatformStatus(t *testing.T) {
+	type args struct {
+		platformStatus *config.PlatformStatus
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "given no platformStatus should error",
+			args:    args{platformStatus: nil},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "given unsupported platformStatus.Type should error (BareMetal)",
+			args: args{
+				platformStatus: &config.PlatformStatus{
+					Type: config.BareMetalPlatformType,
+					BareMetal: &config.BareMetalPlatformStatus{
+						APIServerInternalIP: "1.2.3.4"},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "given unsupported platformStatus.Type should error (AWS)",
+			args: args{
+				platformStatus: &config.PlatformStatus{
+					Type: config.AWSPlatformType,
+					AWS:  &config.AWSPlatformStatus{},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "given unsupported platformStatus.Type should error (Azure)",
+			args: args{
+				platformStatus: &config.PlatformStatus{
+					Type:  config.AzurePlatformType,
+					Azure: &config.AzurePlatformStatus{},
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "given valid platformStatus.Type should pass (VSphere)",
+			args: args{
+				platformStatus: &config.PlatformStatus{
+					Type: config.VSpherePlatformType,
+					VSphere: &config.VSpherePlatformStatus{
+						APIServerInternalIP: "1.2.3.4"},
+				},
+			},
+			want:    "1.2.3.4",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getApiServerInternalIpForPlatformStatus(tt.args.platformStatus)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getApiServerInternalIpForPlatformStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getApiServerInternalIpForPlatformStatus() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds the ensureAPIServerInternal() function to the windows
package, in order to ensure the IP address of the APIServerInternal
while configuring the VM.

If the APIServerInternal is available with an IP address, it's a no-op.

Otherwise, while no valid IP address resolution for APIServerInternal, the
APIServerInternal IP address is discovered from the cluster infrastructure,
specifically from the platform status, and included as a DNS alias entry
in the Windows hosts file.

Supported platform types: vsphere