### PR TITLE
WINC-645: [controllers] Handle generic events

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -230,6 +230,9 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return r.isValidConfigMap(e.ObjectNew)
 		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return r.isValidConfigMap(e.Object)
+		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return r.isValidConfigMap(e.Object)
 		},

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -149,13 +149,8 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 func windowsNodePredicate(byoh bool) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if !isValidWindowsNode(e.Object, byoh) {
-				return false
-			}
-			if e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get() {
-				return true
-			}
-			return false
+			return isValidWindowsNode(e.Object, byoh) &&
+				e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get()
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if !isValidWindowsNode(e.ObjectNew, byoh) {
@@ -167,6 +162,10 @@ func windowsNodePredicate(byoh bool) predicate.Funcs {
 				return true
 			}
 			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isValidWindowsNode(e.Object, byoh) &&
+				e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return isValidWindowsNode(e.Object, byoh)

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -106,6 +106,9 @@ func (r *WindowsMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return r.isValidMachine(e.ObjectNew) && isWindowsMachine(e.ObjectNew.GetLabels())
 		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())
+		},
 		// process delete event
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())


### PR DESCRIPTION
- Simplify the check for a Windows node
- Update all controllers to handle generic events