### PR TITLE
Bug 1995684: Validate and perform DNS lookup on Windows instance network address

### DIFF
--- a/pkg/nodeutil/nodeutil.go
+++ b/pkg/nodeutil/nodeutil.go
@@ -1,0 +1,18 @@
+package nodeutil
+
+import (
+	core "k8s.io/api/core/v1"
+)
+
+// FindByAddress returns a pointer to the node within the given list with an address matching the given address
+// and a bool indicating if the node was found or not.
+func FindByAddress(address string, nodes *core.NodeList) (*core.Node, bool) {
+	for _, node := range nodes.Items {
+		for _, nodeAddress := range node.Status.Addresses {
+			if address == nodeAddress.Address {
+				return &node, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/pkg/nodeutil/nodeutil_test.go
+++ b/pkg/nodeutil/nodeutil_test.go
@@ -1,0 +1,86 @@
+package nodeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindNode(t *testing.T) {
+	ipNode := core.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "ip-node",
+		},
+		Status: core.NodeStatus{
+			Addresses: []core.NodeAddress{
+				{Address: "127.0.0.1", Type: core.NodeInternalIP},
+			},
+		},
+	}
+	dnsNode := core.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "dns-node",
+		},
+		Status: core.NodeStatus{
+			Addresses: []core.NodeAddress{
+				{Address: "localhost", Type: core.NodeInternalDNS},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		address       string
+		nodeList      *core.NodeList
+		expectedOut   *core.Node
+		expectedFound bool
+	}{
+		{
+			name:    "empty node list",
+			address: "localhost",
+			nodeList: &core.NodeList{
+				Items: []core.Node{},
+			},
+			expectedOut:   nil,
+			expectedFound: false,
+		},
+		{
+			name:    "not found",
+			address: "random.networkaddress",
+			nodeList: &core.NodeList{
+				Items: []core.Node{ipNode, dnsNode},
+			},
+			expectedOut:   nil,
+			expectedFound: false,
+		},
+		{
+			name:    "simple happy path",
+			address: "127.0.0.1",
+			nodeList: &core.NodeList{
+				Items: []core.Node{ipNode},
+			},
+			expectedOut:   &ipNode,
+			expectedFound: true,
+		},
+		{
+			name:    "multiple node happy path",
+			address: "localhost",
+			nodeList: &core.NodeList{
+				Items: []core.Node{ipNode, dnsNode},
+			},
+			expectedOut:   &dnsNode,
+			expectedFound: true,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			node, found := FindByAddress(test.address, test.nodeList)
+
+			assert.Equal(t, test.expectedFound, found)
+			assert.Equal(t, test.expectedOut, node)
+		})
+	}
+
+}

--- a/pkg/wiparser/wiparser.go
+++ b/pkg/wiparser/wiparser.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeutil"
 )
 
 // InstanceConfigMap is the name of the ConfigMap where VMs to be configured should be described.
@@ -60,7 +61,7 @@ func Parse(instancesData map[string]string, nodes *core.NodeList) ([]*instance.I
 		}
 
 		// Get the associated node if the described instance has one
-		node, _ := findNode(address, nodes)
+		node, _ := nodeutil.FindByAddress(address, nodes)
 		instances = append(instances, instance.NewInfo(address, username, "", false, node))
 	}
 	return instances, nil
@@ -85,19 +86,6 @@ func validateAddress(address string) error {
 		return errors.Errorf("DNS did not resolve to an address")
 	}
 	return nil
-}
-
-// findNode returns a pointer to the node with an address matching the given address and a bool indicating if the node
-// was found or not.
-func findNode(address string, nodes *core.NodeList) (*core.Node, bool) {
-	for _, node := range nodes.Items {
-		for _, nodeAddress := range node.Status.Addresses {
-			if address == nodeAddress.Address {
-				return &node, true
-			}
-		}
-	}
-	return nil, false
 }
 
 // GetNodeUsername retrieves the username associated with the given node from the instance ConfigMap data


### PR DESCRIPTION
This PR performs checks on a Windows instance's network address.
Instead of using the raw address, it is checked to ensure it is an IPv4
address or if it resolves via DNS lookup. This is needed in case an instance's
DNS address does not match its hostname.

Fixes BZ#1995684