### PR TITLE
WINC-648: [wmco] Remove HNS networks in BYOH deconfiguration

### DIFF
--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -2,18 +2,27 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
+	"github.com/openshift/windows-machine-config-operator/pkg/patch"
+	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
 func reconfigurationTestSuite(t *testing.T) {
+	testCtx, err := NewTestContext()
+	require.NoError(t, err)
 	t.Run("Reconfigure instance", reconfigurationTest)
+	if testCtx.CloudProvider.GetType() == config.VSpherePlatformType {
+		t.Run("Re-add removed instance", testReAddInstance)
+	}
 	// testPrivateKeyChange must be the last test run in the reconfiguration suite. This is because we do not currently
 	// wait for nodes to fully come back up after changing the private key back to the valid key. Only the deletion test
 	// suite should run after this. Any other tests may result in flakes.
@@ -50,4 +59,60 @@ func reconfigurationTest(t *testing.T) {
 
 	err = testCtx.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
 	assert.NoError(t, err, "error waiting for Windows BYOH nodes to be reconfigured")
+}
+
+// testReAddInstance tests the case where a Windows BYOH instance was removed from the cluster, and then re-added.
+func testReAddInstance(t *testing.T) {
+	if gc.numberOfBYOHNodes == 0 {
+		t.Skip("BYOH testing disabled")
+	}
+
+	tc, err := NewTestContext()
+	require.NoError(t, err)
+
+	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), wiparser.InstanceConfigMap,
+		metav1.GetOptions{})
+	require.NoError(t, err, "error retrieving windows-instances ConfigMap")
+	require.NotEmpty(t, windowsInstances.Data, "no instances to remove")
+
+	// Read a single entry from the ConfigMap data
+	var addr, data string
+	for addr, data = range windowsInstances.Data {
+		break
+	}
+
+	// remove the entry that was found and then update the ConfigMap
+	delete(windowsInstances.Data, addr)
+
+	patchData := []*patch.JSONPatch{patch.NewJSONPatch("remove", "/data", windowsInstances.Data)}
+	// convert patch data to bytes
+	patchDataBytes, err := json.Marshal(patchData)
+	require.NoError(t, err, "error getting patch data in bytes")
+
+	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Patch(context.TODO(),
+		wiparser.InstanceConfigMap, types.JSONPatchType, patchDataBytes, metav1.PatchOptions{})
+	require.NoError(t, err, "error patching windows-instances ConfigMap data with remove operation")
+
+	// wait for the node to be removed
+	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes-1, false, true, true)
+	require.NoError(t, err, "error waiting for the removal of a node")
+
+	// update the ConfigMap again, re-adding the instance
+	if windowsInstances.Data == nil {
+		windowsInstances.Data = make(map[string]string)
+	}
+	windowsInstances.Data[addr] = data
+
+	patchData = []*patch.JSONPatch{patch.NewJSONPatch("add", "/data", windowsInstances.Data)}
+	// convert patch data to bytes
+	patchDataBytes, err = json.Marshal(patchData)
+	require.NoError(t, err, "error getting patch data in bytes")
+
+	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Patch(context.TODO(),
+		wiparser.InstanceConfigMap, types.JSONPatchType, patchDataBytes, metav1.PatchOptions{})
+	require.NoError(t, err, "error patching windows-instances ConfigMap data with add operation")
+
+	// wait for the node to be successfully re-added
+	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	assert.NoError(t, err, "error waiting for the Windows node to be re-added")
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -291,7 +291,7 @@ func (tc *testContext) runSSHJob(name, command, ip string) (string, error) {
 func (tc *testContext) getWinServices(addr string) (map[string]string, error) {
 	// This command returns CR+newline separated quoted CSV entries consisting of service name and status. For example:
 	// "kubelet","Running"\r\n"VaultSvc","Stopped"
-	command := fmt.Sprintf("powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command \"Get-Service | " +
+	command := fmt.Sprintf(remotePowerShellCmdPrefix + "Get-Service | " +
 		"Select-Object -Property Name,Status | ConvertTo-Csv -NoTypeInformation\"")
 	out, err := tc.runSSHJob("get-windows-svc-list", command, addr)
 	if err != nil {


### PR DESCRIPTION
The hybrid-overlay process creates HNS networks when it runs on a node. This PR removes the HNS networks created by
previous configuration on the node and adds a test case in the deletion test suite to test the removal.