### PR TITLE
Stop requiring kube-proxy ERROR and WARNING logs

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -8,45 +9,57 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // testNodeLogs ensures that all required log files were created, and copies them to the test's artifact directory
 // It also tests that 'oc adm node-logs' works with the nodes created by WMCO.
 func testNodeLogs(t *testing.T) {
 	// All these paths are relative to /var/log/
-	logFiles := []string{
+	mandatoryLogs := []string{
 		"kube-proxy/kube-proxy.exe.INFO",
-		"kube-proxy/kube-proxy.exe.ERROR",
-		"kube-proxy/kube-proxy.exe.WARNING",
 		"hybrid-overlay/hybrid-overlay.log",
 		"kubelet/kubelet.log",
+	}
+	optionalLogs := []string{
+		"kube-proxy/kube-proxy.exe.ERROR",
+		"kube-proxy/kube-proxy.exe.WARNING",
 	}
 
 	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
 	for _, node := range gc.allNodes() {
 		nodeDir := filepath.Join(nodeArtifacts, node.Name)
-		for _, file := range logFiles {
+		for _, file := range mandatoryLogs {
 			// A subtest is useful here to attempt to get all the logs and not bail on the first error
 			t.Run(node.Name+"/"+file, func(t *testing.T) {
-				// Use oc to read the expected log files, using this instead of API calls as we are supporting compatibility
-				// with 'oc adm node-logs', so we should test directly with the oc tool.
-				cmd := exec.Command("oc", "adm", "node-logs", "--path="+file, node.Name)
-				out, err := cmd.Output()
-				require.NoErrorf(t, err, "failed to get file %s from node %s: %s", file, node.Name, out)
-
-				// Save log files to the artifact directory
-				splitPath := strings.Split(file, "/")
-				require.Greater(t, len(splitPath), 1)
-				err = os.MkdirAll(filepath.Join(nodeDir, splitPath[0]), os.ModePerm)
-				require.NoError(t, err, "failed to create log directory")
-				outputFile := filepath.Join(nodeDir, splitPath[0], filepath.Base(file))
-				err = ioutil.WriteFile(outputFile, out, os.ModePerm)
-				// This doesn't actually indicate an error, but because the artifacts are important for debugging issues
-				// lets make sure we know if there's an issue saving them, in a non-ignorable way
-				assert.NoErrorf(t, err, "error writing to %s", outputFile)
+				assert.NoError(t, retrieveLog(node.Name, file, nodeDir))
 			})
 		}
+		// Grab the optional logs for debugging purposes
+		for _, file := range optionalLogs {
+			_ = retrieveLog(node.Name, file, nodeDir)
+		}
 	}
+}
+
+// retrieveLog grabs the log specified by the given srcPath from the given node, and writes it to the local destination
+// directory
+func retrieveLog(nodeName, srcPath, destDir string) error {
+	cmd := exec.Command("oc", "adm", "node-logs", "--path="+srcPath, nodeName)
+	out, err := cmd.Output()
+	if err != nil {
+		return errors.Wrap(err, "unable to use oc adm to get log")
+	}
+	// Save log files to the artifact directory
+	splitPath := strings.Split(srcPath, "/")
+	if len(splitPath) < 2 {
+		return fmt.Errorf("unexpected format for path %s", srcPath)
+	}
+	err = os.MkdirAll(filepath.Join(destDir, splitPath[0]), os.ModePerm)
+	if err != nil {
+		return errors.Wrap(err, "failed to create log directory")
+	}
+	outputFile := filepath.Join(destDir, splitPath[0], filepath.Base(srcPath))
+	return ioutil.WriteFile(outputFile, out, os.ModePerm)
 }


### PR DESCRIPTION
This PR drops the requirement of there being .ERROR and .WARNING
logs for kube-proxy. These are only present if there was logging at
those log levels