### PR TITLE
WINC-332: Generated file linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ bundle: manifests kustomize
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle --overwrite=false -q --version $(WMCO_VERSION) $(BUNDLE_METADATA_OPTS)
+	sed -i 's/REPLACE_IMAGE:latest/REPLACE_IMAGE/g' bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
 	operator-sdk bundle validate ./bundle
 	sed -i 's/windows-machine-config-operator\.v.\.0\.0/windows-machine-config-operator.v$(WMCO_VERSION)/g' ./bundle/windows-machine-config-operator.package.yaml
 

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     olm.skipRange: '>=4.0.0 <5.0.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -133,6 +133,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   verbs:
   - get
@@ -186,11 +194,3 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusteroperators
-  verbs:
-  - get
-  - list
-  - watch

--- a/hack/verify-bundle.sh
+++ b/hack/verify-bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# The purpose of this script is to check that all generated files related to operator-sdk are kept up to date
+
+make bundle
+# check if any changes to the config/ or bundle/ directories have occured
+status=$(git status config/ bundle/ --porcelain)
+if [ -n "$status" ]; then
+  echo "bundle lint failure"
+  echo "$status"
+  exit 1
+fi


### PR DESCRIPTION
This PR ensures that all generated files are fully updated as part
of `make lint`.
The bundle files were out of date, so they needed to be updated
in order for linting to pass.