### PR TITLE
Bug 1996615: Add pods eviction permission and logging for drainer helper

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -210,6 +210,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
           - secrets
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -48,6 +48,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 
 const (
 	// BYOHLabel is a label that should be applied to all Windows nodes not associated with a Machine.

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -147,7 +147,7 @@ func getClusterAddr(kubeAPIServerEndpoint string) (string, error) {
 
 // Configure configures the Windows VM to make it a Windows worker node
 func (nc *nodeConfig) Configure() error {
-	drainHelper := &drain.Helper{Ctx: context.TODO(), Client: nc.k8sclientset}
+	drainHelper := nc.newDrainHelper()
 	// If we find a node  it implies that we are reconfiguring and we should cordon the node
 	if err := nc.setNode(true); err == nil {
 		// Make a best effort to cordon the node until it is fully configured
@@ -356,6 +356,38 @@ func (nc *nodeConfig) configureCNI() error {
 	return nil
 }
 
+// ErrWriter is a wrapper to enable error-level logging inside kubectl drainer implementation
+type ErrWriter struct {
+	log logr.Logger
+}
+
+func (ew ErrWriter) Write(p []byte) (n int, err error) {
+	// log error
+	ew.log.Error(err, string(p))
+	return len(p), nil
+}
+
+// OutWriter is a wrapper to enable debug-level logging inside kubectl drainer implementation
+type OutWriter struct {
+	log logr.Logger
+}
+
+func (ow OutWriter) Write(p []byte) (n int, err error) {
+	// log debug
+	ow.log.V(1).Info(string(p))
+	return len(p), nil
+}
+
+// newDrainHelper returns new drain.Helper instance
+func (nc *nodeConfig) newDrainHelper() *drain.Helper {
+	return &drain.Helper{
+		Ctx:    context.TODO(),
+		Client: nc.k8sclientset,
+		ErrOut: &ErrWriter{nc.log},
+		Out:    &OutWriter{nc.log},
+	}
+}
+
 // Deconfigure removes the node from the cluster, reverting changes made by the Configure function
 func (nc *nodeConfig) Deconfigure() error {
 	// Set nc.node to the existing node
@@ -364,7 +396,7 @@ func (nc *nodeConfig) Deconfigure() error {
 	}
 
 	// Cordon and drain the Node before we interact with the instance
-	drainHelper := &drain.Helper{Ctx: context.TODO(), Client: nc.k8sclientset}
+	drainHelper := nc.newDrainHelper()
 	if err := drain.RunCordonOrUncordon(drainHelper, nc.node, true); err != nil {
 		return errors.Wrapf(err, "unable to cordon node %s", nc.node.GetName())
 	}


### PR DESCRIPTION
Add create permission to specific pods/eviction resource in the ConfigMap
Controller and config role.yaml.

Bundle manifests generated with:
`make bundle`