### PR TITLE
Bug 1991282: [wmco] Set WMCB node-ip arg appropriately for BYOH

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/go-logr/logr"
+	config "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	core "k8s.io/api/core/v1"
@@ -43,6 +44,8 @@ type instanceReconciler struct {
 	prometheusNodeConfig *metrics.PrometheusNodeConfig
 	// recorder to generate events
 	recorder record.EventRecorder
+	// platform indicates the cloud on which the cluster is running
+	platform config.PlatformType
 }
 
 // ensureInstanceIsUpToDate ensures that the given instance is configured as a node and upgraded to the specifications
@@ -104,7 +107,7 @@ func (r *instanceReconciler) instanceFromNode(node *core.Node) (*instance.Info, 
 		return nil, errors.Wrapf(err, "unable to decrypt username annotation for node %s", node.Name)
 	}
 
-	return instance.NewInfo(addr, username, "", node), nil
+	return instance.NewInfo(addr, username, "", false, node), nil
 }
 
 // GetAddress returns a non-ipv6 address that can be used to reach a Windows node. This can be either an ipv4

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -53,11 +53,6 @@ const (
 // WindowsMachineReconciler is used to create a controller which manages Windows Machine objects
 type WindowsMachineReconciler struct {
 	instanceReconciler
-	// platform indicates the cloud on which OpenShift cluster is running
-	// TODO: Remove this once we figure out how to be provider agnostic. This is specific to proper usage of userData
-	// 		 in vSphere
-	//		 https://bugzilla.redhat.com/show_bug.cgi?id=1876987
-	platform oconfig.PlatformType
 }
 
 // NewWindowsMachineReconciler returns a pointer to a WindowsMachineReconciler
@@ -89,8 +84,8 @@ func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Conf
 			recorder:             mgr.GetEventRecorderFor("windowsmachine"),
 			watchNamespace:       watchNamespace,
 			prometheusNodeConfig: pc,
+			platform:             clusterConfig.Platform(),
 		},
-		platform: clusterConfig.Platform(),
 	}, nil
 }
 
@@ -380,7 +375,7 @@ func (r *WindowsMachineReconciler) addWorkerNode(ipAddress, instanceID, machineN
 		username = "Administrator"
 	}
 
-	err := r.ensureInstanceIsUpToDate(instance.NewInfo(ipAddress, username, hostname, nil), nil, nil)
+	err := r.ensureInstanceIsUpToDate(instance.NewInfo(ipAddress, username, hostname, false, nil), nil, nil)
 	if err != nil {
 		return errors.Wrapf(err, "unable to configure instance %s", instanceID)
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -15,14 +15,16 @@ type Info struct {
 	Username string
 	// NewHostname being set means that the instance's hostname should be changed. An empty value is a no-op.
 	NewHostname string
+	// SetNodeIP indicates if the instance should have the node-ip arg set when running WMCB.
+	SetNodeIP bool
 	// Node is an optional pointer to the Node object associated with the instance, if it has one.
 	Node *core.Node
 }
 
 // NewInfo returns a new Info. newHostname being set means that the instance's hostname should be
 // changed. An empty value is a no-op.
-func NewInfo(address, username, newHostname string, node *core.Node) *Info {
-	return &Info{Address: address, Username: username, NewHostname: newHostname, Node: node}
+func NewInfo(address, username, newHostname string, setNodeIP bool, node *core.Node) *Info {
+	return &Info{Address: address, Username: username, NewHostname: newHostname, SetNodeIP: setNodeIP, Node: node}
 }
 
 // UpToDate returns true if the instance was configured by the current WMCO version

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 	"time"
@@ -524,6 +525,32 @@ func (vm *windows) transferFiles() error {
 	return nil
 }
 
+// getIPV4Address returns an ipv4 address of the host. An error will be thrown if the windows object was created with an
+// ipv6 address or a DNS address that does not resolve to an ipv4 address.
+func (vm *windows) getIPV4Address() (string, error) {
+	if ip := net.ParseIP(vm.instance.Address); ip != nil {
+		// Address is either an ipv6 or ipv4 address
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			return "", errors.Errorf("error using IP %s: only ipv4 addresses are supported", ip.String())
+		}
+		return ipv4.String(), nil
+	}
+
+	// DNS address in this case
+	ips, err := net.LookupIP(vm.instance.Address)
+	if err != nil {
+		return "", errors.Wrapf(err, "lookup of address %s failed", vm.instance.Address)
+	}
+	// Get first ipv4 address returned
+	for _, returnedIP := range ips {
+		if returnedIP.To4() != nil {
+			return returnedIP.String(), nil
+		}
+	}
+	return "", errors.Errorf("%s does not resolve to an ipv4 address", vm.instance.Address)
+}
+
 // runBootstrapper copies the bootstrapper and runs the code on the remote Windows VM
 func (vm *windows) runBootstrapper() error {
 	err := vm.initializeBootstrapperFiles()
@@ -532,6 +559,13 @@ func (vm *windows) runBootstrapper() error {
 	}
 	wmcbInitializeCmd := k8sDir + "\\wmcb.exe initialize-kubelet --ignition-file " + winTemp +
 		"worker.ign --kubelet-path " + k8sDir + "kubelet.exe"
+	if vm.instance.SetNodeIP {
+		nodeIP, err := vm.getIPV4Address()
+		if err != nil {
+			return err
+		}
+		wmcbInitializeCmd += " --node-ip=" + nodeIP
+	}
 
 	out, err := vm.Run(wmcbInitializeCmd, true)
 	vm.log.Info("configured kubelet", "cmd", wmcbInitializeCmd, "output", out)

--- a/pkg/wiparser/wiparser.go
+++ b/pkg/wiparser/wiparser.go
@@ -61,7 +61,7 @@ func Parse(instancesData map[string]string, nodes *core.NodeList) ([]*instance.I
 
 		// Get the associated node if the described instance has one
 		node, _ := findNode(address, nodes)
-		instances = append(instances, instance.NewInfo(address, username, "", node))
+		instances = append(instances, instance.NewInfo(address, username, "", false, node))
 	}
 	return instances, nil
 }

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -38,6 +38,7 @@ func creationTestSuite(t *testing.T) {
 	}
 	t.Run("Node Metadata", testNodeMetadata)
 	t.Run("Services running", testExpectedServicesRunning)
+	t.Run("NodeIP Arg", testNodeIPArg)
 	t.Run("NodeTaint validation", testNodeTaint)
 	t.Run("CSR Validation", func(t *testing.T) { testCSRApproval(t) })
 	t.Run("UserData validation", testUserData)


### PR DESCRIPTION
Sets the WMCB node-ip arg when platform == 'none'. This results in the
node object for the configured node using the given IP. If the actual IP
of the node changes, the ConfigMap must be kept up to date in order for
the node status to not become stale.

Fixes BZ#1991282