### PR TITLE
WINC-715: Introduce Windows services ConfigMap schema

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,12 +3,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# returns the operator version in `Version+GitHash` format
+# returns the operator version in `Version-GitHash` format
 # Takes a semver as an argument. This should be the version present in the WMCO CSV
 add_git_data_to_version() {
   local WMCO_SEMVER=$1
   GIT_COMMIT=$(git rev-parse --short HEAD)
-  FULL_VERSION="${WMCO_SEMVER}+${GIT_COMMIT}"
+  FULL_VERSION="${WMCO_SEMVER}-${GIT_COMMIT}"
 
   # If any files that affect the building of the operator binary have been changed, append "-dirty" to the version.
   if [ -n "$(git status version tools.go go.mod go.sum vendor Makefile build main.go hack pkg controllers --porcelain)" ]; then

--- a/pkg/servicescm/services_test.go
+++ b/pkg/servicescm/services_test.go
@@ -1,0 +1,463 @@
+package servicescm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	// The following cases only test only the structure of the services ConfigMap.
+	// Content validtion is tested below through test methods upon the helpers.
+	testCases := []struct {
+		name        string
+		input       map[string]string
+		expectedErr bool
+	}{
+		{
+			name: "both expected keys",
+			input: map[string]string{
+				servicesKey: "[]",
+				filesKey:    "[]",
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "no keys",
+			input:       map[string]string{},
+			expectedErr: true,
+		},
+		{
+			name: "only 1 of the expected keys",
+			input: map[string]string{
+				servicesKey: "[]",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "correct number but incorrect key",
+			input: map[string]string{
+				filesKey:  "[]",
+				"testKey": "[]",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "too many keys",
+			input: map[string]string{
+				servicesKey: "[]",
+				filesKey:    "[]",
+				"testKey":   "[]",
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			cmData, err := Parse(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, cmData.Services)
+			assert.NotNil(t, cmData.Files)
+		})
+	}
+}
+
+func TestValidateDependencies(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []Service
+		expectedErr bool
+	}{
+		{
+			name:        "empty services list",
+			input:       []Service{},
+			expectedErr: false,
+		},
+		{
+			name: "no dependencies",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid dependencies",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "bootstrap depends on all non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{"test-controller-service", "test-controller-service-2"},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap in the middle of non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{"test-controller-service"},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateDependencies(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePriorities(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []Service
+		expectedErr bool
+	}{
+		{
+			name:        "empty services list",
+			input:       []Service{},
+			expectedErr: false,
+		},
+		{
+			name: "valid priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     5,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid repeated priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "new-bootstrap-service-2",
+					Command:      "C:\\tnew-bootstrap-service-2",
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "overlapping bootstrap and non-bootstrap priorities",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{"new-bootstrap-service"},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service-2"},
+					Bootstrap:    false,
+					Priority:     5,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap lower priority than all non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     2,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{"test-controller-service"},
+					Bootstrap:    false,
+					Priority:     1,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "bootstrap in the middle of non-bootstrap services",
+			input: []Service{
+				{
+					Name:    "new-bootstrap-service",
+					Command: "C:\\new-service --variable-arg1=NODE_NAME --variable-arg2=NETWORK_IP",
+					NodeVariablesInCommand: []NodeCmdArg{
+						{
+							Name:               "NODE_NAME",
+							NodeObjectJsonPath: "metadata.name",
+						},
+					},
+					PowershellVariablesInCommand: []PowershellCmdArg{
+						{
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
+						},
+					},
+					Dependencies: []string{},
+					Bootstrap:    true,
+					Priority:     1,
+				},
+				{
+					Name:         "test-controller-service",
+					Command:      "C:\\test-controller-service",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+				{
+					Name:         "test-controller-service-2",
+					Command:      "C:\\test-controller-service-2",
+					Dependencies: []string{},
+					Bootstrap:    false,
+					Priority:     2,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePriorities(test.input)
+			if test.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -1,0 +1,21 @@
+package servicescm
+
+import (
+	"fmt"
+
+	"github.com/openshift/windows-machine-config-operator/version"
+)
+
+// ServicesConfigMapName is the name of the ConfigMap detailing service configuration for a specific WMCO version
+var ServicesConfigMapName string
+
+// init runs once, initializing global variables
+func init() {
+	ServicesConfigMapName = servicesConfigMapName()
+}
+
+// servicesConfigMapName returns the ConfigMap with the naming scheme:
+// windows-services-<WMCOFullVersion>
+func servicesConfigMapName() string {
+	return fmt.Sprintf("windows-services-%s", version.Get())
+}

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -14,6 +14,49 @@ func init() {
 	ServicesConfigMapName = servicesConfigMapName()
 }
 
+// NodeCmdArg is a variable in a Windows command whose value is sourced from the node object associated with a instance
+type NodeCmdArg struct {
+	// Name is the variable name as it appears in commands
+	Name string `json:"name"`
+	// NodeObjectJsonPath is the JSON path of a field within an instance's Node object
+	NodeObjectJsonPath string `json:"nodeObjectJsonPath"`
+}
+
+// PowershellCmdArg is a variable in a Windows command whose value is determined from the output of a PowerShell script
+type PowershellCmdArg struct {
+	// Name is the variable name as it appears in commands
+	Name string `json:"name"`
+	// Path is the location of the PowerShell script to be run
+	Path string `json:"path"`
+}
+
+// Service represents the configuration spec of a Windows service
+type Service struct {
+	// Name is the name of the Windows service
+	Name string `json:"name"`
+	// Command is command that will be executed. This could potentially include strings whose values will be derived
+	// from NodeVariablesInCommand and PowershellVariablesInCommand.
+	Command string `json:"path"`
+	// Before a command is run on a Windows instance, all node and PowerShell variables will be replaced by their values
+	NodeVariablesInCommand       []NodeCmdArg       `json:"nodeVariablesInCommand,omitempty"`
+	PowershellVariablesInCommand []PowershellCmdArg `json:"powershellVariablesInCommand,omitempty"`
+	// Dependencies is a list of service names that this service is dependent on
+	Dependencies []string `json:"dependencies,omitempty"`
+	// Bootstrap is a boolean flag indicating whether this service should be handled as part of node bootstrapping
+	Bootstrap bool `json:"bootstrap"`
+	// Priority is a non-negative integer that will be used to order the creation of the services.
+	// Priority 0 is created first
+	Priority uint `json:"priority"`
+}
+
+// FileInfo contains the path and checksum of a file copied to an instance by WMCO
+type FileInfo struct {
+	// Path is the filepath of a file on an instance
+	Path string `json:"path"`
+	// Checksum is used to validate that a file has not been changed
+	Checksum string `json:"checksum"`
+}
+
 // servicesConfigMapName returns the ConfigMap with the naming scheme:
 // windows-services-<WMCOFullVersion>
 func servicesConfigMapName() string {

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -1,7 +1,11 @@
 package servicescm
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
 
 	"github.com/openshift/windows-machine-config-operator/version"
 )
@@ -13,6 +17,13 @@ var ServicesConfigMapName string
 func init() {
 	ServicesConfigMapName = servicesConfigMapName()
 }
+
+const (
+	// servicesKey is a required key in the services ConfigMap. The value for this key is a Service object JSON array.
+	servicesKey = "services"
+	// filesKey is a required key in the services ConfigMap. The value for this key is a FileInfo object JSON array.
+	filesKey = "files"
+)
 
 // NodeCmdArg is a variable in a Windows command whose value is sourced from the node object associated with a instance
 type NodeCmdArg struct {
@@ -55,6 +66,123 @@ type FileInfo struct {
 	Path string `json:"path"`
 	// Checksum is used to validate that a file has not been changed
 	Checksum string `json:"checksum"`
+}
+
+// servicesCMData represents the Data field of a `windows-services` ConfigMap resource
+type servicesCMData struct {
+	// Services contains all data required to configure the required Windows services to configure an instance as a Node
+	Services []Service `json:"services"`
+	// Files contains the path and checksum of all the files copied to a Windows VM by WMCO
+	Files []FileInfo `json:"files"`
+}
+
+// NewServicesConfigMapData returns a new servicesCMData. Validates given object contents on creation.
+func NewServicesConfigMapData(services *[]Service, files *[]FileInfo) (*servicesCMData, error) {
+	cmData := &servicesCMData{*services, *files}
+	if err := cmData.validate(); err != nil {
+		return nil, errors.Wrap(err, "unable to create services ConfigMap data object")
+	}
+	return cmData, nil
+}
+
+// Parse converts ConfigMap data into the objects representing a Windows services ConfigMap schema
+// Returns error if the given data is invalid in structure or contents.
+func Parse(data map[string]string) (*servicesCMData, error) {
+	if len(data) != 2 {
+		return nil, errors.New("services ConfigMap should have exactly 2 keys")
+	}
+
+	services := &[]Service{}
+	files := &[]FileInfo{}
+
+	value, ok := data[servicesKey]
+	if !ok {
+		return nil, errors.Errorf("expected `%s` key to exist", servicesKey)
+	}
+	if err := json.Unmarshal([]byte(value), services); err != nil {
+		return nil, err
+	}
+
+	value, ok = data[filesKey]
+	if !ok {
+		return nil, errors.Errorf("expected `%s` key to exist", filesKey)
+	}
+	if err := json.Unmarshal([]byte(value), files); err != nil {
+		return nil, err
+	}
+
+	return NewServicesConfigMapData(services, files)
+}
+
+// validate ensures the given object represents a valid services ConfigMap.
+// The validation ensures bootstrap services always start before controller services according to WICD's expected schema
+func (cmData *servicesCMData) validate() error {
+	if err := validateDependencies(cmData.Services); err != nil {
+		return err
+	}
+	return validatePriorities(cmData.Services)
+}
+
+// validateDependencies ensures that no bootstrap service depends on a non-bootstrap service
+func validateDependencies(services []Service) error {
+	boostrapServices := []Service{}
+	nonBoostrapServices := []Service{}
+	for _, svc := range services {
+		if svc.Bootstrap {
+			boostrapServices = append(boostrapServices, svc)
+		} else {
+			nonBoostrapServices = append(nonBoostrapServices, svc)
+		}
+	}
+
+	for _, bootstrapSvc := range boostrapServices {
+		if hasDependency(bootstrapSvc, nonBoostrapServices) {
+			return errors.Errorf("bootstrap service %s cannot depend on non-boostrap service", bootstrapSvc.Name)
+		}
+	}
+	return nil
+}
+
+// hasDependency checks if a service is dependent on any services in the given slice
+func hasDependency(s Service, possibleDependencies []Service) bool {
+	for _, dependency := range s.Dependencies {
+		for _, possibleDependency := range possibleDependencies {
+			if dependency == possibleDependency.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validatePriorities ensures that each service that has the bootstrap flag set as true has a higher priority than all
+// non-bootstrap services. There should be no overlap in the priorities of bootstrap services and controller services.
+func validatePriorities(services []Service) error {
+	// sort services in ascending priority, bootstrap services towards the front of slice
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].Priority < services[j].Priority
+	})
+
+	// ensure no bootstrap service appears after a controller service in the ordered list
+	nonBoostrapSeen := false
+	lastBoostrapPriority := uint(0)
+	for _, svc := range services {
+		if svc.Bootstrap {
+			if nonBoostrapSeen {
+				return errors.Errorf("bootstrap service %s priority must be higher than all controller services",
+					svc.Name)
+			}
+			lastBoostrapPriority = svc.Priority
+		} else {
+			// corner case if two adjacent bootstrap and controller services have the same priority
+			if svc.Priority == lastBoostrapPriority {
+				return errors.Errorf("controller service %s priority must not overlap with any bootstrap service",
+					svc.Name)
+			}
+			nonBoostrapSeen = true
+		}
+	}
+	return nil
 }
 
 // servicesConfigMapName returns the ConfigMap with the naming scheme:

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -199,7 +199,7 @@ func getWMCOVersion() (string, error) {
 		return "", errors.Wrapf(err, "error running %s", cmd.String())
 	}
 	// out is formatted like:
-	// ./build/_output/bin/windows-machine-config-operator version: "0.0.1+4165dda-dirty", go version: "go1.13.7 linux/amd64"
+	// ./build/_output/bin/windows-machine-config-operator version: "0.0.1-4165dda-dirty", go version: "go1.13.7 linux/amd64"
 	versionSplit := strings.Split(string(out), "\"")
 	if len(versionSplit) < 3 {
 		return "", fmt.Errorf("unexpected version output")


### PR DESCRIPTION
This PR covers the data representation of a service ConfigMap which provides WICD with the specifications for each Windows service that must be created on a Windows instance.

- Services ConfigMap follows the naming pattern `windows-services-<WMCOMajorVersion>-<WMCOMinorVersion>-<WMCOPatchVersion>-<Commit>`