### PR TITLE
[WIP] logging for csr approval in e2e tests

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -356,7 +356,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: windows-machine-config-operator
                 image: REPLACE_IMAGE
-                imagePullPolicy: IfNotPresent
+                imagePullPolicy: Always
                 name: manager
                 resources: {}
               hostNetwork: true

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -431,6 +431,13 @@ func testCSRApproval(t *testing.T) {
 	if gc.numberOfBYOHNodes == 0 {
 		t.Skip("BYOH CSR approval testing disabled")
 	}
+
+	deployment, err := testCtx.client.K8s.AppsV1().Deployments("openshift-cluster-machine-approver").Get(context.TODO(),
+		"machine-approver", meta.GetOptions{})
+	require.NoError(t, err, "error listing Cluster Machine Approver deployment")
+	log.Printf("before testCSRApproval deployment %s/%s... currently at %d pods, expected %d pods",
+		deployment.GetNamespace(), deployment.GetName(), *deployment.Spec.Replicas, 0)
+
 	for _, node := range gc.byohNodes {
 		csrs, err := testCtx.findNodeCSRs(node.GetName())
 		require.NotEqual(t, len(csrs), 0, "could not find BYOH node CSR's")
@@ -453,6 +460,8 @@ func testCSRApproval(t *testing.T) {
 	expectedPodCount := int32(1)
 	err = testCtx.scaleMachineApproverDeployment(&expectedPodCount)
 	require.NoError(t, err, "failed to scale Cluster Machine Approver pods")
+	log.Printf("after testCSRApproval deployment %s/%s... currently at %d pods, expected %d pods",
+		deployment.GetNamespace(), deployment.GetName(), *deployment.Spec.Replicas, expectedPodCount)
 }
 
 // findNodeCSRs returns the list of CSRs for the given node


### PR DESCRIPTION
this is a dummy PR to see if the cluster machine approver is actually getting scaled down in CI. It is being scaled down locally. This is in investigation of an issue seen in pull #844
Intended to be closed.