### PR TITLE
[release-4.7] Bug 1995340: Fix metrics endpoint + Update golden image + IBM cluster support

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -119,7 +119,8 @@ func (r *WindowsMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 		// process delete event
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())
+			// for Windows machines only
+			return isWindowsMachine(e.Object.GetLabels())
 		},
 	}
 

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -361,13 +361,14 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 // getWindowsServerContainerImage gets the appropriate WindowsServer image based on VXLAN port
 func (tc *testContext) getWindowsServerContainerImage() string {
 	var windowsServerImage string
-	// If we're using a custom VXLANPort we need to use 1909. On Azure we are testing 20H2. For other providers we use
-	// 1809
 	if tc.hasCustomVXLAN {
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1909"
+		// If we're using a custom VXLANPort we need to use 2004
+		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-2004"
 	} else if tc.CloudProvider.GetType() == config.AzurePlatformType {
+		// On Azure we are testing 20H2
 		windowsServerImage = "mcr.microsoft.com/windows/servercore:2009"
 	} else {
+		// For other providers we use 1809
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1809"
 	}
 	return windowsServerImage

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -124,12 +124,12 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
 	// The ami's will have the name format: Windows_Server-2019-English-Full-ContainersLatest-2020.01.15
 	// so the question marks will match the date of creation
-	// The image obtained by using windowsAMIFilterValue is compatible with  the test container image -
-	// "mcr.microsoft.com/powershell:lts-nanoserver-1909" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
+	// The image obtained by using windowsAMIFilterValue is compatible with the test container image -
+	// "mcr.microsoft.com/powershell:lts-nanoserver-2004" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
 	// If the windowsAMIFilterValue changes, the test container image also needs to be changed.
-	// if hasCustomVXLANPort is set use 1909 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
+	// if hasCustomVXLANPort is set use 2004 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
 	if hasCustomVXLANPort {
-		windowsAMIFilterValue = "Windows_Server-1909-English-Core-ContainersLatest-????.??.??"
+		windowsAMIFilterValue = "Windows_Server-2004-English-Core-ContainersLatest-????.??.??"
 	} else {
 		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	}

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -54,7 +54,7 @@ func newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSphereMachinePro
 		NumCoresPerSocket: int32(1),
 		// The template is hardcoded with an image which has been properly sysprepped.
 		// TODO: Find a way to automatically update this with latest image
-		Template: "2004-template-with-docker-ssh",
+		Template: "windows-golden-images/vm-winsrv-2004-golden-image-with-hostname",
 		Workspace: &vsphere.Workspace{
 			Datacenter:   "SDDC-Datacenter",
 			Datastore:    "WorkloadDatastore",

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -54,7 +54,7 @@ func newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSphereMachinePro
 		NumCoresPerSocket: int32(1),
 		// The template is hardcoded with an image which has been properly sysprepped.
 		// TODO: Find a way to automatically update this with latest image
-		Template: "windows-golden-images/vm-winsrv-2004-golden-image-with-hostname",
+		Template: "windows-golden-images/windows-server-2004-template",
 		Workspace: &vsphere.Workspace{
 			Datacenter:   "SDDC-Datacenter",
 			Datastore:    "WorkloadDatastore",

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -54,7 +54,7 @@ func newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSphereMachinePro
 		NumCoresPerSocket: int32(1),
 		// The template is hardcoded with an image which has been properly sysprepped.
 		// TODO: Find a way to automatically update this with latest image
-		Template: "1909-template-with-docker-ssh",
+		Template: "2004-template-with-docker-ssh",
 		Workspace: &vsphere.Workspace{
 			Datacenter:   "SDDC-Datacenter",
 			Datastore:    "WorkloadDatastore",


### PR DESCRIPTION
This PR combines a few backports that have inter-dependencies.

While backporting the updates for the golden image template in vSphere, [Bug 1995340](https://bugzilla.redhat.com/show_bug.cgi?id=1995340) was identified and resolved. 
[Bug 2008601 ](https://bugzilla.redhat.com/show_bug.cgi?id=2008601) is a follow-up fix targeting 4.10, that is manually cherry-picked.

The support for IBMCloud is a dependency, and also got manually cherry-picked.
