### PR TITLE
WINC-644: [wmco] Remove "--feature-gates=IPv6DualStack=false"

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -456,7 +456,7 @@ func (vm *windows) ConfigureKubeProxy(nodeName, hostSubnet string) error {
 		"--hostname-override=" + nodeName + " --kubeconfig=c:\\k\\kubeconfig " +
 		"--cluster-cidr=" + hostSubnet + " --log-dir=" + kubeProxyLogDir + " --logtostderr=false " +
 		"--network-name=OVNKubernetesHybridOverlayNetwork --source-vip=" + sVIP +
-		" --enable-dsr=false --feature-gates=IPv6DualStack=false\" depend= " + hybridOverlayServiceName
+		" --enable-dsr=false\" depend= " + hybridOverlayServiceName
 
 	kubeProxyService, err := newService(kubeProxyPath, kubeProxyServiceName, kubeProxyServiceArgs)
 	if err != nil {


### PR DESCRIPTION
This PR removes "--feature-gates=IPv6DualStack=false" from the kube-proxy service args as kubernetes/kubernetes#100966
has been fixed by openshift/kubernetes/commit@d5d9327351de99e6068f62efb388a6ede38d944e