### PR TITLE
Replace git with http URL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,10 @@
 	branch = release-4.9
 [submodule "promu"]
 	path = promu
-	url = git://github.com/openshift/prometheus-promu
+	url = https://github.com/openshift/prometheus-promu
 [submodule "windows_exporter"]
 	path = windows_exporter
-	url = git://github.com/openshift/prometheus-community-windows_exporter
+	url = https://github.com/openshift/prometheus-community-windows_exporter
 [submodule "kubelet"]
 	path = kubelet
 	url = https://github.com/openshift/kubernetes


### PR DESCRIPTION
Github deprecated unauthenticated git:// access.

See https://github.blog/2021-09-01-improving-git-protocol-security-github/