### PR TITLE
[e2e] Rollback node affinity for BYOH label

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -344,39 +344,6 @@ func getAffinityForNode(node *v1.Node) (*v1.Affinity, error) {
 	}, nil
 }
 
-// getNodeAffinityForLabel returns a node affinity that matches the associated label key and values for the given
-// operator. `values` equals `nil` suppress the property, useful for `NodeSelectorOpDoesNotExist` operator.
-func getNodeAffinityForLabel(operator v1.NodeSelectorOperator, key string, values ...string) (*v1.Affinity, error) {
-	if operator == "" {
-		return nil, errors.New("operator cannot be empty")
-	}
-	if key == "" {
-		return nil, errors.New("key cannot be empty")
-	}
-	// build match expression
-	expression := v1.NodeSelectorRequirement{
-		Key:      key,
-		Operator: operator,
-	}
-	// use values, if any
-	if values != nil {
-		expression.Values = values
-	}
-	return &v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
-						MatchExpressions: []v1.NodeSelectorRequirement{
-							expression,
-						},
-					},
-				},
-			},
-		},
-	}, nil
-}
-
 // ensureNamespace checks if a namespace with the provided name exists and creates one if it does not
 func (tc *testContext) ensureNamespace(name string) error {
 	// Check if the namespace exists


### PR DESCRIPTION
This commit revert the node affinity logic introduced, in order to keep
the e2e-upgrade test low in complexity.

To ensure the presence of a running workload in a BYOH node, if any, we trust
the kube-scheduler placement algorithm, that balance the number of workloads
across the available nodes that match taints and selectors.

The number of workloads is set to 3, representing the total number of
nodes (one BYOH and one WM) + 1, assuring the eviction of at least 1 pod from
the BYOH node during the de-configuration process.