### PR TITLE
WINC-695: Configure containerd service and start it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ## Introduction
 The Windows Machine Config Operator configures Windows instances into nodes, enabling Windows container workloads to
 be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.5/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-or by specifying existing instances through a ConfigMap. Through either method, the Windows instance must have the
-Docker container runtime installed. The operator will do all the necessary steps to configure the instance so that it
+or by specifying existing instances through a ConfigMap. The operator will do all the necessary steps to configure the instance so that it
 can join the cluster as a worker node.
 
 More design details can be explored in the [WMCO enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/windows-containers/windows-machine-config-operator.md).
@@ -213,6 +212,9 @@ Cluster autoscaling is supported for Windows instances.
 - Define and deploy a [ClusterAutoscaler](https://docs.openshift.com/container-platform/latest/machine_management/applying-autoscaling.html#configuring-clusterautoscaler).
 - Create a Windows node through a MachineSet (see spec in [Usage section](https://github.com/openshift/windows-machine-config-operator#usage)).
 - Define and deploy a [MachineAutoscaler](https://docs.openshift.com/container-platform/latest/machine_management/applying-autoscaling.html#configuring-machineautoscaler), referencing a Windows MachineSet.
+
+### Container Runtime
+Windows instances brought up with WMCO are set up with the containerd container runtime.
 
 ## Development
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -91,6 +91,7 @@ RUN make build
 #├── containerd
 #│   ├── containerd.exe
 #│   └── containerd-shim-runhcs-v1.exe
+#|   └── containerd_conf.toml
 #├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
@@ -117,10 +118,11 @@ COPY --from=build /build/windows-machine-config-operator/windows_exporter/window
 # Copy azure-cloud-node-manager.exe
 COPY --from=build /build/windows-machine-config-operator/cloud-provider-azure/azure-cloud-node-manager.exe .
 
-# Copy containerd.exe and containerd-shim-runhcs-v1.exe
+# Copy containerd.exe, containerd-shim-runhcs-v1.exe and containerd config containerd_conf.toml
 WORKDIR /payload/containerd/
 COPY --from=build /build/windows-machine-config-operator/containerd/bin/containerd.exe .
 COPY --from=build /build/windows-machine-config-operator/hcsshim/containerd-shim-runhcs-v1.exe .
+COPY pkg/internal/containerd_conf.toml .
 
 # Copy kubelet.exe and kube-proxy.exe
 WORKDIR /payload/kube-node/

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -78,10 +78,11 @@ COPY --from=build /build/windows-machine-config-operator/windows_exporter/window
 # Copy azure-cloud-node-manager.exe
 COPY --from=build /build/windows-machine-config-operator/cloud-provider-azure/azure-cloud-node-manager.exe .
 
-# Copy containerd.exe and containerd-shim-runhcs-v1.exe
+# Copy containerd.exe, containerd-shim-runhcs-v1.exe and containerd config containerd_conf.toml
 WORKDIR /payload/containerd/
 COPY --from=build /build/windows-machine-config-operator/containerd/bin/containerd.exe .
 COPY --from=build /build/windows-machine-config-operator/hcsshim/containerd-shim-runhcs-v1.exe .
+COPY pkg/internal/containerd_conf.toml .
 
 # Copy kubelet.exe and kube-proxy.exe
 WORKDIR /payload/kube-node/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -108,6 +108,7 @@ RUN make build
 #├── containerd
 #│   ├── containerd.exe
 #│   └── containerd-shim-runhcs-v1.exe
+#|   └── containerd_conf.toml
 #├── hybrid-overlay-node.exe
 #├── kube-node
 #│   ├── kubelet.exe
@@ -134,10 +135,11 @@ COPY --from=build /build/windows-machine-config-operator/windows_exporter/window
 # Copy azure-cloud-node-manager.exe
 COPY --from=build /build/windows-machine-config-operator/cloud-provider-azure/azure-cloud-node-manager.exe .
 
-# Copy containerd.exe and containerd-shim-runhcs-v1.exe
+# Copy containerd.exe, containerd-shim-runhcs-v1.exe and containerd config containerd_conf.toml
 WORKDIR /payload/containerd/
 COPY --from=build /build/windows-machine-config-operator/containerd/bin/containerd.exe .
 COPY --from=build /build/windows-machine-config-operator/hcsshim/containerd-shim-runhcs-v1.exe .
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/containerd_conf.toml .
 
 # Copy kubelet.exe and kube-proxy.exe
 WORKDIR /payload/kube-node/

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -27,8 +27,7 @@ spec:
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
     be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
     or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
-    Through either method, the Windows instance to be configured must have the Docker container runtime installed. The operator
-    completes all the necessary steps to configure the underlying VM so that it can join the cluster as a worker node.
+    The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires a Red Hat OpenShift subscription. Users looking to deploy Windows containers workloads in
     production clusters should acquire a subscription before attempting to install this operator. Users without a subscription

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -51,10 +51,8 @@ func init() {
 
 func main() {
 	var debugLogging bool
-	var dockerRuntime bool
 
 	flag.BoolVar(&debugLogging, "debugLogging", false, "Log debug messages")
-	flag.BoolVar(&dockerRuntime, "dockerRuntime", true, "Container runtime to be used")
 
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
@@ -169,7 +167,7 @@ func main() {
 	}
 
 	// Setup all Controllers
-	winMachineReconciler, err := controllers.NewWindowsMachineReconciler(mgr, clusterConfig, watchNamespace, dockerRuntime)
+	winMachineReconciler, err := controllers.NewWindowsMachineReconciler(mgr, clusterConfig, watchNamespace)
 	if err != nil {
 		setupLog.Error(err, "unable to create Windows Machine reconciler")
 		os.Exit(1)
@@ -188,7 +186,7 @@ func main() {
 		setupLog.Error(err, "error removing invalid annotations from Linux nodes")
 	}
 
-	configMapReconciler, err := controllers.NewConfigMapReconciler(mgr, clusterConfig, watchNamespace, dockerRuntime)
+	configMapReconciler, err := controllers.NewConfigMapReconciler(mgr, clusterConfig, watchNamespace)
 	if err != nil {
 		setupLog.Error(err, "unable to create ConfigMap reconciler")
 		os.Exit(1)

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -25,8 +25,7 @@ spec:
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
     be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
     or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
-    Through either method, the Windows instance to be configured must have the Docker container runtime installed. The operator
-    completes all the necessary steps to configure the underlying VM so that it can join the cluster as a worker node.
+    The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires a Red Hat OpenShift subscription. Users looking to deploy Windows containers workloads in
     production clusters should acquire a subscription before attempting to install this operator. Users without a subscription

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -72,7 +72,7 @@ type ConfigMapReconciler struct {
 }
 
 // NewConfigMapReconciler returns a pointer to a ConfigMapReconciler
-func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string, dockerRuntime bool) (*ConfigMapReconciler, error) {
+func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string) (*ConfigMapReconciler, error) {
 	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating kubernetes clientset")
@@ -94,7 +94,6 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 			vxlanPort:            clusterConfig.Network().VXLANPort(),
 			prometheusNodeConfig: pc,
 			platform:             clusterConfig.Platform(),
-			dockerRuntime:        dockerRuntime,
 		},
 	}, nil
 }

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -53,8 +53,6 @@ type instanceReconciler struct {
 	recorder record.EventRecorder
 	// platform indicates the cloud on which the cluster is running
 	platform config.PlatformType
-	// dockerRuntime indicates if the container runtime used is docker or containerd
-	dockerRuntime bool
 }
 
 // ensureInstanceIsUpToDate ensures that the given instance is configured as a node and upgraded to the specifications
@@ -74,7 +72,7 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instanceInfo, r.signer,
-		labelsToApply, annotationsToApply, r.platform, r.dockerRuntime)
+		labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}
@@ -126,7 +124,7 @@ func (r *instanceReconciler) updateKubeletCA(node core.Node, contents []byte) er
 		return errors.Wrapf(err, "error creating instance for node %s", node.Name)
 	}
 	nodeConfig, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, winInstance,
-		r.signer, nil, nil, r.platform, r.dockerRuntime)
+		r.signer, nil, nil, r.platform)
 	if err != nil {
 		return errors.Wrapf(err, "error creating nodeConfig for instance %s", winInstance.Address)
 	}
@@ -186,7 +184,7 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	}
 
 	nc, err := nodeconfig.NewNodeConfig(r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instance, r.signer,
-		nil, nil, r.platform, r.dockerRuntime)
+		nil, nil, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -64,7 +64,7 @@ type WindowsMachineReconciler struct {
 }
 
 // NewWindowsMachineReconciler returns a pointer to a WindowsMachineReconciler
-func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string, dockerRuntime bool) (*WindowsMachineReconciler, error) {
+func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchNamespace string) (*WindowsMachineReconciler, error) {
 	// The client provided by the GetClient() method of the manager is a split client that will always hit the API
 	// server when writing. When reading, the client will either use a cache populated by the informers backing the
 	// controllers, or in certain cases read directly from the API server. It will read from the server both for
@@ -98,7 +98,6 @@ func NewWindowsMachineReconciler(mgr manager.Manager, clusterConfig cluster.Conf
 			watchNamespace:       watchNamespace,
 			prometheusNodeConfig: pc,
 			platform:             clusterConfig.Platform(),
-			dockerRuntime:        dockerRuntime,
 		},
 		machineClient: machineClient,
 	}, nil

--- a/docs/byoh-instance-pre-requisites.md
+++ b/docs/byoh-instance-pre-requisites.md
@@ -1,7 +1,6 @@
 # BYOH Instance Pre-requisites
 
 The following pre-requisites must be fulfilled in order to add a Windows BYOH node.
-* The Docker container runtime must be installed on the instance.
 * The instance must be on the same network as the Linux worker nodes in the cluster.
 * Port 22 must be open and running [an SSH server](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
 * Port 10250 must be open in order for log collection to function.

--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -95,14 +95,7 @@ In case no firewall rule exist, you must create it by running the following Powe
     New-NetFirewallRule -DisplayName 'OpenSSH Server (sshd)' -LocalPort 22 -Enabled True -Direction Inbound -Protocol TCP -Action Allow 
 ```
 
-## 4. Set up the container runtime
-
-Install the `docker` container runtime following the [Microsoft documentation](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).
-
-Alternatively, you can run the provided PowerShell script [install-docker.ps1](vsphere_ci/scripts/install-docker.ps1) 
-to programmatically install `docker` in the Windows VM.
-
-## 5. Set up incoming connection for container logs
+## 4. Set up incoming connection for container logs
 
 Create a new firewall rule in the Windows VM to allow incoming connections for container logs, usually 
 on TCP port `10250` by running the following PowerShell command:
@@ -111,7 +104,7 @@ on TCP port `10250` by running the following PowerShell command:
     New-NetFirewallRule -DisplayName "ContainerLogsPort" -LocalPort 10250 -Enabled True -Direction Inbound -Protocol TCP -Action Allow -EdgeTraversalPolicy Allow
 ```
 
-## 6. Generalize the virtual machine installation
+## 5. Generalize the virtual machine installation
 
 To deploy the Windows VM as a reusable image, you have to first generalize the VM removing computer-specific information 
 such as installed drivers. Running the `sysprep` command with a *unattend* answer file generalizes the image and 
@@ -138,7 +131,7 @@ where `<path/to/unattend.xml>` is the path to the customized answer file.
 Note: There is [a limit](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation#limits-on-how-many-times-you-can-run-sysprep)
 on how many times you can run the `sysprep` command.
 
-## 7. Set up the virtual machine template
+## 6. Set up the virtual machine template
 
 Once the `sysprep` command completes the Windows virtual machine will power off. 
 
@@ -150,7 +143,7 @@ Next, you need to convert this virtual machine, in Power-Off status, to a Templa
 |:---|
 |Figure 1. Steps to convert a VM to Template in vCenter|
 
-## 8. Using the virtual machine template
+## 7. Using the virtual machine template
 
 In order to use the recently created template, enter the template name in the [machineset](../README.md#configuring-windows-instances-provisioned-through-machinesets).
 

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -308,8 +308,7 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
 	// We don't need to pass the platform type here because this parameter is required for WMCB only.
 	// Here we just execute the "hostname" command.
-	win, err := windows.New("", "", "", instanceInfo, instanceSigner, "",
-		true)
+	win, err := windows.New("", "", "", instanceInfo, instanceSigner, "")
 	if err != nil {
 		return "", errors.Wrap(err, "error instantiating Windows instance")
 	}

--- a/pkg/internal/cni-conf-template.json
+++ b/pkg/internal/cni-conf-template.json
@@ -2,7 +2,9 @@
 	"CniVersion":"0.2.0",
 	"Name":"OVNKubernetesHybridOverlayNetwork",
 	"Type":"win-overlay",
+	"apiVersion": 2,
 	"Capabilities":{
+		"portMappings": true,
 		"Dns":true
 	},
 	"Ipam":{
@@ -11,23 +13,36 @@
 	},
 	"Policies":[
 		{
-			"Name":"EndpointPolicy",
-			"Value":{
-				"Type":"OutBoundNAT",
-				"ExceptionList":[
-					"service_network_cidr"
-				],
-				"DestinationPrefix":"",
-				"NeedEncap":false
+			"Name": "EndpointPolicy",
+			"Value": {
+				"Type": "OutBoundNAT",
+				"Settings": {
+					"ExceptionList": [
+						"service_network_cidr"
+					],
+					"DestinationPrefix": "",
+					"NeedEncap": false
+				}
 			}
 		},
 		{
-			"Name":"EndpointPolicy",
-			"Value":{
-				"Type":"ROUTE",
-				"ExceptionList":[],
-				"DestinationPrefix":"service_network_cidr",
-				"NeedEncap":true
+			"Name": "EndpointPolicy",
+			"Value": {
+				"Type": "SDNROUTE",
+				"Settings": {
+					"ExceptionList": [],
+					"DestinationPrefix": "service_network_cidr",
+					"NeedEncap": true
+				}
+			}
+		},
+		{
+			"Name": "EndpointPolicy",
+			"Value": {
+				"Type": "ProviderAddress",
+				"Settings": {
+					"ProviderAddress": "ip_host"
+				}
 			}
 		}
 	]

--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -1,0 +1,174 @@
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "C:\\ProgramData\\containerd\\root"
+state = "C:\\ProgramData\\containerd\\state"
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "\\\\.\\pipe\\containerd-containerd"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = false
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "k8s.gcr.io/pause:3.5"
+    selinux_category_range = 0
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = false
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
+      conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
+      conf_template = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runhcs-wcow-process"
+      disable_snapshot_annotations = false
+      discard_unpacked_layers = false
+      no_pivot = false
+      snapshotter = "windows"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
+          base_runtime_spec = ""
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runhcs.v1"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "C:\\ProgramData\\containerd\\root\\opt"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["windows/amd64", "linux/amd64"]
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["windows", "windows-lcow"]
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "C:\\Program Files\\containerd\\ocicrypt\\keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=C:\\Program Files\\containerd\\ocicrypt\\ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "C:\\Program Files\\containerd\\ocicrypt\\keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=C:\\Program Files\\containerd\\ocicrypt\\ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -53,7 +53,7 @@ version = 2
     max_container_log_line_size = 16384
     netns_mounts_under_state_dir = false
     restrict_oom_score_adj = false
-    sandbox_image = "k8s.gcr.io/pause:3.5"
+    sandbox_image = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
     selinux_category_range = 0
     stats_collect_period = 10
     stream_idle_timeout = "4h0m0s"
@@ -64,8 +64,8 @@ version = 2
     unset_seccomp_profile = ""
 
     [plugins."io.containerd.grpc.v1.cri".cni]
-      bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
-      conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
+      bin_dir = "C:\\k\\cni"
+      conf_dir = "C:\\k\\cni\\config"
       conf_template = ""
       max_conf_num = 1
 

--- a/pkg/nodeconfig/network_test.go
+++ b/pkg/nodeconfig/network_test.go
@@ -11,16 +11,24 @@ var tests = []struct {
 	name         string
 	policies     *policies
 	serviceCIDR  string
+	ip           string
 	errorMessage string
 }{
 	{name: "invalid policies in cniCfg struct",
-		policies:     mockInvalidPolicies(),
+		policies:     mockInvalidPolicyFields(),
 		serviceCIDR:  "10.128.0.0/14",
+		ip:           "10.0.137.49",
 		errorMessage: "invalid policy fields in cniConf struct"},
+
+	{name: "incorrect number of cniCfg policies",
+		policies:     mockInvalidPolicyCount(),
+		serviceCIDR:  "10.128.0.0/14",
+		ip:           "10.0.137.49",
+		errorMessage: "number of policies cannot be less than 3"},
 
 	{name: "valid policies in cniCfg struct",
 		policies:     mockValidPolicies(),
-		serviceCIDR:  "10.128.0.0/14",
+		ip:           "10.0.137.49",
 		errorMessage: ""},
 }
 
@@ -29,7 +37,7 @@ var tests = []struct {
 func TestPopulateCfgPoliciesError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := populateCfgPolicies(tt.policies, tt.serviceCIDR)
+			err := populateCfgPolicies(tt.policies, tt.serviceCIDR, tt.ip)
 			if tt.errorMessage == "" {
 				require.Nil(t, err, "Successful check for invalid CNI config template")
 			} else {
@@ -46,8 +54,9 @@ func TestPopulateCfgPoliciesError(t *testing.T) {
 func TestPopulateCfgPoliciesValues(t *testing.T) {
 	policies := mockValidPolicies()
 	serviceCIDR := "10.128.0.0/14"
-	_ = populateCfgPolicies(policies, serviceCIDR)
-	if (*policies)[0].Value.ExceptionList[0] != serviceCIDR || (*policies)[1].Value.DestinationPrefix != serviceCIDR {
+	ip := "10.0.137.49"
+	_ = populateCfgPolicies(policies, serviceCIDR, ip)
+	if (*policies)[0].Value.Settings.ExceptionList[0] != serviceCIDR || (*policies)[1].Value.Settings.DestinationPrefix != serviceCIDR {
 		t.Errorf("error populating policies in CNI config")
 	}
 }
@@ -57,9 +66,11 @@ func TestPopulateCfgPoliciesValues(t *testing.T) {
 func mockValidPolicies() *policies {
 	name := "EndPointPolicy"
 	exceptionList := []string{"10.132.0.0/16"}
-
-	value0 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
-	value1 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+	setting0 := &settings{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+	setting1 := &settings{ProviderAddress: "10.0.137.49"}
+	value0 := &value{"OutBoundNAT", *setting0}
+	value1 := &value{"SDNRoute", *setting0}
+	value2 := &value{"ProviderAddress", *setting1}
 
 	data0 := struct {
 		Name  string `json:"name"`
@@ -71,17 +82,25 @@ func mockValidPolicies() *policies {
 		Value value  `json:"value"`
 	}{name, *value1}
 
-	return &policies{data0, data1}
+	data2 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value2}
+
+	return &policies{data0, data1, data2}
 }
 
-// mockValidPolicies is a helper function to create a set of invalid CNI config policies
+// mockInvalidPolicyFields is a helper function to create a set of invalid CNI config policies
 // for testing populateCfgPolicies()
-func mockInvalidPolicies() *policies {
+func mockInvalidPolicyFields() *policies {
 	name := "EndPointPolicy"
 	exceptionList := []string{""}
-
-	value0 := &value{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
-	value1 := &value{ExceptionList: exceptionList, DestinationPrefix: ""}
+	setting0 := &settings{ExceptionList: exceptionList, DestinationPrefix: "10.132.0.0/16"}
+	value0 := &value{"OutBoundNAT", *setting0}
+	setting1 := &settings{ExceptionList: exceptionList, DestinationPrefix: ""}
+	value1 := &value{"SDNRoute", *setting1}
+	setting2 := &settings{ProviderAddress: ""}
+	value2 := &value{"ProviderAddress", *setting2}
 
 	policy0 := struct {
 		Name  string `json:"name"`
@@ -93,5 +112,20 @@ func mockInvalidPolicies() *policies {
 		Value value  `json:"value"`
 	}{name, *value1}
 
-	return &policies{policy0, policy1}
+	policy2 := struct {
+		Name  string `json:"name"`
+		Value value  `json:"value"`
+	}{name, *value2}
+
+	return &policies{policy0, policy1, policy2}
+}
+
+// mockInvalidPolicyCount is a helper function to create a set of CNI config policies
+// with incorrect number of policies
+func mockInvalidPolicyCount() *policies {
+	policies := *mockValidPolicies()
+	if len(policies) > 0 {
+		policies = policies[:len(policies)-1]
+	}
+	return &policies
 }

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -414,8 +414,8 @@ func (nc *nodeConfig) configureCNI() error {
 	if err := nc.network.setHostSubnet(nc.node.Annotations[HybridOverlaySubnet]); err != nil {
 		return errors.Wrap(err, "error populating host subnet in node network")
 	}
-	// populate the CNI config file with the host subnet and the service network CIDR
-	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, payload.CNIConfigTemplatePath)
+	// populate the CNI config file with the host subnet, service network CIDR and IP address of the Windows VM
+	configFile, err := nc.network.populateCniConfig(nc.clusterServiceCIDR, nc.GetIPv4Address(), payload.CNIConfigTemplatePath)
 	if err != nil {
 		return errors.Wrapf(err, "error populating CNI config file %s", configFile)
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -123,7 +123,7 @@ func discoverKubeAPIServerEndpoint() (string, error) {
 // hostName having a value will result in the VM's hostname being changed to the given value.
 func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPort string,
 	instanceInfo *instance.Info, signer ssh.Signer, additionalLabels,
-	additionalAnnotations map[string]string, platformType configv1.PlatformType, dockerRuntime bool) (*nodeConfig, error) {
+	additionalAnnotations map[string]string, platformType configv1.PlatformType) (*nodeConfig, error) {
 	var err error
 
 	if nodeConfigCache.workerIgnitionEndPoint == "" {
@@ -152,7 +152,7 @@ func NewNodeConfig(clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPor
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
 	win, err := windows.New(nodeConfigCache.workerIgnitionEndPoint, clusterDNS, vxlanPort,
-		instanceInfo, signer, string(platformType), dockerRuntime)
+		instanceInfo, signer, string(platformType))
 	if err != nil {
 		return nil, errors.Wrap(err, "error instantiating Windows instance from VM")
 	}

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -25,6 +25,8 @@ const (
 	ContainerdPath = payloadDirectory + "/containerd/containerd.exe"
 	//HcsshimPath contains the path of the hcsshim binary. The container image should already have this binary mounted
 	HcsshimPath = payloadDirectory + "/containerd/containerd-shim-runhcs-v1.exe"
+	// ContainerdConfPath contains the path of the containerd config file.
+	ContainerdConfPath = payloadDirectory + "/containerd/containerd_conf.toml"
 	// IgnoreWgetPowerShellPath contains the path of the powershell script which allows wget to ignore certs. The
 	// container image should already have this mounted
 	IgnoreWgetPowerShellPath = payloadDirectory + "/powershell/wget-ignore-cert.ps1"

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -131,6 +131,7 @@ func getFilesToTransfer() (map[*payload.FileInfo]string, error) {
 		payload.AzureCloudNodeManagerPath: k8sDir,
 		payload.ContainerdPath:            ContainerdDir,
 		payload.HcsshimPath:               ContainerdDir,
+		payload.ContainerdConfPath:        ContainerdDir,
 	}
 	files := make(map[*payload.FileInfo]string)
 	for src, dest := range srcDestPairs {

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -83,9 +83,6 @@ func (tc *testContext) testBYOHRemoval(t *testing.T) {
 func (tc *testContext) checkDirsDoNotExist(address string) (bool, error) {
 	command := ""
 
-	// TODO: Remove appending containerd directory when we default to using runtime containerd
-	windows.RequiredDirectories = append(windows.RequiredDirectories, windows.ContainerdDir)
-
 	for _, dir := range windows.RequiredDirectories {
 		command += fmt.Sprintf("if ((Test-Path %s) -eq $true) { Write-Output %s exists}", dir, dir)
 	}

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -21,6 +21,7 @@ func testNodeLogs(t *testing.T) {
 		"kube-proxy/kube-proxy.exe.INFO",
 		"hybrid-overlay/hybrid-overlay.log",
 		"kubelet/kubelet.log",
+		"containerd/containerd.log",
 	}
 	optionalLogs := []string{
 		"kube-proxy/kube-proxy.exe.ERROR",


### PR DESCRIPTION
This PR makes the required CNI directory changes to the default containerd config file and stores it in the payload directory. It also creates the Windows containerd service using the config file along with the logging options and starts the service on the Windows node.