### PR TITLE
WINC-610: Introduce vSphere Template as golden image

### DIFF
--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -54,7 +54,7 @@ func newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSphereMachinePro
 		NumCoresPerSocket: int32(1),
 		// The template is hardcoded with an image which has been properly sysprepped.
 		// TODO: Find a way to automatically update this with latest image
-		Template: "windows-golden-images/vm-winsrv-2004-golden-image-with-hostname",
+		Template: "windows-golden-images/windows-server-2004-template",
 		Workspace: &vsphere.Workspace{
 			Datacenter:   "SDDC-Datacenter",
 			Datastore:    "WorkloadDatastore",


### PR DESCRIPTION
The vSphere Template is introduced as the standard golden image distribution
format, as recommended by SMEs.

Follow-up to df8b7de