### PR TITLE
[e2e] Scale down CVO when testing BYOH CSRs

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math"
@@ -18,14 +17,12 @@ import (
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
-	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
@@ -35,6 +32,10 @@ const (
 	// vmConfigurationTime is the maximum amount of time expected for a Windows VM to be fully configured and ready for WMCO
 	// after the hardware is provisioned.
 	vmConfigurationTime = 10 * time.Minute
+
+	clusterVersionOperatorNamespace   = "openshift-cluster-version"
+	clusterVersionOperatorDeployment  = "cluster-version-operator"
+	clusterVersionOperatorPodSelector = "k8s-app=cluster-version-operator"
 
 	machineApproverNamespace   = "openshift-cluster-machine-approver"
 	machineApproverDeployment  = "machine-approver"
@@ -139,27 +140,16 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 		t.Skip("BYOH testing disabled")
 	}
 
-	// Patch the CVO with overrides spec value for cluster-machine-approver deployment
-	// Doing so, stops CVO from creating/updating its deployment hereafter.
-	nodeCSRApproverOverride := config.ComponentOverride{
-		Kind:      "Deployment",
-		Group:     "apps",
-		Namespace: "openshift-cluster-machine-approver",
-		Name:      "machine-approver",
-		Unmanaged: true,
-	}
-	patchData, err := json.Marshal([]*patch.JSONPatch{
-		patch.NewJSONPatch("add", "/spec/overrides", []config.ComponentOverride{nodeCSRApproverOverride})})
-	require.NoErrorf(t, err, "unable to generate patch request body for CVO override: %v", nodeCSRApproverOverride)
-
-	_, err = tc.client.Config.ConfigV1().ClusterVersions().Patch(context.TODO(), "version", types.JSONPatchType,
-		patchData, metav1.PatchOptions{})
-	require.NoErrorf(t, err, "unable to apply patch %s to ClusterVersion", patchData)
+	// Scale down the Cluster Version Operator deployment
+	// Doing so, stops CVO from creating/updating the cluster-machine-approver deployment hereafter.
+	expectedPodCount := int32(0)
+	err := tc.scaleDeployment(clusterVersionOperatorNamespace, clusterVersionOperatorDeployment,
+		clusterVersionOperatorPodSelector, &expectedPodCount)
+	require.NoError(t, err, "failed to scale down CVO pods")
 
 	// Scale the Cluster Machine Approver Deployment to 0
 	// This is required for testing BYOH CSR approval feature so that BYOH instances
 	// CSR's are not approved by Cluster Machine Approver
-	expectedPodCount := int32(0)
 	err = tc.scaleDeployment(machineApproverNamespace, machineApproverDeployment, machineApproverPodSelector,
 		&expectedPodCount)
 	require.NoError(t, err, "failed to scale down Machine Approver pods")

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -468,8 +468,9 @@ func testCSRApproval(t *testing.T) {
 
 	// Scale the Cluster Machine Approver deployment back to 1.
 	expectedPodCount := int32(1)
-	err = testCtx.scaleMachineApproverDeployment(&expectedPodCount)
-	require.NoError(t, err, "failed to scale Cluster Machine Approver pods")
+	err = testCtx.scaleDeployment(machineApproverNamespace, machineApproverDeployment, machineApproverPodSelector,
+		&expectedPodCount)
+	require.NoError(t, err, "failed to scale up Cluster Machine Approver pods")
 }
 
 // findNodeCSRs returns the list of CSRs for the given node

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -471,6 +471,11 @@ func testCSRApproval(t *testing.T) {
 	err = testCtx.scaleDeployment(machineApproverNamespace, machineApproverDeployment, machineApproverPodSelector,
 		&expectedPodCount)
 	require.NoError(t, err, "failed to scale up Cluster Machine Approver pods")
+
+	// Scale the Cluster Version Operator deployment back to 1.
+	err = testCtx.scaleDeployment(clusterVersionOperatorNamespace, clusterVersionOperatorDeployment,
+		clusterVersionOperatorPodSelector, &expectedPodCount)
+	require.NoError(t, err, "failed to scale up CVO pods")
 }
 
 // findNodeCSRs returns the list of CSRs for the given node


### PR DESCRIPTION
This PR scales down the CVO when testing WMCO's CSR approval functionality.
This is needed to prevent CVO from scaling the cluster-machine-operator
deployment back up, something we scale down ourselves so it does not try to
auto-approve CSRs for Windows BYOH nodes (in CI, our BYOH nodes are
Machine-backed but without the Windows version annotation for ease of testing).
We are seeing an issue where the previous solution, adding a CVO override to
make the cluster-machine-operator deployment unmanaged, is no longer sufficient.
This PR also refactors a method used to scale deployments in the e2e tests.