### PR TITLE
[docs] SSH shell pre-requisite

### DIFF
--- a/docs/byoh-instance-pre-requisites.md
+++ b/docs/byoh-instance-pre-requisites.md
@@ -4,6 +4,7 @@ The following pre-requisites must be fulfilled in order to add a Windows BYOH no
 * The Docker container runtime must be installed on the instance.
 * The instance must be on the same network as the Linux worker nodes in the cluster.
 * Port 22 must be open and running [an SSH server](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
+  * The default shell for the SSH server must be set to [cmd.exe](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows).
 * Port 10250 must be open in order for log collection to function.
 * An administrator user is present with the [private key used in the secret](/README.md#create-a-private-key-secret) set as an authorized SSH key.
 * The hostname of the instance must follow the [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123) DNS label standard:


### PR DESCRIPTION
If the default shell is not powershell, the following bug will be hit:
https://bugzilla.redhat.com/show_bug.cgi?id=2000772

This can be reverted when the above bug is fixed.