### PR TITLE
[docs][vsphere-ci] Update VMware Tools to v11.3.0

### DIFF
--- a/docs/vsphere_ci/build.json
+++ b/docs/vsphere_ci/build.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "os-iso-path": "[WorkloadDatastore] windows-iso-images/winsrv2004_sep_2020_x64_dvd.iso",
-    "vmtools-iso-path": "[WorkloadDatastore] windows-iso-images/vmtools-v11333-windows.iso",
+    "vmtools-iso-path": "[WorkloadDatastore] windows-iso-images/vmtools-v11360-windows.iso",
     "vm-template-folder": "windows-golden-images",
     "vm-template-name": "windows-server-2004-template",
     "vm-elevated-password": "WindowsPassword",


### PR DESCRIPTION
Update the VMware Tools ISO image with newer version in the build.json script, used by Packer to create the golden image template.

[See VMware documentation for release notes](https://docs.vmware.com/en/VMware-Tools/11.3/rn/VMware-Tools-1130-Release-Notes.html)