### PR TITLE
[csr_controller] RetryOnConflict in CSR approvals

### DIFF
--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -96,7 +96,8 @@ func (a *Approver) Approve() error {
 
 	if _, err := a.k8sclientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.Background(),
 		a.csr.Name, a.csr, meta.UpdateOptions{}); err != nil {
-		return errors.Wrapf(err, "could not update conditions for approval CSR: %s", a.csr.Name)
+		// have to return err itself here (not wrapped inside another error) so it can be identified as a conflict
+		return err
 	}
 	a.log.Info("CSR approved", "CSR", a.csr.Name)
 	return nil


### PR DESCRIPTION
This PR consolidates the retry logic introduced in 223c8b95202a17b7072743bea44010ce3f5700c9 using [RetryOnConflict](https://github.com/kubernetes/client-go/blob/v0.23.3/util/retry/util.go#L103).
