### PR TITLE
Bug 1982991: Remove Service account file from bundle manifests

### DIFF
--- a/bundle/manifests/windows-machine-config-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/windows-machine-config-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: windows-machine-config-operator

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
-- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: windows-machine-config-operator
-  namespace: system


### PR DESCRIPTION
This PR removes the serviceaccount.yaml file from bundle manifests since it contains the same information as
held by the CSV spec for SA generation.
This causes an issue with the operator during upgrade with the CSV requirements not being met and the message: "Service account is owned by another ClusterServiceVersion"