### PR TITLE
WINC-643: Normalize BYOH and Machine logs and events

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,7 +78,7 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 			client:               mgr.GetClient(),
 			k8sclientset:         clientset,
 			clusterServiceCIDR:   clusterConfig.Network().GetServiceCIDR(),
-			log:                  ctrl.Log.WithName("controllers").WithName("ConfigMap"),
+			log:                  ctrl.Log.WithName("controllers").WithName("configmap"),
 			watchNamespace:       watchNamespace,
 			recorder:             mgr.GetEventRecorderFor("configmap"),
 			vxlanPort:            clusterConfig.Network().VXLANPort(),
@@ -130,6 +131,7 @@ func (r *ConfigMapReconciler) reconcileNodes(ctx context.Context, windowsInstanc
 		return errors.Wrap(err, "unable to parse instances from ConfigMap")
 	}
 
+	r.log.Info("processing", "instances in", wiparser.InstanceConfigMap)
 	// For each instance, ensure that it is configured into a node
 	if err := r.ensureInstancesAreUpToDate(instances); err != nil {
 		r.recorder.Eventf(windowsInstances, core.EventTypeWarning, "InstanceSetupFailure", err.Error())
@@ -156,6 +158,8 @@ func (r *ConfigMapReconciler) ensureInstancesAreUpToDate(instances []*instances.
 	if err != nil {
 		return err
 	}
+	windowsInstances := &core.ConfigMap{ObjectMeta: meta.ObjectMeta{Name: wiparser.InstanceConfigMap,
+		Namespace: r.watchNamespace}}
 	for _, instance := range instances {
 		encryptedUsername, err := crypto.EncryptToJSONString(instance.Username, privateKeyBytes)
 		if err != nil {
@@ -171,6 +175,8 @@ func (r *ConfigMapReconciler) ensureInstancesAreUpToDate(instances []*instances.
 			// that has issues with configuration.
 			return errors.Wrapf(err, "error configuring host with address %s", instance.Address)
 		}
+		r.recorder.Eventf(windowsInstances, core.EventTypeNormal, "InstanceSetup",
+			"Configured instance with address %s as a worker node", instance.Address)
 	}
 	return nil
 }
@@ -178,6 +184,8 @@ func (r *ConfigMapReconciler) ensureInstancesAreUpToDate(instances []*instances.
 // deconfigureInstances removes all BYOH nodes that are not specified in the given instances slice, and
 // deconfigures the instances associated with them.
 func (r *ConfigMapReconciler) deconfigureInstances(instances []*instances.InstanceInfo, nodes *core.NodeList) error {
+	windowsInstances := &core.ConfigMap{ObjectMeta: meta.ObjectMeta{Name: wiparser.InstanceConfigMap,
+		Namespace: r.watchNamespace}}
 	for _, node := range nodes.Items {
 		// Only looking at BYOH nodes
 		if _, present := node.Annotations[BYOHAnnotation]; !present {
@@ -191,6 +199,8 @@ func (r *ConfigMapReconciler) deconfigureInstances(instances []*instances.Instan
 		if err := r.deconfigureInstance(&node); err != nil {
 			return errors.Wrapf(err, "unable to deconfigure instance with node %s", node.GetName())
 		}
+		r.recorder.Eventf(windowsInstances, core.EventTypeNormal, "InstanceTeardown",
+			"Deconfigured node with addresses %v", node.Status.Addresses)
 	}
 	return nil
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -55,6 +55,9 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instance *instances.Instan
 
 	// Instance is up to date, do nothing
 	if instance.UpToDate() {
+		// Instance being up to date indicates that node object is present with the version annotation
+		r.log.Info("instance is up to date", "node", instance.Node.GetName(), "version",
+			instance.Node.GetAnnotations()[metadata.VersionAnnotation])
 		return nil
 	}
 
@@ -67,6 +70,9 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instance *instances.Instan
 	// Check if the instance was configured by a previous version of WMCO and must be deconfigured before being
 	// configured again.
 	if instance.UpgradeRequired() {
+		// Instance requiring an upgrade indicates that node object is present with the version annotation
+		r.log.Info("instance requires upgrade", "node", instance.Node.GetName(), "version",
+			instance.Node.GetAnnotations()[metadata.VersionAnnotation], "expected version", version.Get())
 		if err := nc.Deconfigure(); err != nil {
 			return err
 		}

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -204,7 +204,7 @@ func (r *WindowsMachineReconciler) isValidMachine(obj client.Object) bool {
 // Note: The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	log := r.log.WithValues("windowsmachine", request.NamespacedName)
+	log := r.log.WithValues("machine", request.NamespacedName)
 	log.V(1).Info("reconciling")
 
 	// Create a new signer from the private key the instances will be configured with
@@ -270,7 +270,6 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.R
 				}
 				return ctrl.Result{}, r.deleteMachine(machine)
 			}
-			log.Info("machine has current version", "version", node.Annotations[metadata.VersionAnnotation])
 			// version annotation exists with a valid value, node is fully configured.
 			// configure Prometheus when we have already configured Windows Nodes. This is required to update Endpoints object if
 			// it gets reverted when the operator pod restarts.
@@ -314,7 +313,7 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.R
 		return ctrl.Result{}, errors.Errorf("unable to get instance ID from provider ID for machine %s", machine.Name)
 	}
 
-	log.Info("processing")
+	log.Info("processing", "address", ipAddress)
 	// Make the Machine a Windows Worker node
 	if err := r.addWorkerNode(ipAddress, instanceID, machine.Name); err != nil {
 		var authErr *windows.AuthErr
@@ -382,7 +381,6 @@ func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineN
 		return errors.Wrapf(err, "unable to configure instance %s", instanceID)
 	}
 
-	r.log.Info("Windows VM has been configured as a worker node", "ID", instanceID)
 	return nil
 }
 

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -112,7 +112,7 @@ func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPor
 			"creating new node config")
 	}
 
-	log := ctrl.Log.WithName(fmt.Sprintf("nodeconfig %s", instance.Address))
+	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instance.Address))
 	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, vxlanPort,
 		instance, signer)
 	if err != nil {
@@ -205,6 +205,9 @@ func (nc *nodeConfig) Configure() error {
 		if err := drain.RunCordonOrUncordon(drainHelper, nc.node, false); err != nil {
 			return errors.Wrapf(err, "error uncordoning the node %s", nc.node.GetName())
 		}
+
+		nc.log.Info("instance has been configured as a worker node", "version",
+			nc.node.Annotations[metadata.VersionAnnotation])
 		return nil
 	}()
 
@@ -383,6 +386,8 @@ func (nc *nodeConfig) Deconfigure() error {
 	if err != nil {
 		return errors.Wrapf(err, "error removing version annotation from node %s", nc.node.GetName())
 	}
+
+	nc.log.Info("instance has been deconfigured", "node", nc.node.GetName())
 	return nil
 }
 


### PR DESCRIPTION
- Change ConfigMap controller log name to "configmap" to be consistent  with other controllers
- Change the Windows Machine controller log name to reduce stuttering
- Add logs when deconfiguring a BYOH instance
- Add events for BYOH instances