### PR TITLE
WINC-715: WMCO creates and maintains Windows services ConfigMap

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,12 +3,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# returns the operator version in `Version+GitHash` format
+# returns the operator version in `Version-GitHash` format
 # Takes a semver as an argument. This should be the version present in the WMCO CSV
 add_git_data_to_version() {
   local WMCO_SEMVER=$1
   GIT_COMMIT=$(git rev-parse --short HEAD)
-  FULL_VERSION="${WMCO_SEMVER}+${GIT_COMMIT}"
+  # The commit hash retreived varies in length, so we will standardize to length received from the operator image
+  GIT_COMMIT="${GIT_COMMIT:0:7}"
+  FULL_VERSION="${WMCO_SEMVER}-${GIT_COMMIT}"
 
   # If any files that affect the building of the operator binary have been changed, append "-dirty" to the version.
   if [ -n "$(git status version tools.go go.mod go.sum vendor Makefile build main.go hack pkg controllers --porcelain)" ]; then

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/operator-framework/operator-lib/leader"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -23,6 +24,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/metrics"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig/payload"
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/version"
 	//+kubebuilder:scaffold:imports
 )
@@ -224,6 +226,13 @@ func main() {
 	// Configure the metric resources
 	if err := metricsConfig.Configure(ctx); err != nil {
 		setupLog.Error(err, "error setting up metrics")
+		os.Exit(1)
+	}
+
+	// Create the singleton Windows services ConfigMap
+	if err := configMapReconciler.EnsureServicesConfigMapExists(); err != nil {
+		setupLog.Error(err, "error ensuring object exists", "singleton", types.NamespacedName{Namespace: watchNamespace,
+			Name: servicescm.Name})
 		os.Exit(1)
 	}
 

--- a/controllers/configmap_controller_test.go
+++ b/controllers/configmap_controller_test.go
@@ -8,6 +8,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
@@ -21,10 +22,20 @@ func TestIsValidConfigMap(t *testing.T) {
 		isValidConfigMap bool
 	}{
 		{
-			name: "valid ConfigMap",
+			name: "valid instances ConfigMap",
 			configMapObj: &core.ConfigMap{
 				ObjectMeta: meta.ObjectMeta{
 					Name:      wiparser.InstanceConfigMap,
+					Namespace: watchNamespace,
+				},
+			},
+			isValidConfigMap: true,
+		},
+		{
+			name: "valid services ConfigMap",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      servicescm.Name,
 					Namespace: watchNamespace,
 				},
 			},
@@ -46,10 +57,20 @@ func TestIsValidConfigMap(t *testing.T) {
 			isValidConfigMap: false,
 		},
 		{
-			name: "invalid namespace",
+			name: "invalid instances ConfigMap namespace",
 			configMapObj: &core.ConfigMap{
 				ObjectMeta: meta.ObjectMeta{
 					Name:      wiparser.InstanceConfigMap,
+					Namespace: "invalid",
+				},
+			},
+			isValidConfigMap: false,
+		},
+		{
+			name: "invalid services ConfigMap namespace",
+			configMapObj: &core.ConfigMap{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      servicescm.Name,
 					Namespace: "invalid",
 				},
 			},

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -1,0 +1,24 @@
+package servicescm
+
+import (
+	"fmt"
+
+	"github.com/openshift/windows-machine-config-operator/version"
+)
+
+// NamePrefix is the prefix of all Windows services ConfigMap names
+const NamePrefix = "windows-services-"
+
+// Name is the full name of the Windows services ConfigMap, detailing the service config for a specific WMCO version
+var Name string
+
+// init runs once, initializing global variables
+func init() {
+	Name = getName()
+}
+
+// getName returns the name of the ConfigMap, using the following naming convention:
+// windows-services-<WMCOFullVersion>
+func getName() string {
+	return fmt.Sprintf("%s%s", NamePrefix, version.Get())
+}

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -17,6 +17,52 @@ func init() {
 	Name = getName()
 }
 
+// NodeCmdArg describes a Windows command variable and how its value can be populated
+type NodeCmdArg struct {
+	// Name is the variable name as it appears in commands
+	Name string `json:"name"`
+	// NodeObjectJsonPath is the JSON path of a field within an instance's Node object.
+	// The value of this field is the value of the variable
+	NodeObjectJsonPath string `json:"nodeObjectJsonPath"`
+}
+
+// PowershellCmdArg describes a PowerShell variable and how its value can be populated
+type PowershellCmdArg struct {
+	// Name is the variable name as it appears in commands
+	Name string `json:"name"`
+	// Path is the location of a PowerShell script whose output is the value of the variable
+	Path string `json:"path"`
+}
+
+// Service represents the configuration spec of a Windows service
+type Service struct {
+	// Name is the name of the Windows service
+	Name string `json:"name"`
+	// Command is the command that will launch the Windows service. This could potentially include strings whose values
+	// will be derived from NodeVariablesInCommand and PowershellVariablesInCommand.
+	// Before the command is run on an instance, all node and PowerShell variables will be replaced by their values
+	Command string `json:"path"`
+	// NodeVariablesInCommand holds all variables in the service command whose values are sourced from a node object
+	NodeVariablesInCommand []NodeCmdArg `json:"nodeVariablesInCommand,omitempty"`
+	// PowershellVariablesInCommand holds all variables in the command whose values are sourced from a PowerShell script
+	PowershellVariablesInCommand []PowershellCmdArg `json:"powershellVariablesInCommand,omitempty"`
+	// Dependencies is a list of service names that this service is dependent on
+	Dependencies []string `json:"dependencies,omitempty"`
+	// Bootstrap is a boolean flag indicating whether this service should be handled as part of node bootstrapping
+	Bootstrap bool `json:"bootstrap"`
+	// Priority is a non-negative integer that will be used to order the creation of the services.
+	// Priority 0 is created first
+	Priority uint `json:"priority"`
+}
+
+// FileInfo contains the path and checksum of a file copied to an instance by WMCO
+type FileInfo struct {
+	// Path is the filepath of a file on an instance
+	Path string `json:"path"`
+	// Checksum is the checksum of the file specified at Path. It is used to validate that a file has not been changed
+	Checksum string `json:"checksum"`
+}
+
 // getName returns the name of the ConfigMap, using the following naming convention:
 // windows-services-<WMCOFullVersion>
 func getName() string {

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -1,0 +1,472 @@
+package servicescm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	// The following cases test only the structure of the services ConfigMap.
+	// Content validtion is tested below through test methods upon the helpers.
+	testCases := []struct {
+		name        string
+		input       map[string]string
+		expectedErr bool
+	}{
+		{
+			name: "both expected keys",
+			input: map[string]string{
+				servicesKey: "[]",
+				filesKey:    "[]",
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "no keys",
+			input:       map[string]string{},
+			expectedErr: true,
+		},
+		{
+			name: "only 1 of the expected keys",
+			input: map[string]string{
+				servicesKey: "[]",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "correct number but incorrect key",
+			input: map[string]string{
+				filesKey:  "[]",
+				"testKey": "[]",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "too many keys",
+			input: map[string]string{
+				servicesKey: "[]",
+				filesKey:    "[]",
+				"testKey":   "[]",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cmData, err := Parse(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, cmData.Services)
+			assert.NotNil(t, cmData.Files)
+		})
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	// Ensure that the ConfigMap we generate internally as the source of truth passes our own validation functions
+	configMap, err := Generate(Name, "testNamespace")
+	require.NoError(t, err)
+
+	_, err = Parse(configMap.Data)
+	require.NoError(t, err)
+}
+
+func TestValidateDependencies(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []Service
+		expectedErr bool
+	}{
+		{
+			name:        "empty services list",
+			input:       []Service{},
+			expectedErr: false,
+		},
+		{
+			name: "no dependencies",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid dependencies",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "bootstrap depends on all non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{"test-controller-service", "test-controller-service-2"},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap in the middle of non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{"test-controller-service"},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateDependencies(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePriorities(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []Service
+		expectedErr bool
+	}{
+		{
+			name:        "empty services list",
+			input:       []Service{},
+			expectedErr: false,
+		},
+		{
+			name: "valid priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     5,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid repeated priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "new-bootstrap-service-2",
+					Command:      "C:\\tnew-bootstrap-service-2",
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "overlapping bootstrap and non-bootstrap priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     5,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap lower priority than all non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     2,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service"},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap in the middle of non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePriorities(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -49,6 +49,7 @@ func creationTestSuite(t *testing.T) {
 		return
 	}
 	t.Run("Node Metadata", testNodeMetadata)
+	t.Run("Services ConfigMap validation", testServicesConfigMap)
 	t.Run("Services running", testExpectedServicesRunning)
 	t.Run("NodeIP Arg", testNodeIPArg)
 	t.Run("NodeTaint validation", testNodeTaint)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -199,7 +199,7 @@ func getWMCOVersion() (string, error) {
 		return "", errors.Wrapf(err, "error running %s", cmd.String())
 	}
 	// out is formatted like:
-	// ./build/_output/bin/windows-machine-config-operator version: "0.0.1+4165dda-dirty", go version: "go1.13.7 linux/amd64"
+	// windows-machine-config-operator version: "5.0.0-1b759bf1-dirty", go version: "go1.17.5 linux/amd64"
 	versionSplit := strings.Split(string(out), "\"")
 	if len(versionSplit) < 3 {
 		return "", fmt.Errorf("unexpected version output")

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -32,6 +32,7 @@ import (
 	nc "github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
@@ -190,7 +191,9 @@ func (tc *testContext) getClusterKubeVersion() (string, error) {
 	return strings.Join(versionSplit[0:2], "."), nil
 }
 
-// getWMCOVersion returns the version of the operator. This is sourced from the WMCO binary used to create the operator image.
+// getWMCOVersion returns the version of the operator. This is sourced from the WMCO binary used
+// to create the operator image. We cannot use version.Get() as there is no easy way to populate ldflags
+// when running e2e tests without having to maintain the WMCO version in another location.
 // This function will return an error if the binary is missing.
 func getWMCOVersion() (string, error) {
 	cmd := exec.Command(wmcoPath, "version")
@@ -462,6 +465,103 @@ func testExpectedServicesRunning(t *testing.T) {
 			}
 		})
 	}
+}
+
+// testServicesConfigMap tests multiple aspects of expected functionality for the services ConfigMap
+// 1. It exists on operator startup 2. It is re-created when deleted 3. It is recreated if invalid contents are detected
+func testServicesConfigMap(t *testing.T) {
+	tc, err := NewTestContext()
+	require.NoError(t, err)
+
+	operatorVersion, err := getWMCOVersion()
+	require.NoError(t, err)
+	servicesConfigMapName := servicescm.NamePrefix + operatorVersion
+
+	// Ensure the windows-services ConfigMap exists in the cluster
+	_, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(),
+		servicesConfigMapName, meta.GetOptions{})
+	require.NoErrorf(t, err, "error retrieving ConfigMap: %s", servicesConfigMapName)
+
+	err = tc.testServicesCMRegeneration(servicesConfigMapName)
+	require.NoErrorf(t, err, "error ensuring ConfigMap %s is re-created when deleted", servicesConfigMapName)
+
+	err = tc.testInvalidServicesCM(servicesConfigMapName)
+	require.NoError(t, err, "error testing handling of invalid ConfigMap")
+}
+
+// testServicesCMRegeneration tests that if the services ConfigMap is deleted, a valid one is re-created in its place
+func (tc *testContext) testServicesCMRegeneration(cmName string) error {
+	err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Delete(context.TODO(), cmName, meta.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	_, err = tc.waitForValidWindowsServicesConfigMap(cmName)
+	return err
+}
+
+// testInvalidServicesCM tests that an invalid services ConfigMap is deleted and a valid one is re-created in its place
+func (tc *testContext) testInvalidServicesCM(cmName string) error {
+	// Scale down the WMCO deployment to 0
+	if err := tc.scaleWMCODeployment(0); err != nil {
+		return err
+	}
+	// Delete existing services CM
+	err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Delete(context.TODO(), cmName, meta.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Invalid as data is missing (services and files)
+	invalidServicesCM := &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      cmName,
+			Namespace: tc.namespace,
+		},
+		Data: make(map[string]string, 2),
+	}
+	if _, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Create(context.TODO(), invalidServicesCM,
+		meta.CreateOptions{}); err != nil {
+		return err
+	}
+
+	// Restart the operator pod
+	if err := tc.scaleWMCODeployment(1); err != nil {
+		return err
+	}
+	// Try to retreive newly created ConfigMap and validate its contents
+	windowsServices, err := tc.waitForValidWindowsServicesConfigMap(cmName)
+	if err != nil {
+		return errors.Wrapf(err, "error retreiving ConfigMap %s", cmName)
+	}
+	if _, err := servicescm.Parse(windowsServices.Data); err != nil {
+		return errors.Wrapf(err, "error ensuring ConfigMap %s is re-created validly", cmName)
+	}
+	return nil
+}
+
+// waitForValidWindowsServicesConfigMap returns a reference to the ConfigMap that matches the given name.
+// If a ConfigMap with valid contents is not found within the time limit, an error is returned.
+func (tc *testContext) waitForValidWindowsServicesConfigMap(cmName string) (*core.ConfigMap, error) {
+	configMap := &core.ConfigMap{}
+	err := wait.Poll(retry.Interval, retry.ResourceChangeTimeout, func() (bool, error) {
+		var err error
+		configMap, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), cmName, meta.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Retry if the Get() results in a IsNotFound error
+				return false, nil
+			}
+			return false, errors.Wrapf(err, "error retrieving ConfigMap: %s", cmName)
+		}
+		// Here, we've retreived a ConfigMap but still need to ensure it is valid.
+		// If it's not valid, retry in hopes that WMCO will replace it with a valid one as expected.
+		_, err = servicescm.Parse(configMap.Data)
+		return err == nil, nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error waiting for ConfigMap %s/%s", tc.namespace, cmName)
+	}
+	return configMap, nil
 }
 
 // testCSRApproval tests if the BYOH CSR's have been approved by WMCO CSR approver


### PR DESCRIPTION
This PR creates the data representation of a service ConfigMap which provides WICD with the specifications for each Windows service that must be created on a Windows instance.
WMCO will then create and maintain a service ConfigMap which provides WICD with the specifications for each Windows service that must be created on a Windows instance. To begin with maintain a no-op ConfigMap, and in follow-up PRs we will move services one by one to be included in the ConfigMap.

- Services ConfigMap is a singleton within the namespace
- The ConfigMap is immutable
- If the ConfigMap is deleted it is recreated
- If a ConfigMap with incorrect values is found, WMCO will delete and recreate it with the proper values
  - this applies both on operator start and during reconciling
- The Services ConfigMap will be created on operator startup
- Services ConfigMap follows the naming pattern `windows-services-<WMCOMajorVersion>-<WMCOMinorVersion>-<WMCOPatchVersion>-<Commit>`