### PR TITLE
WINC-649: [wmco] Change BYOH annotation to a label

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -146,8 +146,8 @@ func windowsNodePredicate(byoh bool) predicate.Funcs {
 			if e.Object.GetLabels()[core.LabelOSStable] != "windows" {
 				return false
 			}
-			if (byoh && e.Object.GetAnnotations()[BYOHAnnotation] != "true") ||
-				(!byoh && e.Object.GetAnnotations()[BYOHAnnotation] == "true") {
+			if (byoh && e.Object.GetLabels()[BYOHLabel] != "true") ||
+				(!byoh && e.Object.GetLabels()[BYOHLabel] == "true") {
 				return false
 			}
 			if e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get() {
@@ -159,8 +159,8 @@ func windowsNodePredicate(byoh bool) predicate.Funcs {
 			if e.ObjectNew.GetLabels()[core.LabelOSStable] != "windows" {
 				return false
 			}
-			if (byoh && e.ObjectNew.GetAnnotations()[BYOHAnnotation] != "true") ||
-				(!byoh && e.ObjectNew.GetAnnotations()[BYOHAnnotation] == "true") {
+			if (byoh && e.ObjectNew.GetLabels()[BYOHLabel] != "true") ||
+				(!byoh && e.ObjectNew.GetLabels()[BYOHLabel] == "true") {
 				return false
 			}
 			if e.ObjectNew.GetAnnotations()[metadata.VersionAnnotation] != version.Get() ||

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -185,7 +185,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				continue
 			}
 			annotationsToApply := make(map[string]string)
-			if _, present := node.Annotations[BYOHAnnotation]; present {
+			if _, present := node.GetLabels()[BYOHLabel]; present {
 				// For BYOH nodes, update the username annotation and public key hash annotation using new private key
 				expectedUsernameAnnotation, err := r.getEncryptedUsername(ctx, node, privateKeyBytes)
 				if err != nil {


### PR DESCRIPTION
Changes the BYOH annotation to a label to allow for easier selection of
BYOH nodes.