### PR TITLE
WINC-607: Add support for platform=none in e2e test suite (Cont.)

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -165,6 +165,9 @@ ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
 
 # Changes needed for our CI
 
+# jq is needed in e2e test script to count the number of data items in the windows-instances ConfigMap
+RUN yum install -y jq
+
 # Install client binaries
 COPY --from=build /build/oc /usr/bin/oc
 COPY --from=build /build/kubectl /usr/bin/kubectl

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -115,7 +115,10 @@ func testWindowsNodeDeletion(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
 
+	// set expected node count to zero, since all Windows Nodes should be deleted in the test
+	expectedNodeCount := int32(0)
 	// Get all the Machines created by the e2e tests
+	// For platform=none, the resulting slice is empty
 	e2eMachineSets, err := testCtx.client.Machine.MachineSets(clusterinfo.MachineAPINamespace).List(context.TODO(),
 		meta.ListOptions{LabelSelector: clusterinfo.MachineE2ELabel + "=true"})
 	require.NoError(t, err, "error listing MachineSets")
@@ -126,20 +129,18 @@ func testWindowsNodeDeletion(t *testing.T) {
 			break
 		}
 	}
+	// skip the scale down step if there is no MachineSet with Windows label
+	if windowsMachineSetWithLabel != nil {
+		// Scale the Windows MachineSet to 0
+		windowsMachineSetWithLabel.Spec.Replicas = &expectedNodeCount
+		_, err = testCtx.client.Machine.MachineSets(clusterinfo.MachineAPINamespace).Update(context.TODO(),
+			windowsMachineSetWithLabel, meta.UpdateOptions{})
+		require.NoError(t, err, "error updating Windows MachineSet")
 
-	require.NotNil(t, windowsMachineSetWithLabel, "could not find MachineSet with Windows label")
-
-	// Scale the Windows MachineSet to 0
-	expectedNodeCount := int32(0)
-	windowsMachineSetWithLabel.Spec.Replicas = &expectedNodeCount
-	_, err = testCtx.client.Machine.MachineSets(clusterinfo.MachineAPINamespace).Update(context.TODO(),
-		windowsMachineSetWithLabel, meta.UpdateOptions{})
-	require.NoError(t, err, "error updating Windows MachineSet")
-
-	// we are waiting 10 minutes for all windows machines to get deleted.
-	err = testCtx.waitForWindowsNodes(expectedNodeCount, true, false, false)
-	require.NoError(t, err, "Windows node deletion failed")
-
+		// we are waiting 10 minutes for all windows machines to get deleted.
+		err = testCtx.waitForWindowsNodes(expectedNodeCount, true, false, false)
+		require.NoError(t, err, "Windows node deletion failed")
+	}
 	t.Run("BYOH node removal", testCtx.testBYOHRemoval)
 
 	// Cleanup all the MachineSets created by us.


### PR DESCRIPTION
Follow-up to https://github.com/openshift/windows-machine-config-operator/pull/858