### PR TITLE
WINC-730: Add WICD unit test stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ lint:
 unit:
 	hack/unit.sh ${GO_MOD_FLAGS}
 
+.PHONY: wicd-unit
+wicd-unit:
+	hack/wicd-unit.sh
+
 .PHONY: run-ci-e2e-test
 run-ci-e2e-test:
 	hack/run-ci-e2e-test.sh -t basic

--- a/hack/wicd-unit.sh
+++ b/hack/wicd-unit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Placeholder stub for WICD unit tests
+# Currently requiring Windows VM env variables to be set, in order to validate release job functionality
+if [ -z "$INSTANCE_ADDRESS" ]; then
+    echo "Windows VM address not provided"
+    return 1
+fi
+if [ -z "$INSTANCE_USERNAME" ]; then
+    echo "Windows VM username not provided"
+    return 1
+fi
+if [ -z "$KUBE_SSH_KEY_PATH" ]; then
+    echo "env KUBE_SSH_KEY_PATH not found"
+    return 1
+fi
+
+# Ensure the image used in the release job has ssh installed, as this will be used to remotely run tests against a
+# Windows VM. Running a dummy command to ensure connection to the VM is possible
+ssh -o StrictHostKeyChecking=no -i $KUBE_SSH_KEY_PATH $INSTANCE_USERNAME@$INSTANCE_ADDRESS "dir"
+


### PR DESCRIPTION
This commit adds a Make target for unit testing WICD. The purpose of
this is to validate that the WICD unit release job is fufilling all of
its requirements. Once both this stub and the release job are created,
this stub can be expanded to actually perform the tests required of it.