### PR TITLE
WINC-716: WMCO removes unneeded service ConfigMaps

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -316,7 +316,7 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&core.ConfigMap{}, builder.WithPredicates(configMapPredicate)).
 		Watches(&source.Kind{Type: &core.Node{}}, handler.EnqueueRequestsFromMapFunc(r.mapToConfigMap),
-			builder.WithPredicates(windowsNodePredicate(true))).
+			builder.WithPredicates(outdatedWindowsNodePredicate(true))).
 		Complete(r)
 }
 

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"net"
+	"strings"
 
 	config "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
@@ -47,6 +48,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/signer"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
+	"github.com/openshift/windows-machine-config-operator/version"
 )
 
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
@@ -156,6 +158,10 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context,
 // reconcileServices uses the data within the services ConfigMap to ensure WMCO-managed Windows services on
 // Windows Nodes have the expected configuration and are in the expected state
 func (r *ConfigMapReconciler) reconcileServices(ctx context.Context, windowsServices *core.ConfigMap) error {
+	if err := r.removeOutdatedServicesConfigMaps(ctx); err != nil {
+		return err
+	}
+
 	// If a ConfigMap with invalid values is found, WMCO will delete and recreate it with proper values
 	if _, err := servicescm.Parse(windowsServices.Data); err != nil {
 		// Deleting will trigger an event for the configmap_controller, which will re-create a proper ConfigMap
@@ -168,6 +174,62 @@ func (r *ConfigMapReconciler) reconcileServices(ctx context.Context, windowsServ
 	}
 	// TODO: actually react to changes to the services ConfigMap
 	return nil
+}
+
+// removeOutdatedServicesConfigMaps deletes any outdated services ConfigMaps, if all nodes have moved past that version
+func (r *ConfigMapReconciler) removeOutdatedServicesConfigMaps(ctx context.Context) error {
+	nodes := &core.NodeList{}
+	if err := r.client.List(ctx, nodes, client.MatchingLabels{core.LabelOSStable: "windows"}); err != nil {
+		return err
+	}
+	versionAnnotations := getVersionAnnotations(nodes.Items)
+
+	servicesConfigMaps, err := r.listServiceConfigMaps(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "unable to retrieve list of services ConfigMaps")
+	}
+	for _, cm := range servicesConfigMaps {
+		cmVersion := strings.TrimPrefix(cm.Name, servicescm.NamePrefix)
+		if isTiedToRelevantVersion(cmVersion, versionAnnotations) {
+			continue
+		}
+		// Remove any services ConfigMap tied to a WMCO version that no Windows nodes are at anymore
+		if err := r.client.Delete(ctx, &cm); err != nil {
+			return errors.Wrapf(err, "could not delete outdated services ConfigMap %s", cm.Name)
+		}
+		r.log.Info("Deleted outdated resource", "ConfigMap",
+			kubeTypes.NamespacedName{Namespace: r.watchNamespace, Name: cm.Name})
+	}
+	return nil
+}
+
+// isTiedToRelevantVersion checks if the given version is the current WMCO version or is in the given map of versions
+func isTiedToRelevantVersion(v string, versions map[string]struct{}) bool {
+	if v == version.Get() {
+		// The current WMCO version is always considered relevant
+		return true
+	}
+	for version := range versions {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}
+
+// listServiceConfigMaps returns a list of all windows-services ConfigMaps in the operator namespace
+func (r *ConfigMapReconciler) listServiceConfigMaps(ctx context.Context) ([]core.ConfigMap, error) {
+	watchNamespaceCMs := &core.ConfigMapList{}
+	if err := r.client.List(ctx, watchNamespaceCMs, &client.ListOptions{Namespace: r.watchNamespace}); err != nil {
+		return nil, err
+	}
+	servicesConfigMaps := []core.ConfigMap{}
+	for _, cm := range watchNamespaceCMs.Items {
+		if strings.HasPrefix(cm.Name, servicescm.NamePrefix) {
+			servicesConfigMaps = append(servicesConfigMaps, cm)
+		}
+	}
+	return servicesConfigMaps, nil
 }
 
 // reconcileNodes corrects the discrepancy between the "expected" instances, and the "actual" Node list

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -214,6 +214,17 @@ func outdatedWindowsNodePredicate(byoh bool) predicate.Funcs {
 
 }
 
+// getVersionAnnotations returns a map whose keys are the WMCO versions that have configured any Windows nodes
+func getVersionAnnotations(nodes []core.Node) map[string]struct{} {
+	versions := make(map[string]struct{})
+	for _, node := range nodes {
+		if versionAnnotation, present := node.Annotations[metadata.VersionAnnotation]; present {
+			versions[versionAnnotation] = struct{}{}
+		}
+	}
+	return versions
+}
+
 // isValidWindowsNode returns true if the node object has the Windows label and the BYOH
 // label present for only the BYOH nodes based on the value of the byoh boolean parameter.
 func isValidWindowsNode(o client.Object, byoh bool) bool {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -155,6 +155,34 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	return nil
 }
 
+// windowsNodeVersionChangePredicate returns a predicate whose filter catches Windows nodes that indicate a version
+// change either through deletion away from an old version or creation/update to the latest WMCO version
+func windowsNodeVersionChangePredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// catch Machine-backed Windows node upgrades as they are re-created
+			return e.Object.GetLabels()[core.LabelOSStable] == "windows" &&
+				e.Object.GetAnnotations()[metadata.VersionAnnotation] == version.Get()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// catch BYOH Windows node upgrades to the current WMCO version as they are re-configured in place
+			return e.ObjectNew.GetLabels()[core.LabelOSStable] == "windows" &&
+				(e.ObjectOld.GetAnnotations()[metadata.VersionAnnotation] !=
+					e.ObjectNew.GetAnnotations()[metadata.VersionAnnotation]) &&
+				e.ObjectNew.GetAnnotations()[metadata.VersionAnnotation] == version.Get()
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return e.Object.GetLabels()[core.LabelOSStable] == "windows" &&
+				e.Object.GetAnnotations()[metadata.VersionAnnotation] == version.Get()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// catch if a node stuck at an older WMCO version is deleted
+			return e.Object.GetLabels()[core.LabelOSStable] == "windows" &&
+				e.Object.GetAnnotations()[metadata.VersionAnnotation] != version.Get()
+		},
+	}
+}
+
 // outdatedWindowsNodePredicate returns a predicate which filters out all node objects that are not up-to-date Windows
 // nodes. Up-to-date refers to the version annotation and public key hash annotations.
 // If BYOH is true, only BYOH nodes will be allowed through, else no BYOH nodes will be allowed.

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -155,9 +155,10 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	return nil
 }
 
-// windowsNodePredicate returns a predicate which filters out all node objects that are not Windows nodes.
+// outdatedWindowsNodePredicate returns a predicate which filters out all node objects that are not up-to-date Windows
+// nodes. Up-to-date refers to the version annotation and public key hash annotations.
 // If BYOH is true, only BYOH nodes will be allowed through, else no BYOH nodes will be allowed.
-func windowsNodePredicate(byoh bool) predicate.Funcs {
+func outdatedWindowsNodePredicate(byoh bool) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return isValidWindowsNode(e.Object, byoh) &&

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -128,7 +128,7 @@ func (r *WindowsMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mapi.Machine{}, builder.WithPredicates(machinePredicate)).
 		Watches(&source.Kind{Type: &core.Node{}}, handler.EnqueueRequestsFromMapFunc(r.mapNodeToMachine),
-			builder.WithPredicates(windowsNodePredicate(false))).
+			builder.WithPredicates(outdatedWindowsNodePredicate(false))).
 		Complete(r)
 }
 

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -478,15 +478,21 @@ func testServicesConfigMap(t *testing.T) {
 	servicesConfigMapName := servicescm.NamePrefix + operatorVersion
 
 	// Ensure the windows-services ConfigMap exists in the cluster
-	_, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(),
-		servicesConfigMapName, meta.GetOptions{})
-	require.NoErrorf(t, err, "error retrieving ConfigMap: %s", servicesConfigMapName)
+	t.Run("Services ConfigMap existance", func(t *testing.T) {
+		_, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), servicesConfigMapName,
+			meta.GetOptions{})
+		assert.NoErrorf(t, err, "error ensuring ConfigMap %s exists", servicesConfigMapName)
+	})
 
-	err = tc.testServicesCMRegeneration(servicesConfigMapName)
-	require.NoErrorf(t, err, "error ensuring ConfigMap %s is re-created when deleted", servicesConfigMapName)
+	t.Run("Services ConfigMap re-creation", func(t *testing.T) {
+		err = tc.testServicesCMRegeneration(servicesConfigMapName)
+		assert.NoErrorf(t, err, "error ensuring ConfigMap %s is re-created when deleted", servicesConfigMapName)
+	})
 
-	err = tc.testInvalidServicesCM(servicesConfigMapName)
-	require.NoError(t, err, "error testing handling of invalid ConfigMap")
+	t.Run("Invalid services ConfigMap deletion", func(t *testing.T) {
+		err = tc.testInvalidServicesCM(servicesConfigMapName)
+		assert.NoError(t, err, "error testing handling of invalid ConfigMap")
+	})
 }
 
 // testServicesCMRegeneration tests that if the services ConfigMap is deleted, a valid one is re-created in its place

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -549,7 +549,7 @@ func (tc *testContext) testInvalidServicesCM(cmName string) error {
 // If a ConfigMap with valid contents is not found within the time limit, an error is returned.
 func (tc *testContext) waitForValidWindowsServicesConfigMap(cmName string) (*core.ConfigMap, error) {
 	configMap := &core.ConfigMap{}
-	err := wait.Poll(retry.Interval, retry.ResourceChangeTimeout, func() (bool, error) {
+	err := wait.PollImmediate(retry.Interval, retry.ResourceChangeTimeout, func() (bool, error) {
 		var err error
 		configMap, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), cmName, meta.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
This PR adds the responsibility of removing outdated services ConfigMaps.
This will be particularly useful during upgrades -- the operator will clean up old 
services configs to ensure the source of truth is tied to the current operator version.