### PR TITLE
WINC-723: Set v1.23 as the required k8s version

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -435,7 +435,7 @@ spec:
   - email: team-winc@redhat.com
     name: Red Hat, Windows Container Support for OpenShift
   maturity: stable
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
   version: 5.0.0

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -158,7 +158,7 @@ spec:
   - email: team-winc@redhat.com
     name: Red Hat, Windows Container Support for OpenShift
   maturity: stable
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
   version: 0.0.0

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -24,7 +24,7 @@ const (
 	ovnKubernetesNetwork = "OVNKubernetes"
 	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
 	// 1.20.x are supported for baseK8sVersion 1.20)
-	baseK8sVersion = "v1.22"
+	baseK8sVersion = "v1.23"
 	// cloudControllerOwnershipConditionType defines the Condition type for Cloud Controllers ownership
 	cloudControllerOwnershipConditionType = "CloudControllerOwner"
 	// clusterCloudControllerManagerOperatorName is the registered name of Cluster Cloud Controller Manager Operator

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -125,9 +125,9 @@ func TestIsValidKubernetesVersion(t *testing.T) {
 		error   bool
 	}{
 		{"cluster version lower than supported version ", "v1.17.1", true},
-		{"cluster version equals supported version", "v1.22.0", false},
-		{"cluster version equals supported version", "v1.23.4", false},
-		{"cluster version greater than supported version ", "v1.24.2", true},
+		{"cluster version equals supported version", "v1.23.0", false},
+		{"cluster version equals supported version", "v1.24.4", false},
+		{"cluster version greater than supported version ", "v1.25.2", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This commit updates the csv and WMCO code to require kubernetes 1.23 in
order to be installed and ran.