### PR TITLE
WINC-602: [wmco] Support Windows Server 2022

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -185,7 +185,7 @@ get_vsphere_ms() {
 
   # set golden image template name
   # TODO: read from parameter
-  template="windows-golden-images/windows-server-2004-template"
+  template="windows-golden-images/windows-server-2022-template-networkHotfix"
 
   # TODO: Reduce the number of API calls, make just one call
   #       to `oc get machines` and pass the data around. This is the

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -70,9 +70,6 @@ const (
 	// and expose metrics at endpoint with default port :9182 and default URL path /metrics
 	windowsExporterServiceArgs = "--collectors.enabled " +
 		"cpu,cs,logical_disk,net,os,service,system,textfile,container,memory,cpu_info"
-	// remotePowerShellCmdPrefix holds the PowerShell prefix that needs to be prefixed  for every remote PowerShell
-	// command executed on the remote Windows VM
-	remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPolicy Bypass "
 	// serviceQueryCmd is the Windows command used to query a service
 	serviceQueryCmd = "sc.exe qc "
 	// serviceNotFound is part of the error output returned when a service does not exist. 1060 is an error code
@@ -285,7 +282,7 @@ func (vm *windows) FileExists(path string) (bool, error) {
 
 func (vm *windows) Run(cmd string, psCmd bool) (string, error) {
 	if psCmd && !vm.defaultShellPowerShell {
-		cmd = remotePowerShellCmdPrefix + cmd
+		cmd = formatRemotePowerShellCommand(cmd)
 	} else if !psCmd && vm.defaultShellPowerShell {
 		// When running cmd through powershell, double quotes can cause parsing issues, so replace with single quotes
 		// CMD doesn't treat ' as quotes when processing commands, so the quotes must be changed on a case by case basis
@@ -462,8 +459,7 @@ func (vm *windows) ConfigureCNI(configFile string) error {
 
 	cniConfigDest := cniConfDir + filepath.Base(configFile)
 	// run the configure-cni command on the Windows VM
-	configureCNICmd := k8sDir + "wmcb.exe configure-cni --cni-dir=\"" +
-		cniDir + " --cni-config=\"" + cniConfigDest
+	configureCNICmd := k8sDir + "wmcb.exe configure-cni --cni-dir=" + cniDir + " --cni-config=" + cniConfigDest
 
 	out, err := vm.Run(configureCNICmd, true)
 	if err != nil {
@@ -859,12 +855,12 @@ func (vm *windows) waitForServiceToRun(serviceName string) error {
 // createHNSEndpoint makes a request to create a new HNS endpoint for the Hybrid Overlay network on the VM. On success,
 // the IP of the endpoint will be returned.
 func (vm *windows) createHNSEndpoint() (string, error) {
-	cmd := "\"Import-Module -DisableNameChecking " + hnsPSModule + "; " +
+	cmd := "Import-Module -DisableNameChecking " + hnsPSModule + "; " +
 		"$net = (Get-HnsNetwork | where { $_.Name -eq '" + OVNKubeOverlayNetwork + "' }); " +
 		"$endpoint = New-HnsEndpoint -NetworkId $net.ID -Name VIPEndpoint; " +
 		"Attach-HNSHostEndpoint -EndpointID $endpoint.ID -CompartmentID 1; " +
 		"(Get-NetIPConfiguration -AllCompartments -All -Detailed | " +
-		"where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()\""
+		"where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()"
 	out, err := vm.Run(cmd, true)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get source VIP")
@@ -921,7 +917,7 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 
 // removeHNSNetwork removes the given HNS network.
 func (vm *windows) removeHNSNetwork(networkName string) error {
-	cmd := getHNSNetworkCmd(networkName) + " | Remove-HnsNetwork;\""
+	cmd := getHNSNetworkCmd(networkName) + " | Remove-HnsNetwork;"
 	// PowerShell returns error waiting without exit status or signal error when the OVNKubeOverlayNetwork is removed.
 	if out, err := vm.Run(cmd, true); err != nil && !(networkName == OVNKubeOverlayNetwork && strings.Contains(err.Error(), cmdExitNoStatus)) {
 		return errors.Wrapf(err, "failed to remove %s HNS network with output: %s", networkName, out)
@@ -930,6 +926,13 @@ func (vm *windows) removeHNSNetwork(networkName string) error {
 }
 
 // Generic helper methods
+
+// formatRemotePowerShellCommand returns a formatted string, prepended with the required PowerShell prefix and
+// surrounding quotes needed to execute the given command on a remote Windows VM
+func formatRemotePowerShellCommand(command string) string {
+	remotePowerShellCmdPrefix := "powershell.exe -NonInteractive -ExecutionPolicy Bypass"
+	return fmt.Sprintf("%s \"%s\"", remotePowerShellCmdPrefix, command)
+}
 
 // mkdirCmd returns the Windows command to create a directory if it does not exists
 func mkdirCmd(dirName string) string {
@@ -944,5 +947,5 @@ func rmDirCmd(dirName string) string {
 
 // getHNSNetworkCmd returns the Windows command to get HNS network by name
 func getHNSNetworkCmd(networkName string) string {
-	return "\"Get-HnsNetwork | where { $_.Name -eq '" + networkName + "'}"
+	return "Get-HnsNetwork | where { $_.Name -eq '" + networkName + "'}"
 }

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -121,14 +121,14 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 	windowsAMIFilterName := "name"
 	windowsAMIFilterValue := ""
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
-	// The ami's will have the name format: Windows_Server-2019-English-Full-ContainersLatest-2020.01.15
+	// The ami's will have the name format: Windows_Server-2022-English-Full-ContainersLatest-2022.01.19
 	// so the question marks will match the date of creation
 	// The image obtained by using windowsAMIFilterValue is compatible with the test container image -
-	// "mcr.microsoft.com/powershell:lts-nanoserver-2004" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
+	// "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
 	// If the windowsAMIFilterValue changes, the test container image also needs to be changed.
-	// if hasCustomVXLANPort is set use 2004 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
+	// if hasCustomVXLANPort is set use 2022 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
 	if hasCustomVXLANPort {
-		windowsAMIFilterValue = "Windows_Server-2004-English-Core-ContainersLatest-????.??.??"
+		windowsAMIFilterValue = "Windows_Server-2022-English-Full-ContainersLatest-????.??.??"
 	} else {
 		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	}

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -47,7 +47,7 @@ func (p *Provider) newVSphereMachineProviderSpec(clusterID string) (*mapi.VSpher
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2004-template"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-networkHotfix"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -16,7 +16,7 @@ var (
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 	// deploymentRetries is the amount of time to retry creating a Windows Server deployment, to compensate for the
-	// time it takes to download the Server2019 image to the node
+	// time it takes to download the Server image to the node
 	deploymentRetries = 10
 )
 


### PR DESCRIPTION
This PR removes SAC Windows Server 2004 (EOL as of 2021-12-14) from our CI and docs,
and replaces it with LTSC Windows Server 2022 
(support announced here kubernetes/kubernetes#104438, EOL is 2026-10-13).
It also improves documentation around building the vSphere golden image using Packer.

Windows Server 2022 is tested in the vSphere environments. 
The golden image is built with a private networking OS fix supplied my Microsoft, 
so official support is on hold until they release the patch publicly.
Support on AWS and Azure is not included in this work.