### PR TITLE
[community-4.7] [e2e] Update golden image template for vSphere

### DIFF
--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -54,7 +54,7 @@ func newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSphereMachinePro
 		NumCoresPerSocket: int32(1),
 		// The template is hardcoded with an image which has been properly sysprepped.
 		// TODO: Find a way to automatically update this with latest image
-		Template: "1909-template-with-docker-ssh",
+		Template: "windows-golden-images/vm-winsrv-2004-golden-image-with-hostname",
 		Workspace: &vsphere.Workspace{
 			Datacenter:   "SDDC-Datacenter",
 			Datastore:    "WorkloadDatastore",


### PR DESCRIPTION
This commit updates the name of the golden image template used
in the e2e tests for vSphere. In order to prevent the templates
to be pruned by the automatic cleanup process that takes place
in the vSphere platform the following conventions are adopted:
  - all golden image template names starts with the `vm` prefix
  - the windows-golden-images folder holds all the templates
  - the windows-golden-images folder is excluded from the
    automatic cleanup process.

See https://issues.redhat.com/browse/DPP-7909