### PR TITLE
WINC-607: [build] Install jq in CI Dockerfile

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -8,7 +8,8 @@ LABEL stage=build
 WORKDIR /build/
 
 # dos2unix is needed to build CNI plugins
-RUN yum install -y dos2unix
+# jq is needed in e2e test script to count the number of data items in the windows-instances ConfigMap
+RUN yum install -y dos2unix jq
 
 # Download client binaries
 # TODO: Remove this, see https://issues.redhat.com/browse/WINC-520 


### PR DESCRIPTION
This PR Install `jq` in CI Dockerfile. `jq`requirement was introduced in [c1fb113](https://github.com/openshift/windows-machine-config-operator/pull/858/commits/c1fb113a4043cc0cb98ef1cfdf568d21010f095f#diff-f6f13ef4e3c83b5e22c436df5b1a4b24fd2c22a80d25855668b41828bcc05e12R194).