### PR TITLE
Bug 1992841: Do not react to Windows Node deletion

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -247,6 +247,11 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context, request ctrl.R
 		err := r.client.Get(ctx, kubeTypes.NamespacedName{Namespace: machine.Status.NodeRef.Namespace,
 			Name: machine.Status.NodeRef.Name}, node)
 		if err != nil {
+			// Do not requeue if associated node cannot be found (i.e. deleted) for a running machine
+			if k8sapierrors.IsNotFound(err) {
+				log.Info("the node associated with this machine does not exist, no-op", "name", machine.GetName())
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, errors.Wrapf(err, "could not get node associated with machine %s", machine.GetName())
 		}
 


### PR DESCRIPTION
This PR does not react/re-queue when a Node associated with a Windows machine
cannot be found (i.e. is deleted), leaving the previously configured Machine
in the `Running` state. 

This approach was chosen rather than deleting &
re-creating the unassociated Machine as optimizing machine management is not in
scope of WMCO responsibilities. In addition, not reacting is in line with the 
current functionality of Linux Machines, standardizing OpenShift functionality.
Also, the Machine cannot be reconfigured to create a new Node object since
the machine-api's nodelink_controller will not update any Machine's Node
reference, neither after deleting a Node nor after reconfiguring a Machine.

Fixes BZ#1992841