### PR TITLE
Bug 2005360:  Lookup nodes via IPv4 address

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -1,0 +1,33 @@
+package netutil
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// ResolveToIPv4Address returns an IPv4 address associated with the given address. An error will be thrown if given
+// an IPv6 address or a DNS address that does not resolve to an IPv4 network address.
+func ResolveToIPv4Address(address string) (string, error) {
+	if ip := net.ParseIP(address); ip != nil {
+		// Address is either an IPv6 or IPv4 address
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			return "", errors.Errorf("not an IPv4 network address: %s", ip.String())
+		}
+		return ipv4.String(), nil
+	}
+
+	// DNS address in this case
+	ips, err := net.LookupIP(address)
+	if err != nil {
+		return "", errors.Wrapf(err, "lookup of address %s failed", address)
+	}
+	// Get first IPv4 address returned
+	for _, returnedIP := range ips {
+		if returnedIP.To4() != nil {
+			return returnedIP.String(), nil
+		}
+	}
+	return "", errors.Errorf("%s does not resolve to an IPv4 address", address)
+}

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -1,0 +1,53 @@
+package netutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveToIPv4Address(t *testing.T) {
+	testCases := []struct {
+		name        string
+		address     string
+		expectErr   bool
+		expectedOut string
+	}{
+		{
+			name:        "ipv4 address",
+			address:     "127.0.0.1",
+			expectErr:   false,
+			expectedOut: "127.0.0.1",
+		},
+		{
+			name:        "ipv4 resolvable dns address",
+			address:     "localhost",
+			expectErr:   false,
+			expectedOut: "127.0.0.1",
+		},
+		{
+			name:        "ipv6 address",
+			address:     "::1",
+			expectErr:   true,
+			expectedOut: "",
+		},
+		{
+			name:        "unresolvable DNS address",
+			address:     "fake.local",
+			expectErr:   true,
+			expectedOut: "",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := ResolveToIPv4Address(test.address)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedOut, out)
+		})
+	}
+}

--- a/pkg/wiparser/wiparser_test.go
+++ b/pkg/wiparser/wiparser_test.go
@@ -97,7 +97,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "valid dns and ip addresses with associated nodes",
-			input: map[string]string{"localhost": "username=core", "127.0.0.1": "username=Admin"},
+			input: map[string]string{"localhost": "username=core", "127.0.0.2": "username=Admin"},
 			nodeList: &core.NodeList{
 				Items: []core.Node{
 					{
@@ -106,7 +106,7 @@ func TestParse(t *testing.T) {
 						},
 						Status: core.NodeStatus{
 							Addresses: []core.NodeAddress{
-								{Address: "127.0.0.1", Type: core.NodeInternalIP},
+								{Address: "127.0.0.2", Type: core.NodeInternalIP},
 							},
 						},
 					},
@@ -116,22 +116,22 @@ func TestParse(t *testing.T) {
 						},
 						Status: core.NodeStatus{
 							Addresses: []core.NodeAddress{
-								{Address: "localhost", Type: core.NodeInternalDNS},
+								{Address: "127.0.0.1", Type: core.NodeInternalIP},
 							},
 						},
 					},
 				},
 			},
 			expectedOut: []*instance.Info{
-				{Address: "127.0.0.1", IPv4Address: "127.0.0.1", Username: "Admin",
+				{Address: "127.0.0.2", IPv4Address: "127.0.0.2", Username: "Admin",
 					Node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: "ip-node"},
-						Status: core.NodeStatus{Addresses: []core.NodeAddress{{Address: "127.0.0.1",
+						Status: core.NodeStatus{Addresses: []core.NodeAddress{{Address: "127.0.0.2",
 							Type: core.NodeInternalIP}},
 						}}},
 				{Address: "localhost", IPv4Address: "127.0.0.1", Username: "core",
 					Node: &core.Node{ObjectMeta: meta.ObjectMeta{Name: "dns-node"},
-						Status: core.NodeStatus{Addresses: []core.NodeAddress{{Address: "localhost",
-							Type: core.NodeInternalDNS}},
+						Status: core.NodeStatus{Addresses: []core.NodeAddress{{Address: "127.0.0.1",
+							Type: core.NodeInternalIP}},
 						}}},
 			},
 			expectedErr: false,


### PR DESCRIPTION
This commit fixes an issue where the DNS address used to configure a
BYOH node is not present in the addresses of the Node object.

A unit test case had to be removed, as the case was not possible, with
two nodes having the same resolved address.

Fixes BZ#2005360