### PR TITLE
[wmco] Fix issues with removing HNS networks

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -253,7 +253,7 @@ func (vm *windows) Run(cmd string, psCmd bool) (string, error) {
 		// Hack to not print the error log for "sc.exe qc" returning 1060 for non existent services
 		// and not print error when the command takes too long to return after removing HNS networks.
 		if !(strings.HasPrefix(cmd, serviceQueryCmd) && strings.HasSuffix(err.Error(), serviceNotFound)) &&
-			!(strings.Contains(err.Error(), cmdExitNoStatus) && strings.HasSuffix(cmd, removeHNSCommand+";")) {
+			!(strings.Contains(err.Error(), cmdExitNoStatus) && strings.HasSuffix(cmd, removeHNSCommand+";\"")) {
 			vm.log.Error(err, "error running", "cmd", cmd, "out", out)
 		}
 		return out, errors.Wrapf(err, "error running %s", cmd)


### PR DESCRIPTION
This PR fixes the HNSCommand suffix in the Run() method to avoid printing out the error logging message for PS timeouts when deleting HNS networks.
This PR also fixes the flake on Azure platform with the failure to remove all HNS networks.