### PR TITLE
[release-4.7] Bug 1985349: Remove SA file from bundle manifests

### DIFF
--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: windows-machine-config-operator


### PR DESCRIPTION
This PR removes the serviceaccount.yaml file from bundle manifests since it contains the same information as
held by the CSV spec for SA generation.
This causes an issue with the operator during upgrade with the CSV requirements not being met and the message
"Service account is owned by another ClusterServiceVersion"