### PR TITLE
[windows] Add dependencies to Windows service struct

### DIFF
--- a/pkg/windows/service.go
+++ b/pkg/windows/service.go
@@ -10,16 +10,19 @@ type service struct {
 	name string
 	// args is the arguments that the binary will be ran with
 	args string
+	// dependencies is a list of the names of the services that this service is dependent on
+	dependencies []string
 }
 
 // newService initializes and returns a pointer to the service struct
-func newService(binaryPath, name, args string) (*service, error) {
+func newService(binaryPath, name, args string, dependencies []string) (*service, error) {
 	if binaryPath == "" || name == "" {
 		return nil, errors.Errorf("can't instantiate a service with incomplete service parameters")
 	}
 	return &service{
-		binaryPath: binaryPath,
-		name:       name,
-		args:       args,
+		binaryPath:   binaryPath,
+		name:         name,
+		args:         args,
+		dependencies: dependencies,
 	}, nil
 }


### PR DESCRIPTION
This commit adds the new dependencies field to the service struct. This
is preferrable to having to add the `depend` field in each service's
arguments, as depend is not part of the binPath.