### PR TITLE
[docs] Standardize name of user data secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ spec:
           snapshot: ""
           template: <Windows_VM_template>
           userDataSecret:
-            name: worker-user-data-managed
+            name: windows-user-data
           workspace:
              datacenter: <vCenter DataCenter Name>
              datastore: <vCenter Datastore Name>

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -122,7 +122,7 @@ spec:
               snapshot: ""
               template: <Windows_VM_template
               userDataSecret:
-                name: worker-user-data-managed
+                name: windows-user-data
               workspace:
                 datacenter: <vCenter DataCenter Name>
                 datastore: <vCenter Datastore Name>

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -120,7 +120,7 @@ spec:
               snapshot: ""
               template: <Windows_VM_template
               userDataSecret:
-                name: worker-user-data-managed
+                name: windows-user-data
               workspace:
                 datacenter: <vCenter DataCenter Name>
                 datastore: <vCenter Datastore Name>


### PR DESCRIPTION
This PR standardizes the name of the user data secret in the sample
MachineSets in the README and in the CSV. The name is now consistent with
the user data name constant we use in the source code and in the sample
MachineSets for other cloud providers: `windows-user-data`

Ran `make bundle`