### PR TITLE
[OCPCLOUD-1247] Pass platform type to WMCB 

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -71,7 +71,7 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instanceInfo, r.signer,
-		labelsToApply, annotationsToApply)
+		labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}
@@ -139,7 +139,7 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instance, r.signer,
-		nil, nil)
+		nil, nil, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -305,7 +305,9 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 
 // findHostName returns the actual host name of the instance by running the 'hostname' command
 func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
-	win, err := windows.New("", "", "", instanceInfo, instanceSigner)
+	// We don't need to pass the platform type here because this parameter is required for WMCB only.
+	// Here we just execute the "hostname" command.
+	win, err := windows.New("", "", "", instanceInfo, instanceSigner, "")
 	if err != nil {
 		return "", errors.Wrap(err, "error instantiating Windows instance")
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -115,7 +116,7 @@ func discoverKubeAPIServerEndpoint() (string, error) {
 // hostName having a value will result in the VM's hostname being changed to the given value.
 func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPort string,
 	instanceInfo *instance.Info, signer ssh.Signer, additionalLabels,
-	additionalAnnotations map[string]string) (*nodeConfig, error) {
+	additionalAnnotations map[string]string, platformType configv1.PlatformType) (*nodeConfig, error) {
 	var err error
 	if nodeConfigCache.workerIgnitionEndPoint == "" {
 		var kubeAPIServerEndpoint string
@@ -143,7 +144,7 @@ func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPor
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
 	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, clusterDNS, vxlanPort,
-		instanceInfo, signer)
+		instanceInfo, signer, string(platformType))
 	if err != nil {
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")
 	}


### PR DESCRIPTION
This commit passes platform typy to WCMB using the new `--platform-type` parameter.

Depending on the platform, WCMB may perform additional actions to configure the nodes. For instance, on AWS it overrides default hostname for kubelet using values from metadata server.