### PR TITLE
Bug 1994859: Get and pass Cluster DNS to wmcb.exe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.38.23
 	github.com/go-logr/logr v0.4.0
 	github.com/openshift/api v0.0.0-20211103131146-a0807454a876

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -188,3 +188,50 @@ func TestGetVXLANPort(t *testing.T) {
 		})
 	}
 }
+
+// TestGetDNS tests the DNS server IP generation from a given subnet
+func TestGetDNS(t *testing.T) {
+	type args struct {
+		subnet string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty subnet",
+			args:    args{subnet: ""},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid subnet",
+			args:    args{subnet: "invalid"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "no IP in subnet",
+			args:    args{subnet: "172.30.0.0/32"},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "valid subnet",
+			args:    args{subnet: "172.30.0.0/16"},
+			want:    "172.30.0.10",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetDNS(tt.args.subnet)
+			if (err != nil) != tt.wantErr {
+				assert.Errorf(t, err, "error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -305,7 +305,7 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 
 // findHostName returns the actual host name of the instance by running the 'hostname' command
 func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
-	win, err := windows.New("", "", instanceInfo, instanceSigner)
+	win, err := windows.New("", "", "", instanceInfo, instanceSigner)
 	if err != nil {
 		return "", errors.Wrap(err, "error instantiating Windows instance")
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -136,8 +136,13 @@ func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPor
 			"creating new node config")
 	}
 
+	clusterDNS, err := cluster.GetDNS(clusterServiceCIDR)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting cluster DNS from service CIDR: %s", clusterServiceCIDR)
+	}
+
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
-	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, vxlanPort,
+	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, clusterDNS, vxlanPort,
 		instanceInfo, signer)
 	if err != nil {
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -559,21 +559,21 @@ func (tc *testContext) createWinCurlerJob(name string, winServerIP string, affin
 }
 
 // getWinCurlerCommand generates a command to curl a Windows server from the given IP address
-func (tc *testContext) getWinCurlerCommand(winServerIP string) []string {
+func (tc *testContext) getWinCurlerCommand(winServerIP string) string {
 	// This will continually try to read from the Windows Server. We have to try multiple times as the Windows container
 	// takes some time to finish initial network setup.
-	winCurlerCommand := []string{powerShellExe, "-command", "for (($i =0), ($j = 0); $i -lt 60; $i++) { " +
+	return "for (($i =0), ($j = 0); $i -lt 60; $i++) { " +
 		"$response = Invoke-Webrequest -UseBasicParsing -Uri " + winServerIP +
 		"; $code = $response.StatusCode; echo \"GET returned code $code\";" +
-		"If ($code -eq 200) {exit 0}; Start-Sleep -s 10;}; exit 1"}
-	return winCurlerCommand
+		"If ($code -eq 200) {exit 0}; Start-Sleep -s 10;}; exit 1"
 }
 
-// createWindowsServerJob creates a job which will run the provided command with a Windows Server image
-func (tc *testContext) createWindowsServerJob(name string, command []string, affinity *v1.Affinity) (*batchv1.Job, error) {
+// createWindowsServerJob creates a job which will run the provided PowerShell command with a Windows Server image
+func (tc *testContext) createWindowsServerJob(name, pwshCommand string, affinity *v1.Affinity) (*batchv1.Job, error) {
 	windowsNodeSelector := map[string]string{"kubernetes.io/os": "windows"}
 	windowsTolerations := []v1.Toleration{{Key: "os", Value: "Windows", Effect: v1.TaintEffectNoSchedule}}
 	windowsServerImage := tc.getWindowsServerContainerImage()
+	command := []string{powerShellExe, "-command", pwshCommand}
 	return tc.createJob(name, windowsServerImage, command, windowsNodeSelector, windowsTolerations, affinity)
 }
 

--- a/vendor/github.com/apparentlymart/go-cidr/LICENSE
+++ b/vendor/github.com/apparentlymart/go-cidr/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Martin Atkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -1,0 +1,236 @@
+// Package cidr is a collection of assorted utilities for computing
+// network and host addresses within network ranges.
+//
+// It expects a CIDR-type address structure where addresses are divided into
+// some number of prefix bits representing the network and then the remaining
+// suffix bits represent the host.
+//
+// For example, it can help to calculate addresses for sub-networks of a
+// parent network, or to calculate host addresses within a particular prefix.
+//
+// At present this package is prioritizing simplicity of implementation and
+// de-prioritizing speed and memory usage. Thus caution is advised before
+// using this package in performance-critical applications or hot codepaths.
+// Patches to improve the speed and memory usage may be accepted as long as
+// they do not result in a significant increase in code complexity.
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+// Subnet takes a parent CIDR range and creates a subnet within it
+// with the given number of additional prefix bits and the given
+// network number.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number
+// of 5, becomes 10.3.5.0/24 .
+func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	return SubnetBig(base, newBits, big.NewInt(int64(num)))
+}
+
+// SubnetBig takes a parent CIDR range and creates a subnet within it with the
+// given number of additional prefix bits and the given network number. It
+// differs from Subnet in that it takes a *big.Int for the num, instead of an int.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number of 5,
+// becomes 10.3.5.0/24 .
+func SubnetBig(base *net.IPNet, newBits int, num *big.Int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	newPrefixLen := parentLen + newBits
+
+	if newPrefixLen > addrLen {
+		return nil, fmt.Errorf("insufficient address space to extend prefix of %d by %d", parentLen, newBits)
+	}
+
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if num.Uint64() > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addrLen),
+	}, nil
+}
+
+// Host takes a parent CIDR range and turns it into a host IP address with the
+// given host number.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func Host(base *net.IPNet, num int) (net.IP, error) {
+	return HostBig(base, big.NewInt(int64(num)))
+}
+
+// HostBig takes a parent CIDR range and turns it into a host IP address with
+// the given host number. It differs from Host in that it takes a *big.Int for
+// the num, instead of an int.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func HostBig(base *net.IPNet, num *big.Int) (net.IP, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	hostLen := addrLen - parentLen
+
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
+
+	numUint64 := big.NewInt(int64(num.Uint64()))
+	if num.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(num)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		num.Sub(maxHostNum, numUint64)
+	}
+
+	if numUint64.Cmp(maxHostNum) == 1 {
+		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
+	}
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, num, bitlength), nil
+}
+
+// AddressRange returns the first and last addresses in the given CIDR range.
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+
+// AddressCount returns the number of distinct host addresses within the given
+// CIDR range.
+//
+// Since the result is a uint64, this function returns meaningful information
+// only for IPv4 ranges and IPv6 ranges with a prefix size of at least 65.
+func AddressCount(network *net.IPNet) uint64 {
+	prefixLen, bits := network.Mask.Size()
+	return 1 << (uint64(bits) - uint64(prefixLen))
+}
+
+//VerifyNoOverlap takes a list subnets and supernet (CIDRBlock) and verifies
+//none of the subnets overlap and all subnets are in the supernet
+//it returns an error if any of those conditions are not satisfied
+func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
+	firstLastIP := make([][]net.IP, len(subnets))
+	for i, s := range subnets {
+		first, last := AddressRange(s)
+		firstLastIP[i] = []net.IP{first, last}
+	}
+	for i, s := range subnets {
+		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
+			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
+		}
+		for j := 0; j < len(subnets); j++ {
+			if i == j {
+				continue
+			}
+
+			first := firstLastIP[j][0]
+			last := firstLastIP[j][1]
+			if s.Contains(first) || s.Contains(last) {
+				return fmt.Errorf("%s overlaps with %s", subnets[j].String(), s.String())
+			}
+		}
+	}
+	return nil
+}
+
+// PreviousSubnet returns the subnet of the desired mask in the IP space
+// just lower than the start of IPNet provided. If the IP space rolls over
+// then the second return value is true
+func PreviousSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	startIP := checkIPv4(network.IP)
+	previousIP := make(net.IP, len(startIP))
+	copy(previousIP, startIP)
+	cMask := net.CIDRMask(prefixLen, 8*len(previousIP))
+	previousIP = Dec(previousIP)
+	previous := &net.IPNet{IP: previousIP.Mask(cMask), Mask: cMask}
+	if startIP.Equal(net.IPv4zero) || startIP.Equal(net.IPv6zero) {
+		return previous, true
+	}
+	return previous, false
+}
+
+// NextSubnet returns the next available subnet of the desired mask size
+// starting for the maximum IP of the offset subnet
+// If the IP exceeds the maxium IP then the second return value is true
+func NextSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	_, currentLast := AddressRange(network)
+	mask := net.CIDRMask(prefixLen, 8*len(currentLast))
+	currentSubnet := &net.IPNet{IP: currentLast.Mask(mask), Mask: mask}
+	_, last := AddressRange(currentSubnet)
+	last = Inc(last)
+	next := &net.IPNet{IP: last.Mask(mask), Mask: mask}
+	if last.Equal(net.IPv4zero) || last.Equal(net.IPv6zero) {
+		return next, true
+	}
+	return next, false
+}
+
+//Inc increases the IP by one this returns a new []byte for the IP
+func Inc(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	incIP := make([]byte, len(IP))
+	copy(incIP, IP)
+	for j := len(incIP) - 1; j >= 0; j-- {
+		incIP[j]++
+		if incIP[j] > 0 {
+			break
+		}
+	}
+	return incIP
+}
+
+//Dec decreases the IP by one this returns a new []byte for the IP
+func Dec(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	decIP := make([]byte, len(IP))
+	copy(decIP, IP)
+	decIP = checkIPv4(decIP)
+	for j := len(decIP) - 1; j >= 0; j-- {
+		decIP[j]--
+		if decIP[j] < 255 {
+			break
+		}
+	}
+	return decIP
+}
+
+func checkIPv4(ip net.IP) net.IP {
+	// Go for some reason allocs IPv6len for IPv4 so we have to correct it
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -1,0 +1,37 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}
+
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+	return intToIP(ipInt, totalBits)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,6 +23,9 @@ github.com/MakeNowJust/heredoc
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/apparentlymart/go-cidr v1.1.0
+## explicit
+github.com/apparentlymart/go-cidr/cidr
 # github.com/aws/aws-sdk-go v1.38.23
 ## explicit
 github.com/aws/aws-sdk-go/aws


### PR DESCRIPTION
In this PR a pre-work commit is introduced to avoid future code duplication by
generalizing the `createWindowsServerJob` function, accepting just a PowerShell 
command string instead of the generic command array.

The Cluster DNS is generated from the serviceNetwork subnet and passed
to the wmcb.exe initialize-kubelet command, to configure the kubelet
with a specific DNS server IP which will be used by all Windows containers.

Added e2e test case to ensure DNS resolution works properly inside the
Windows container.

Closes #575