### PR TITLE
Revert "[e2e] Improve CVO override creation and patching"

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math"
@@ -25,7 +24,6 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
-	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
@@ -135,20 +133,8 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 
 	// Patch the CVO with overrides spec value for cluster-machine-approver deployment
 	// Doing so, stops CVO from creating/updating its deployment hereafter.
-	nodeCSRApproverOverride := config.ComponentOverride{
-		Kind:      "Deployment",
-		Group:     "apps",
-		Namespace: "openshift-cluster-machine-approver",
-		Name:      "machine-approver",
-		Unmanaged: true,
-	}
-	patchData, err := json.Marshal([]*patch.JSONPatch{
-		patch.NewJSONPatch("add", "/spec/overrides", []config.ComponentOverride{nodeCSRApproverOverride})})
-	require.NoErrorf(t, err, "unable to generate patch request body for CVO override: %v", nodeCSRApproverOverride)
-
-	_, err = tc.client.Config.ConfigV1().ClusterVersions().Patch(context.TODO(), "version", types.JSONPatchType,
-		patchData, metav1.PatchOptions{})
-	require.NoErrorf(t, err, "unable to apply patch %s to ClusterVersion", patchData)
+	patchData := `[{"op":"add","path":"/spec/overrides","value":[{"kind":"Deployment","group":"apps","name":"machine-approver","namespace":"openshift-cluster-machine-approver","unmanaged":true}]}]`
+	_, err := tc.client.Config.ConfigV1().ClusterVersions().Patch(context.TODO(), "version", types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 
 	// Scale the Cluster Machine Approver Deployment to 0
 	// This is required for testing BYOH CSR approval feature so that BYOH instances


### PR DESCRIPTION
Reverts openshift/windows-machine-config-operator#861

This revert is in hopes of unblocking CI and finding the cause of CSR approval failures, which seemed to have been fixed by https://github.com/openshift/windows-machine-config-operator/pull/844.