### PR TITLE
WINC-617: Specify container runtime flag and transfer containerd files

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -68,7 +68,7 @@ type ConfigMapReconciler struct {
 }
 
 // NewConfigMapReconciler returns a pointer to a ConfigMapReconciler
-func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string) (*ConfigMapReconciler, error) {
+func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string, dockerRuntime bool) (*ConfigMapReconciler, error) {
 	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating kubernetes clientset")
@@ -90,6 +90,7 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 			vxlanPort:            clusterConfig.Network().VXLANPort(),
 			prometheusNodeConfig: pc,
 			platform:             clusterConfig.Platform(),
+			dockerRuntime:        dockerRuntime,
 		},
 	}, nil
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -52,6 +52,8 @@ type instanceReconciler struct {
 	recorder record.EventRecorder
 	// platform indicates the cloud on which the cluster is running
 	platform config.PlatformType
+	// dockerRuntime indicates if the container runtime used is docker or containerd
+	dockerRuntime bool
 }
 
 // ensureInstanceIsUpToDate ensures that the given instance is configured as a node and upgraded to the specifications
@@ -71,7 +73,7 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instanceInfo, r.signer,
-		labelsToApply, annotationsToApply, r.platform)
+		labelsToApply, annotationsToApply, r.platform, r.dockerRuntime)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}
@@ -139,7 +141,7 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instance, r.signer,
-		nil, nil, r.platform)
+		nil, nil, r.platform, r.dockerRuntime)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -63,7 +63,7 @@ type WindowsMachineReconciler struct {
 }
 
 // NewWindowsMachineReconciler returns a pointer to a WindowsMachineReconciler
-func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string) (*WindowsMachineReconciler, error) {
+func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string, dockerRuntime bool) (*WindowsMachineReconciler, error) {
 	// The client provided by the GetClient() method of the manager is a split client that will always hit the API
 	// server when writing. When reading, the client will either use a cache populated by the informers backing the
 	// controllers, or in certain cases read directly from the API server. It will read from the server both for
@@ -97,6 +97,7 @@ func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Conf
 			watchNamespace:       watchNamespace,
 			prometheusNodeConfig: pc,
 			platform:             clusterConfig.Platform(),
+			dockerRuntime:        dockerRuntime,
 		},
 		machineClient: machineClient,
 	}, nil

--- a/main.go
+++ b/main.go
@@ -49,7 +49,10 @@ func init() {
 
 func main() {
 	var debugLogging bool
+	var dockerRuntime bool
+
 	flag.BoolVar(&debugLogging, "debugLogging", false, "Log debug messages")
+	flag.BoolVar(&dockerRuntime, "dockerRuntime", true, "Container runtime to be used")
 
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
@@ -164,7 +167,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	winMachineReconciler, err := controllers.NewWindowsMachineReconciler(mgr, clusterConfig, watchNamespace)
+	winMachineReconciler, err := controllers.NewWindowsMachineReconciler(mgr, clusterConfig, watchNamespace, dockerRuntime)
 	if err != nil {
 		setupLog.Error(err, "unable to create Windows Machine reconciler")
 		os.Exit(1)
@@ -183,7 +186,7 @@ func main() {
 		setupLog.Error(err, "error removing invalid annotations from Linux nodes")
 	}
 
-	configMapReconciler, err := controllers.NewConfigMapReconciler(mgr, clusterConfig, watchNamespace)
+	configMapReconciler, err := controllers.NewConfigMapReconciler(mgr, clusterConfig, watchNamespace, dockerRuntime)
 	if err != nil {
 		setupLog.Error(err, "unable to create ConfigMap reconciler")
 		os.Exit(1)

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -307,7 +307,8 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
 	// We don't need to pass the platform type here because this parameter is required for WMCB only.
 	// Here we just execute the "hostname" command.
-	win, err := windows.New("", "", "", instanceInfo, instanceSigner, "")
+	win, err := windows.New("", "", "", instanceInfo, instanceSigner, "",
+		true)
 	if err != nil {
 		return "", errors.Wrap(err, "error instantiating Windows instance")
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -120,7 +120,7 @@ func discoverKubeAPIServerEndpoint() (string, error) {
 // hostName having a value will result in the VM's hostname being changed to the given value.
 func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPort string,
 	instanceInfo *instance.Info, signer ssh.Signer, additionalLabels,
-	additionalAnnotations map[string]string, platformType configv1.PlatformType) (*nodeConfig, error) {
+	additionalAnnotations map[string]string, platformType configv1.PlatformType, dockerRuntime bool) (*nodeConfig, error) {
 	var err error
 
 	if nodeConfigCache.workerIgnitionEndPoint == "" {
@@ -149,7 +149,7 @@ func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPor
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
 	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, clusterDNS, vxlanPort,
-		instanceInfo, signer, string(platformType))
+		instanceInfo, signer, string(platformType), dockerRuntime)
 	if err != nil {
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")
 	}

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -20,6 +20,11 @@ const (
 	// KubeProxyPath contains the path of the kube-proxy binary. The container image should already have this binary
 	// mounted
 	KubeProxyPath = payloadDirectory + "/kube-node/kube-proxy.exe"
+	// ContainerdPath contains the path of the containerd binary. The container image should already have this binary
+	// mounted
+	ContainerdPath = payloadDirectory + "/containerd/containerd.exe"
+	//HcsshimPath contains the path of the hcsshim binary. The container image should already have this binary mounted
+	HcsshimPath = payloadDirectory + "/containerd/containerd-shim-runhcs-v1.exe"
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
 	IgnoreWgetPowerShellPath = payloadDirectory + "/powershell/wget-ignore-cert.ps1"

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -192,10 +192,13 @@ type windows struct {
 	defaultShellPowerShell bool
 	// platformType overrides default hostname in bootstrapper
 	platformType string
+	// dockerRuntime indicates if the container runtime used is docker or containerd
+	dockerRuntime bool
 }
 
 // New returns a new Windows instance constructed from the given WindowsVM
-func New(workerIgnitionEndpoint, clusterDNS, vxlanPort string, instanceInfo *instance.Info, signer ssh.Signer, platformType string) (Windows, error) {
+func New(workerIgnitionEndpoint, clusterDNS, vxlanPort string, instanceInfo *instance.Info, signer ssh.Signer,
+	platformType string, dockerRuntime bool) (Windows, error) {
 	log := ctrl.Log.WithName(fmt.Sprintf("wc %s", instanceInfo.Address))
 	log.V(1).Info("initializing SSH connection")
 	conn, err := newSshConnectivity(instanceInfo.Username, instanceInfo.Address, signer, log)
@@ -212,6 +215,7 @@ func New(workerIgnitionEndpoint, clusterDNS, vxlanPort string, instanceInfo *ins
 			log:                    log,
 			defaultShellPowerShell: defaultShellPowershell(conn),
 			platformType:           platformType,
+			dockerRuntime:          dockerRuntime,
 		},
 		nil
 }

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -82,6 +82,10 @@ func (tc *testContext) testBYOHRemoval(t *testing.T) {
 // address
 func (tc *testContext) checkDirsDoNotExist(address string) (bool, error) {
 	command := ""
+
+	// TODO: Remove appending containerd directory when we default to using runtime containerd
+	windows.RequiredDirectories = append(windows.RequiredDirectories, windows.ContainerdDir)
+
 	for _, dir := range windows.RequiredDirectories {
 		command += fmt.Sprintf("if ((Test-Path %s) -eq $true) { Write-Output %s exists}", dir, dir)
 	}


### PR DESCRIPTION
This PR adds a flag through CSV args to specify the Windows host container runtime as docker or containerd. If the flag value is "containerd", the Containerd related files are transferred to the Windows VM.
This PR addresses both [WINC-617](https://issues.redhat.com/browse/WINC-617) and [WINC-694](https://issues.redhat.com/browse/WINC-694).

Ran
`make bundle`