### PR TITLE
Revert "[e2e] Scale down CVO when testing BYOH CSRs"

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math"
@@ -17,12 +18,14 @@ import (
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
@@ -32,10 +35,6 @@ const (
 	// vmConfigurationTime is the maximum amount of time expected for a Windows VM to be fully configured and ready for WMCO
 	// after the hardware is provisioned.
 	vmConfigurationTime = 10 * time.Minute
-
-	clusterVersionOperatorNamespace   = "openshift-cluster-version"
-	clusterVersionOperatorDeployment  = "cluster-version-operator"
-	clusterVersionOperatorPodSelector = "k8s-app=cluster-version-operator"
 
 	machineApproverNamespace   = "openshift-cluster-machine-approver"
 	machineApproverDeployment  = "machine-approver"
@@ -140,16 +139,27 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 		t.Skip("BYOH testing disabled")
 	}
 
-	// Scale down the Cluster Version Operator deployment
-	// Doing so, stops CVO from creating/updating the cluster-machine-approver deployment hereafter.
-	expectedPodCount := int32(0)
-	err := tc.scaleDeployment(clusterVersionOperatorNamespace, clusterVersionOperatorDeployment,
-		clusterVersionOperatorPodSelector, &expectedPodCount)
-	require.NoError(t, err, "failed to scale down CVO pods")
+	// Patch the CVO with overrides spec value for cluster-machine-approver deployment
+	// Doing so, stops CVO from creating/updating its deployment hereafter.
+	nodeCSRApproverOverride := config.ComponentOverride{
+		Kind:      "Deployment",
+		Group:     "apps",
+		Namespace: "openshift-cluster-machine-approver",
+		Name:      "machine-approver",
+		Unmanaged: true,
+	}
+	patchData, err := json.Marshal([]*patch.JSONPatch{
+		patch.NewJSONPatch("add", "/spec/overrides", []config.ComponentOverride{nodeCSRApproverOverride})})
+	require.NoErrorf(t, err, "unable to generate patch request body for CVO override: %v", nodeCSRApproverOverride)
+
+	_, err = tc.client.Config.ConfigV1().ClusterVersions().Patch(context.TODO(), "version", types.JSONPatchType,
+		patchData, metav1.PatchOptions{})
+	require.NoErrorf(t, err, "unable to apply patch %s to ClusterVersion", patchData)
 
 	// Scale the Cluster Machine Approver Deployment to 0
 	// This is required for testing BYOH CSR approval feature so that BYOH instances
 	// CSR's are not approved by Cluster Machine Approver
+	expectedPodCount := int32(0)
 	err = tc.scaleDeployment(machineApproverNamespace, machineApproverDeployment, machineApproverPodSelector,
 		&expectedPodCount)
 	require.NoError(t, err, "failed to scale down Machine Approver pods")

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -471,11 +471,6 @@ func testCSRApproval(t *testing.T) {
 	err = testCtx.scaleDeployment(machineApproverNamespace, machineApproverDeployment, machineApproverPodSelector,
 		&expectedPodCount)
 	require.NoError(t, err, "failed to scale up Cluster Machine Approver pods")
-
-	// Scale the Cluster Version Operator deployment back to 1.
-	err = testCtx.scaleDeployment(clusterVersionOperatorNamespace, clusterVersionOperatorDeployment,
-		clusterVersionOperatorPodSelector, &expectedPodCount)
-	require.NoError(t, err, "failed to scale up CVO pods")
 }
 
 // findNodeCSRs returns the list of CSRs for the given node


### PR DESCRIPTION
This reverts commit 1521abca32c05a7f46f099980e7ef2c864982c62 from #869.
Not needed anymore as the CVO bug (https://bugzilla.redhat.com/show_bug.cgi?id=2042039)
that it worked around has been fixed with https://github.com/openshift/cluster-version-operator/pull/728.