### PR TITLE
WINC-612: [wmco] Handle deletion of windows-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ data:
     username=core
 ```
 
+Deleting `windows-instances` is viewed as a request to deconfigure all Windows instances added as Nodes and revert them
+back to the state they were in before, barring any logs and container runtime artifacts.
+
 ### Configuring Windows instances provisioned through MachineSets
 Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
 Please note that the windows-user-data secret will be created by the WMCO lazily when it is configuring the first

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -54,7 +54,6 @@ const (
 	// UsernameAnnotation is a node annotation that contains the username used to log into the Windows instance
 	UsernameAnnotation = "windowsmachineconfig.openshift.io/username"
 	// InstanceConfigMap is the name of the ConfigMap where VMs to be configured should be described.
-	// TODO: Possibly make this a singleton that WMCO creates https://issues.redhat.com/browse/WINC-612
 	InstanceConfigMap = "windows-instances"
 )
 
@@ -106,17 +105,15 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Fetch the ConfigMap. The predicate will have filtered out any ConfigMaps that we should not reconcile
 	// so it is safe to assume that all ConfigMaps being reconciled describe hosts that need to be present in the
-	// cluster.
+	// cluster. This also handles the case when the reconciliation is kicked off by the InstanceConfigMap being deleted.
+	// In the deletion case, an empty InstanceConfigMap will be reconciled now resulting in all existing BYOH nodes
+	// being deleted.
 	configMap := &core.ConfigMap{}
 	if err := r.client.Get(ctx, req.NamespacedName, configMap); err != nil {
-		if k8sapierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return ctrl.Result{}, nil
+		if !k8sapierrors.IsNotFound(err) {
+			// Error reading the object - requeue the request.
+			return ctrl.Result{}, err
 		}
-		// Error reading the object - requeue the request.
-		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, r.reconcileNodes(ctx, configMap)
@@ -281,6 +278,9 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return r.isValidConfigMap(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return r.isValidConfigMap(e.Object)
 		},
 	}
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
If the admin deletes the `windows-instances` ConfigMap, the operation is viewed as a call to deconfigure all BYOH Windows instances. This PR handles that scenario.