### PR TITLE
[release-4.8] Prep for 3.1.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 3.0.0
+WMCO_VERSION ?= 3.1.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -23,10 +23,10 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. The operator is configured to watch for Machines with a `machine.openshift.io/os-id: Windows`
-    label. You can initiate the process by creating a MachineSet that uses a Windows image with the Docker
-    container runtime installed. The operator completes all the necessary steps to configure the underlying VM so that it can join
-    the cluster as a worker node.
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
+    Through either method, the Windows instance to be configured must have the Docker container runtime installed. The operator
+    completes all the necessary steps to configure the underlying VM so that it can join the cluster as a worker node.
 
     Usage of this operator requires a Red Hat OpenShift subscription. Users looking to deploy Windows containers workloads in
     production clusters should acquire a subscription before attempting to install this operator. Users without a subscription
@@ -35,7 +35,7 @@ spec:
     ### Pre-requisites
     * A Red Hat OpenShift subscription
     * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v3.0.0
+  name: windows-machine-config-operator.v3.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -404,4 +404,4 @@ spec:
   minKubeVersion: 1.21.0
   provider:
     name: Red Hat
-  version: 3.0.0
+  version: 3.1.0

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v3.0.0
+  - currentCSV: windows-machine-config-operator.v3.1.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -21,10 +21,10 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. The operator is configured to watch for Machines with a `machine.openshift.io/os-id: Windows`
-    label. You can initiate the process by creating a MachineSet that uses a Windows image with the Docker
-    container runtime installed. The operator completes all the necessary steps to configure the underlying VM so that it can join
-    the cluster as a worker node.
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
+    Through either method, the Windows instance to be configured must have the Docker container runtime installed. The operator
+    completes all the necessary steps to configure the underlying VM so that it can join the cluster as a worker node.
 
     Usage of this operator requires a Red Hat OpenShift subscription. Users looking to deploy Windows containers workloads in
     production clusters should acquire a subscription before attempting to install this operator. Users without a subscription
@@ -33,7 +33,7 @@ spec:
     ### Pre-requisites
     * A Red Hat OpenShift subscription
     * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing


### PR DESCRIPTION
This PR updates the WMCO version to v3.1.0 and for the next 4.8 operator release.