### PR TITLE
Bug 2008601: Fix delete event subscription

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -106,7 +106,8 @@ func (r *WindowsMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 		// process delete event
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())
+			// for Windows machines only
+			return isWindowsMachine(e.Object.GetLabels())
 		},
 	}
 


### PR DESCRIPTION
Adjust machine predicate to react upon Delete events for machines
that include the Windows label.

The previously proposed fix, is too restrictive since it includes the
validation of the machine object (r.isValidMachine(e.Object)), meaning
  a) machine have a valid phase, and
  b) machine have a valid IP address

There is an edge case, especially in vSphere, where the machine' IP addresses
are removed while the machine is still in Deleting phase. So, the event is
filtered out and WMCO is not able to update the metrics endpoint.

Removing the validation of the machine object from the filtering, entertains
the edge case.

Fixes BZ#2008601

Follow-up to https://github.com/openshift/windows-machine-config-operator/pull/571/commits/2a4484b755d334e06c4616ec9f4ad8bb61eadec9