### PR TITLE
[e2e] Fix WMCO binary path

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 	flag.IntVar(&numberOfMachineNodes, "machine-node-count", 1,
 		"number of nodes to be created for testing the Machine controller."+
 			"Setting this to 0 will result in some tests being skipped")
-	flag.StringVar(&wmcoPath, "wmco-path", "./build/_output/bin/windows-machine-config-operator",
+	flag.StringVar(&wmcoPath, "wmco-path", "./../../build/_output/bin/windows-machine-config-operator",
 		"Path to the WMCO binary, used for version validation")
 	flag.StringVar(&privateKeyPath, "private-key-path", "",
 		"path of the private key file used to configure the Windows node")


### PR DESCRIPTION
This PR fixes an old bug that occurs only when running WMCO e2e tests locally.
Since the test files are not within the top level WMCO directory and instead
nested in the `test/e2e` directories, this must be reflected when referencing
the WMCO binary. Otherwise, things like [getting the operator version](https://github.com/openshift/windows-machine-config-operator/blob/master/test/e2e/validation_test.go#L195-L196) will fail.