### PR TITLE
[Dockerfile] Update index image version label to 4.10

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.9"
+LABEL com.redhat.openshift.versions="=v4.10"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically


### PR DESCRIPTION
This PR updates the index image label version in the bundle.Dockerfile to v4.10, complaint with the version operator will be available in.