### PR TITLE
Use more appropriate sample domain name for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ metadata:
 data:
   10.1.42.1: |-
     username=Administrator
-  instance.dns.com: |-
+  instance.example.com: |-
     username=core
 ```
 
@@ -83,7 +83,7 @@ metadata:
   name: windows-instances
   namespace: openshift-windows-machine-config-operator
 data:
-  instance.dns.com: |-
+  instance.example.com: |-
     username=core
 ```
 


### PR DESCRIPTION
Avoid using "dns.com" which is owned by an actual company;  "example.com" is more appropriate for use here.