### PR TITLE
Bug 2002961: Prevent error loop when a CSR is queued and then approved externally

### DIFF
--- a/controllers/certificatesigningrequests_controller.go
+++ b/controllers/certificatesigningrequests_controller.go
@@ -88,6 +88,14 @@ func (r *certificateSigningRequestsReconciler) Reconcile(ctx context.Context, re
 
 // reconcileCSR handles the CSR validation and approval
 func (r *certificateSigningRequestsReconciler) reconcileCSR(request *certificates.CertificateSigningRequest) error {
+	// If a CSR is approved/denied after being added to the queue, but before we reconcile it,
+	// trying to approve it again will result in an error and cause a loop.
+	// Return early if the CSR has been approved/denied externally.
+	if !isPending(request) {
+		r.log.Info("CSR is already approved/denied", "Name", request.Name)
+		return nil
+	}
+
 	certificateSigningRequest, err := csr.NewApprover(r.client, r.k8sclientset, request, r.log, r.recorder, r.watchNamespace)
 	if err != nil {
 		return errors.Wrapf(err, "could not create WMCO CSR Approver")


### PR DESCRIPTION
When adding a CSR to the queue, we filter based on whether the CSR is already approved. We don't however check this again during the reconciliation loop.

In certain scenarios, we can end up in a situation where the CSR is approved externally before we get to it. In this case, the approval call for to the API server fails as we are duplicating the approved condition. When this API call fails, this causes the CSR to requeue and we end up with the CSR in a constant loop of attempting to be approved, but unable for it to actually be approved.

To prevent this, before we reconcile any CSR, we should check that it hasn't already been approved out of band.

This should mirror the same being added in https://github.com/openshift/cluster-machine-approver/pull/129