### PR TITLE
[doc] Document pre-requsite for PTR records

### DIFF
--- a/docs/byoh-instance-pre-requisites.md
+++ b/docs/byoh-instance-pre-requisites.md
@@ -11,3 +11,4 @@ The following pre-requisites must be fulfilled in order to add a Windows BYOH no
   * Contain only lowercase alphanumeric characters or '-'.
   * Start with an alphanumeric character.
   * End with an alphanumeric character.
+* A PTR record must exist corresponding to the instance address which resolves to the instance hostname for successful reverse DNS lookups. 


### PR DESCRIPTION
This PR adds a bullet point stating address used in the configMap must have a PTR record resolving to the instance host name.