### PR TITLE
Bug 2032048: Fix CVO override and retry Update of CSRs approval status

### DIFF
--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -89,9 +89,9 @@ func (a *Approver) Approve() error {
 	a.csr.Status.Conditions = append(a.csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
 		Type:           certificates.CertificateApproved,
 		Status:         "True",
-		Message:        "Approved by WMCO",
+		Message:        "This CSR was approved by the WMCO certificate Approver.",
 		LastUpdateTime: meta.Now(),
-		Reason:         "WMCOApproved",
+		Reason:         "WMCOApprove",
 	})
 
 	if _, err := a.k8sclientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.Background(),

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -133,7 +133,7 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 
 	// Patch the CVO with overrides spec value for cluster-machine-approver deployment
 	// Doing so, stops CVO from creating/updating its deployment hereafter.
-	patchData := `[{"op":"add","path":"/spec/overrides","value":[{"kind":"Deployment","group":"apps/v1","name":"machine-approver","namespace":"openshift-cluster-machine-approver","unmanaged":true}]}]`
+	patchData := `[{"op":"add","path":"/spec/overrides","value":[{"kind":"Deployment","group":"apps","name":"machine-approver","namespace":"openshift-cluster-machine-approver","unmanaged":true}]}]`
 	_, err := tc.client.Config.ConfigV1().ClusterVersions().Patch(context.TODO(), "version", types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 
 	// Scale the Cluster Machine Approver Deployment to 0

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -439,13 +439,14 @@ func testCSRApproval(t *testing.T) {
 		for _, csr := range csrs {
 			isWMCOApproved := func() bool {
 				for _, c := range csr.Status.Conditions {
-					if c.Type == certificates.CertificateApproved && c.Reason == "WMCOApproved" {
+					if c.Type == certificates.CertificateApproved && c.Reason == "WMCOApprove" {
 						return true
 					}
 				}
 				return false
 			}()
-			assert.Equal(t, isWMCOApproved, true, "expected BYOH node CSR to be approved by WMCO CSR approver: %s", node.GetName())
+			assert.Equal(t, isWMCOApproved, true, "expected BYOH node %s CSR %s to be approved by WMCO CSR approver",
+				node.GetName(), csr.GetName())
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the group value when adding a CVO override for 
the cluster-machine-approver. Overrides were not taking effect 
due to an invalid value ([CVO docs](https://github.com/openshift/enhancements/blob/f97876821d3bb506d28fee565271d3bebbbc682c/dev-guide/cluster-version-operator/dev/clusterversion.md#setting-objects-unmanaged) are incorrect).This is required for testing 
BYOH CSR approval feature so that CSRs associated with 
BYOH instances are not approved by Cluster Machine Approver.

The PR also takes the recommended k8s approach to Updating CSRs.
If an update fails due to a conflict, we want to retrieve an updated
reference to the object before trying again to apply our own changes to it.
Otherwise, Update calls can result in failures as the CSR object can
become a stale reference (if some other entity changes the CSR resource
while WMCO is configuring for example). Lastly it brings the WMCO CSR 
approval condition's message and reason fields in line with 
the kubectl certificate approver and the Node CSR approver.