### PR TITLE
[release4.9] WINC-607: Add support for platform=none in e2e test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ unit:
 run-ci-e2e-test:
 	hack/run-ci-e2e-test.sh -t basic
 
+.PHONY: run-ci-e2e-byoh-test
+run-ci-e2e-byoh-test:
+	hack/run-ci-e2e-test.sh -t basic -m 0
+
 .PHONY: run-ci-e2e-upgrade-test
 run-ci-e2e-upgrade-test:
 	hack/run-ci-e2e-test.sh -t upgrade

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -167,3 +167,29 @@ transform_csv() {
   fi
   sed -i "s|"$1"|"$2"|g" $MANIFEST_LOC/manifests/windows-machine-config-operator.clusterserviceversion.yaml
 }
+
+# creates the `windows-instances` ConfigMap
+# Parameters:
+#  1: the ConfigMap data section
+createWindowsInstancesConfigMap() {
+  DATA=$1
+  if [[ -z "$DATA" ]]; then
+    error-exit "ConfigMap data cannot be empty"
+  fi
+  cat <<EOF | oc apply -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: windows-instances
+  namespace: ${WMCO_DEPLOY_NAMESPACE}
+${DATA}
+EOF
+}
+
+# returns the number of instances from `windows-instances` ConfigMap
+getWindowsInstanceCountFromConfigMap() {
+ oc get configmaps \
+   windows-instances \
+   -n "${WMCO_DEPLOY_NAMESPACE}" \
+   -o json | jq '.data | length'
+}

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -10,6 +10,7 @@ import (
 	oc "github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	awsProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/aws"
 	azureProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/azure"
+	noneProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/none"
 	vSphereProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
 
@@ -37,6 +38,8 @@ func NewCloudProvider(hasCustomVXLANPort bool) (CloudProvider, error) {
 		return azureProvider.New(openshift, hasCustomVXLANPort)
 	case config.VSpherePlatformType:
 		return vSphereProvider.New(openshift)
+	case config.NonePlatformType:
+		return noneProvider.New(openshift)
 	default:
 		return nil, fmt.Errorf("the '%v' cloud provider is not supported", provider)
 	}

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -4,7 +4,7 @@ import (
 	"github.com/pkg/errors"
 
 	config "github.com/openshift/api/config/v1"
-	mapi "github.com/openshift/api/machine/v1beta1"
+	mapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 )
 

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -1,0 +1,31 @@
+package none
+
+import (
+	"github.com/pkg/errors"
+
+	config "github.com/openshift/api/config/v1"
+	mapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+)
+
+// Provider is a provider struct for testing platform=none
+type Provider struct {
+	oc *clusterinfo.OpenShift
+}
+
+// New returns a Provider implementation for platform=none
+func New(clientset *clusterinfo.OpenShift) (*Provider, error) {
+	return &Provider{
+		oc: clientset,
+	}, nil
+}
+
+// GenerateMachineSet is not supported for platform=none and throws an exception
+func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*mapi.MachineSet, error) {
+	return nil, errors.New("MachineSet generation not supported for platform=none")
+}
+
+// GetType returns the platform type for platform=none
+func (p *Provider) GetType() config.PlatformType {
+	return config.NonePlatformType
+}


### PR DESCRIPTION
Manual backport of #858 to fix the location of openshift/mapi api used in all branches before release-4.10.
