### PR TITLE
[config] Add ServiceAccount manifest

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource
 # if your manager will use a service account that exists at

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: system
+  name: windows-machine-config-operator


### PR DESCRIPTION
When I deploy the operator with `make deploy`, I get next error from WMCO deployment:

```txt
error looking up service account openshift-windows-machine-config-operator/windows-machine-config-operator:
      serviceaccount "windows-machine-config-operator" not found'
```

This commit adds a manifest for the missing service account. After that everything installs well.