### PR TITLE
[build] Fix file copying in Dockerfile.wmco

### DIFF
--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -14,7 +14,7 @@ COPY vendor vendor
 COPY .gitignore .gitignore
 COPY Makefile Makefile
 COPY build build
-COPY main.go .
+COPY cmd cmd
 COPY controllers controllers
 COPY hack hack
 COPY pkg pkg


### PR DESCRIPTION
This PR is a follow-up to https://github.com/openshift/windows-machine-config-operator/pull/944.
Dockerfile.wmco was missed when changing the location of main.go, preventing operator builds locally.