### PR TITLE
Prep for 4.0.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 3.1.0
+WMCO_VERSION ?= 4.0.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,14 +8,14 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=2.0.0 <3.0.0'
+    olm.skipRange: '>=3.0.0 <4.0.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.operatorframework.io/builder: operator-sdk-v2.0.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v3.1.0
+  name: windows-machine-config-operator.v4.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -34,8 +34,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift subscription
-    * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.9 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.9/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -410,4 +410,4 @@ spec:
   minKubeVersion: 1.22.0
   provider:
     name: Red Hat
-  version: 3.1.0
+  version: 4.0.0

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v3.1.0
+  - currentCSV: windows-machine-config-operator.v4.0.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=2.0.0 <3.0.0'
+    olm.skipRange: '>=3.0.0 <4.0.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     repository: https://github.com/openshift/windows-machine-config-operator
@@ -32,8 +32,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift subscription
-    * OCP 4.8 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.8/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.9 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.9/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing


### PR DESCRIPTION
This PR updates the WMCO version to v4.0.0 and updates the olm.SkipRange to '>=3.0.0 <4.0.0' for the 4.9 operator release.