### PR TITLE
WINC-730: Windows service unit testable interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/mod v0.4.2
+	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	k8s.io/client-go v0.23.1
@@ -94,7 +95,6 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/hack/wicd-unit.sh
+++ b/hack/wicd-unit.sh
@@ -3,8 +3,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Placeholder stub for WICD unit tests
-# Currently requiring Windows VM env variables to be set, in order to validate release job functionality
 if [ -z "$INSTANCE_ADDRESS" ]; then
     echo "Windows VM address not provided"
     return 1
@@ -17,8 +15,11 @@ if [ -z "$KUBE_SSH_KEY_PATH" ]; then
     echo "env KUBE_SSH_KEY_PATH not found"
     return 1
 fi
+WICD_UNIT_EXE="wicd_unit.exe"
+# Build unit tests for Windows. Specifically targetting packages used by WICD.
+GOOS=windows GOFLAGS=-v go test -c ./pkg/winsvc/... -o $WICD_UNIT_EXE
 
-# Ensure the image used in the release job has ssh installed, as this will be used to remotely run tests against a
-# Windows VM. Running a dummy command to ensure connection to the VM is possible
-ssh -o StrictHostKeyChecking=no -i $KUBE_SSH_KEY_PATH $INSTANCE_USERNAME@$INSTANCE_ADDRESS "dir"
+# Run the unit tests against the Windows host
+scp -o StrictHostKeyChecking=no -i $KUBE_SSH_KEY_PATH $WICD_UNIT_EXE $INSTANCE_USERNAME@$INSTANCE_ADDRESS:$WICD_UNIT_EXE
+ssh -o StrictHostKeyChecking=no -i $KUBE_SSH_KEY_PATH $INSTANCE_USERNAME@$INSTANCE_ADDRESS "$WICD_UNIT_EXE"
 

--- a/pkg/winsvc/winsvc.go
+++ b/pkg/winsvc/winsvc.go
@@ -1,0 +1,176 @@
+//go:build windows
+
+package winsvc
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+type Mgr interface {
+	CreateService(string, string, mgr.Config, ...string) (Service, error)
+	ListServices() ([]string, error)
+	OpenService(string) (Service, error)
+}
+
+// fakeServiceList mocks out the state of all services on a Windows instance
+type fakeServiceList struct {
+	m    *sync.Mutex
+	svcs map[string]Service
+}
+
+// write overwrites the given service to the svcs map
+func (l *fakeServiceList) write(name string, svc Service) {
+	l.m.Lock()
+	defer l.m.Unlock()
+	l.svcs[name] = svc
+}
+
+// read returns the entry with the given name, and a bool indicating if it exists or not
+func (l *fakeServiceList) read(name string) (Service, bool) {
+	l.m.Lock()
+	defer l.m.Unlock()
+	service, exists := l.svcs[name]
+	return service, exists
+}
+
+// listServiceNames returns a slice of all service names
+func (l *fakeServiceList) listServiceNames() []string {
+	l.m.Lock()
+	defer l.m.Unlock()
+	var names []string
+	for svcName := range l.svcs {
+		names = append(names, svcName)
+	}
+	return names
+}
+
+// remove deletes the entry with the given name, throwing an error if it doesn't exist
+func (l *fakeServiceList) remove(name string) error {
+	l.m.Lock()
+	defer l.m.Unlock()
+	_, exists := l.svcs[name]
+	if !exists {
+		return errors.New("service does not exist")
+	}
+	delete(l.svcs, name)
+	return nil
+}
+
+func newFakeServiceList() *fakeServiceList {
+	return &fakeServiceList{
+		m:    &sync.Mutex{},
+		svcs: make(map[string]Service),
+	}
+}
+
+type testMgr struct {
+	svcList *fakeServiceList
+}
+
+// CreateService installs new service name on the system.
+// The service will be executed by running exepath binary.
+// Use config c to specify service parameters.
+// Any args will be passed as command-line arguments when
+// the service is started; these arguments are distinct from
+// the arguments passed to Service.Start or via the "Start
+// parameters" field in the service's Properties dialog box.
+func (t testMgr) CreateService(name, exepath string, config mgr.Config, args ...string) (Service, error) {
+	// Throw an error if the service already exists
+	if _, ok := t.svcList.read(name); ok {
+		return nil, errors.New("service already exists")
+	}
+	config.BinaryPathName = exepath
+	service := FakeService{
+		name:   name,
+		config: config,
+		status: svc.Status{
+			State: svc.Stopped,
+		},
+		serviceList: t.svcList,
+	}
+	t.svcList.write(name, &service)
+	return &service, nil
+}
+
+func (t testMgr) ListServices() ([]string, error) {
+	return t.svcList.listServiceNames(), nil
+}
+
+func (t testMgr) OpenService(name string) (Service, error) {
+	service, exists := t.svcList.read(name)
+	if !exists {
+		return nil, fmt.Errorf("service does not exist")
+	}
+	return service, nil
+}
+
+type Service interface {
+	Delete() error
+	Close() error
+	Start(...string) error
+	Config() (mgr.Config, error)
+	Control(svc.Cmd) (svc.Status, error)
+	Query() (svc.Status, error)
+	UpdateConfig(mgr.Config) error
+}
+
+type FakeService struct {
+	name        string
+	config      mgr.Config
+	status      svc.Status
+	serviceList *fakeServiceList
+}
+
+func (f FakeService) Delete() error {
+	return f.serviceList.remove(f.name)
+}
+
+func (f FakeService) Close() error {
+	return nil
+}
+
+func (f FakeService) Start(_ ...string) error {
+	f.status.State = svc.Running
+	return nil
+}
+
+func (f FakeService) Config() (mgr.Config, error) {
+	return f.config, nil
+}
+
+func (f FakeService) Control(cmd svc.Cmd) (svc.Status, error) {
+	switch cmd {
+	case svc.Stop:
+		f.status.State = svc.Stopped
+	}
+	return f.status, nil
+}
+
+func (f FakeService) Query() (svc.Status, error) {
+	return f.status, nil
+}
+
+func (f FakeService) UpdateConfig(config mgr.Config) error {
+	f.config = config
+	return nil
+}
+
+func NewMgr() (*mgr.Mgr, error) {
+	return mgr.Connect()
+}
+
+func NewTestMgr(existingServices map[string]*FakeService) *testMgr {
+	testMgr := &testMgr{newFakeServiceList()}
+	if existingServices != nil {
+		for name, svc := range existingServices {
+			svc.serviceList = testMgr.svcList
+			testMgr.svcList.svcs[name] = svc
+		}
+	}
+	return testMgr
+}

--- a/pkg/winsvc/winsvc_test.go
+++ b/pkg/winsvc/winsvc_test.go
@@ -1,0 +1,175 @@
+//go:build windows
+
+package winsvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// These test functions have been created to define the expected behavior of the structs mocking the Windows
+// service API. The expected behavior should match up with the behavior seen when using the Windows API, and
+// if differences are seen between the two, the mock implementations should be modified to correct the difference.
+
+func TestCreateService(t *testing.T) {
+	testIO := []struct {
+		name         string
+		svcName      string
+		svcExepath   string
+		svcConfig    mgr.Config
+		existingSvcs map[string]*FakeService
+		expectErr    bool
+	}{
+		{
+			name:    "new service with no other services",
+			svcName: "svc-one",
+			svcConfig: mgr.Config{
+				Description: "testsvc",
+			},
+			svcExepath:   "testpath",
+			existingSvcs: nil,
+			expectErr:    false,
+		},
+		{
+			name:    "new service with different existing service",
+			svcName: "svc-one",
+			svcConfig: mgr.Config{
+				Description: "testsvc",
+			},
+			svcExepath:   "testpath",
+			existingSvcs: map[string]*FakeService{"svc-two": {}},
+			expectErr:    false,
+		},
+		{
+			name:    "existing service",
+			svcName: "svc-one",
+			svcConfig: mgr.Config{
+				Description: "testsvc",
+			},
+			svcExepath:   "testpath",
+			existingSvcs: map[string]*FakeService{"svc-one": {}},
+			expectErr:    true,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			testMgr := NewTestMgr(test.existingSvcs)
+			_, err := testMgr.CreateService(test.svcName, test.svcExepath, test.svcConfig)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			// ensure all existing keys are preserved
+			for svcName := range test.existingSvcs {
+				assert.Contains(t, testMgr.svcList.svcs, svcName)
+			}
+			// ensure new service has been added to list with correct values
+			require.Contains(t, testMgr.svcList.svcs, test.svcName)
+			newSvcInterface := testMgr.svcList.svcs[test.svcName]
+			newSvc, ok := newSvcInterface.(*FakeService)
+			require.True(t, ok, "cannot cast service to correct type")
+			assert.Equal(t, test.svcName, newSvc.name)
+			assert.Equal(t, test.svcExepath, newSvc.config.BinaryPathName)
+			assert.Equal(t, test.svcConfig.Description, newSvc.config.Description)
+			assert.Equal(t, svc.Stopped, newSvc.status.State)
+		})
+	}
+}
+
+func TestListServices(t *testing.T) {
+	testIO := []struct {
+		name         string
+		existingSvcs map[string]*FakeService
+		expected     []string
+	}{
+		{
+			name:         "no services",
+			existingSvcs: map[string]*FakeService{},
+			expected:     []string{},
+		},
+		{
+			name:         "some services",
+			existingSvcs: map[string]*FakeService{"svc-one": {}, "svc-two": {}},
+			expected:     []string{"svc-one", "svc-two"},
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			testMgr := NewTestMgr(test.existingSvcs)
+			list, err := testMgr.ListServices()
+			require.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, list)
+		})
+	}
+}
+
+func TestOpenService(t *testing.T) {
+	testIO := []struct {
+		name         string
+		svcName      string
+		existingSvcs map[string]*FakeService
+		expected     *FakeService
+		expectErr    bool
+	}{
+		{
+			name:         "existing service",
+			svcName:      "svc-one",
+			existingSvcs: map[string]*FakeService{"svc-one": {config: mgr.Config{Description: "testsvc"}}},
+			expectErr:    false,
+		},
+		{
+			name:         "nonexistent service",
+			svcName:      "svc-two",
+			existingSvcs: map[string]*FakeService{"svc-one": {config: mgr.Config{Description: "testsvc"}}},
+			expectErr:    true,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			testMgr := NewTestMgr(test.existingSvcs)
+			s, err := testMgr.OpenService(test.svcName)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.existingSvcs[test.svcName], s)
+		})
+	}
+}
+
+func TestDeleteService(t *testing.T) {
+	testIO := []struct {
+		name         string
+		svcName      string
+		existingSvcs map[string]*FakeService
+	}{
+		{
+			name:         "service exists",
+			svcName:      "svc-one",
+			existingSvcs: map[string]*FakeService{"svc-one": {name: "svc-one", config: mgr.Config{Description: "testsvc"}}},
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			testMgr := NewTestMgr(test.existingSvcs)
+			// First check that the service exists in the service list
+			list, err := testMgr.ListServices()
+			require.NoError(t, err)
+			require.Contains(t, list, test.svcName)
+			// Open the service to get a service handle, and then delete the service
+			s, err := testMgr.OpenService(test.svcName)
+			require.NoError(t, err)
+			require.NoError(t, s.Delete())
+			// Check that the service is no longer present in the service list
+			list, err = testMgr.ListServices()
+			require.NoError(t, err)
+			assert.NotContains(t, list, test.svcName)
+		})
+	}
+}

--- a/vendor/golang.org/x/sys/windows/svc/mgr/config.go
+++ b/vendor/golang.org/x/sys/windows/svc/mgr/config.go
@@ -1,0 +1,180 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package mgr
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// Service start types.
+	StartManual    = windows.SERVICE_DEMAND_START // the service must be started manually
+	StartAutomatic = windows.SERVICE_AUTO_START   // the service will start by itself whenever the computer reboots
+	StartDisabled  = windows.SERVICE_DISABLED     // the service cannot be started
+
+	// The severity of the error, and action taken,
+	// if this service fails to start.
+	ErrorCritical = windows.SERVICE_ERROR_CRITICAL
+	ErrorIgnore   = windows.SERVICE_ERROR_IGNORE
+	ErrorNormal   = windows.SERVICE_ERROR_NORMAL
+	ErrorSevere   = windows.SERVICE_ERROR_SEVERE
+)
+
+// TODO(brainman): Password is not returned by windows.QueryServiceConfig, not sure how to get it.
+
+type Config struct {
+	ServiceType      uint32
+	StartType        uint32
+	ErrorControl     uint32
+	BinaryPathName   string // fully qualified path to the service binary file, can also include arguments for an auto-start service
+	LoadOrderGroup   string
+	TagId            uint32
+	Dependencies     []string
+	ServiceStartName string // name of the account under which the service should run
+	DisplayName      string
+	Password         string
+	Description      string
+	SidType          uint32 // one of SERVICE_SID_TYPE, the type of sid to use for the service
+	DelayedAutoStart bool   // the service is started after other auto-start services are started plus a short delay
+}
+
+func toStringSlice(ps *uint16) []string {
+	r := make([]string, 0)
+	p := unsafe.Pointer(ps)
+
+	for {
+		s := windows.UTF16PtrToString((*uint16)(p))
+		if len(s) == 0 {
+			break
+		}
+
+		r = append(r, s)
+		offset := unsafe.Sizeof(uint16(0)) * (uintptr)(len(s)+1)
+		p = unsafe.Pointer(uintptr(p) + offset)
+	}
+
+	return r
+}
+
+// Config retrieves service s configuration paramteres.
+func (s *Service) Config() (Config, error) {
+	var p *windows.QUERY_SERVICE_CONFIG
+	n := uint32(1024)
+	for {
+		b := make([]byte, n)
+		p = (*windows.QUERY_SERVICE_CONFIG)(unsafe.Pointer(&b[0]))
+		err := windows.QueryServiceConfig(s.Handle, p, n, &n)
+		if err == nil {
+			break
+		}
+		if err.(syscall.Errno) != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return Config{}, err
+		}
+		if n <= uint32(len(b)) {
+			return Config{}, err
+		}
+	}
+
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_DESCRIPTION)
+	if err != nil {
+		return Config{}, err
+	}
+	p2 := (*windows.SERVICE_DESCRIPTION)(unsafe.Pointer(&b[0]))
+
+	b, err = s.queryServiceConfig2(windows.SERVICE_CONFIG_DELAYED_AUTO_START_INFO)
+	if err != nil {
+		return Config{}, err
+	}
+	p3 := (*windows.SERVICE_DELAYED_AUTO_START_INFO)(unsafe.Pointer(&b[0]))
+	delayedStart := false
+	if p3.IsDelayedAutoStartUp != 0 {
+		delayedStart = true
+	}
+
+	b, err = s.queryServiceConfig2(windows.SERVICE_CONFIG_SERVICE_SID_INFO)
+	if err != nil {
+		return Config{}, err
+	}
+	sidType := *(*uint32)(unsafe.Pointer(&b[0]))
+
+	return Config{
+		ServiceType:      p.ServiceType,
+		StartType:        p.StartType,
+		ErrorControl:     p.ErrorControl,
+		BinaryPathName:   windows.UTF16PtrToString(p.BinaryPathName),
+		LoadOrderGroup:   windows.UTF16PtrToString(p.LoadOrderGroup),
+		TagId:            p.TagId,
+		Dependencies:     toStringSlice(p.Dependencies),
+		ServiceStartName: windows.UTF16PtrToString(p.ServiceStartName),
+		DisplayName:      windows.UTF16PtrToString(p.DisplayName),
+		Description:      windows.UTF16PtrToString(p2.Description),
+		DelayedAutoStart: delayedStart,
+		SidType:          sidType,
+	}, nil
+}
+
+func updateDescription(handle windows.Handle, desc string) error {
+	d := windows.SERVICE_DESCRIPTION{Description: toPtr(desc)}
+	return windows.ChangeServiceConfig2(handle,
+		windows.SERVICE_CONFIG_DESCRIPTION, (*byte)(unsafe.Pointer(&d)))
+}
+
+func updateSidType(handle windows.Handle, sidType uint32) error {
+	return windows.ChangeServiceConfig2(handle, windows.SERVICE_CONFIG_SERVICE_SID_INFO, (*byte)(unsafe.Pointer(&sidType)))
+}
+
+func updateStartUp(handle windows.Handle, isDelayed bool) error {
+	var d windows.SERVICE_DELAYED_AUTO_START_INFO
+	if isDelayed {
+		d.IsDelayedAutoStartUp = 1
+	}
+	return windows.ChangeServiceConfig2(handle,
+		windows.SERVICE_CONFIG_DELAYED_AUTO_START_INFO, (*byte)(unsafe.Pointer(&d)))
+}
+
+// UpdateConfig updates service s configuration parameters.
+func (s *Service) UpdateConfig(c Config) error {
+	err := windows.ChangeServiceConfig(s.Handle, c.ServiceType, c.StartType,
+		c.ErrorControl, toPtr(c.BinaryPathName), toPtr(c.LoadOrderGroup),
+		nil, toStringBlock(c.Dependencies), toPtr(c.ServiceStartName),
+		toPtr(c.Password), toPtr(c.DisplayName))
+	if err != nil {
+		return err
+	}
+	err = updateSidType(s.Handle, c.SidType)
+	if err != nil {
+		return err
+	}
+
+	err = updateStartUp(s.Handle, c.DelayedAutoStart)
+	if err != nil {
+		return err
+	}
+
+	return updateDescription(s.Handle, c.Description)
+}
+
+// queryServiceConfig2 calls Windows QueryServiceConfig2 with infoLevel parameter and returns retrieved service configuration information.
+func (s *Service) queryServiceConfig2(infoLevel uint32) ([]byte, error) {
+	n := uint32(1024)
+	for {
+		b := make([]byte, n)
+		err := windows.QueryServiceConfig2(s.Handle, infoLevel, &b[0], n, &n)
+		if err == nil {
+			return b, nil
+		}
+		if err.(syscall.Errno) != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return nil, err
+		}
+		if n <= uint32(len(b)) {
+			return nil, err
+		}
+	}
+}

--- a/vendor/golang.org/x/sys/windows/svc/mgr/mgr.go
+++ b/vendor/golang.org/x/sys/windows/svc/mgr/mgr.go
@@ -1,0 +1,215 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package mgr can be used to manage Windows service programs.
+// It can be used to install and remove them. It can also start,
+// stop and pause them. The package can query / change current
+// service state and config parameters.
+//
+package mgr
+
+import (
+	"syscall"
+	"time"
+	"unicode/utf16"
+	"unsafe"
+
+	"golang.org/x/sys/internal/unsafeheader"
+	"golang.org/x/sys/windows"
+)
+
+// Mgr is used to manage Windows service.
+type Mgr struct {
+	Handle windows.Handle
+}
+
+// Connect establishes a connection to the service control manager.
+func Connect() (*Mgr, error) {
+	return ConnectRemote("")
+}
+
+// ConnectRemote establishes a connection to the
+// service control manager on computer named host.
+func ConnectRemote(host string) (*Mgr, error) {
+	var s *uint16
+	if host != "" {
+		s = syscall.StringToUTF16Ptr(host)
+	}
+	h, err := windows.OpenSCManager(s, nil, windows.SC_MANAGER_ALL_ACCESS)
+	if err != nil {
+		return nil, err
+	}
+	return &Mgr{Handle: h}, nil
+}
+
+// Disconnect closes connection to the service control manager m.
+func (m *Mgr) Disconnect() error {
+	return windows.CloseServiceHandle(m.Handle)
+}
+
+type LockStatus struct {
+	IsLocked bool          // Whether the SCM has been locked.
+	Age      time.Duration // For how long the SCM has been locked.
+	Owner    string        // The name of the user who has locked the SCM.
+}
+
+// LockStatus returns whether the service control manager is locked by
+// the system, for how long, and by whom. A locked SCM indicates that
+// most service actions will block until the system unlocks the SCM.
+func (m *Mgr) LockStatus() (*LockStatus, error) {
+	bytesNeeded := uint32(unsafe.Sizeof(windows.QUERY_SERVICE_LOCK_STATUS{}) + 1024)
+	for {
+		bytes := make([]byte, bytesNeeded)
+		lockStatus := (*windows.QUERY_SERVICE_LOCK_STATUS)(unsafe.Pointer(&bytes[0]))
+		err := windows.QueryServiceLockStatus(m.Handle, lockStatus, uint32(len(bytes)), &bytesNeeded)
+		if err == windows.ERROR_INSUFFICIENT_BUFFER && bytesNeeded >= uint32(unsafe.Sizeof(windows.QUERY_SERVICE_LOCK_STATUS{})) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		status := &LockStatus{
+			IsLocked: lockStatus.IsLocked != 0,
+			Age:      time.Duration(lockStatus.LockDuration) * time.Second,
+			Owner:    windows.UTF16PtrToString(lockStatus.LockOwner),
+		}
+		return status, nil
+	}
+}
+
+func toPtr(s string) *uint16 {
+	if len(s) == 0 {
+		return nil
+	}
+	return syscall.StringToUTF16Ptr(s)
+}
+
+// toStringBlock terminates strings in ss with 0, and then
+// concatenates them together. It also adds extra 0 at the end.
+func toStringBlock(ss []string) *uint16 {
+	if len(ss) == 0 {
+		return nil
+	}
+	t := ""
+	for _, s := range ss {
+		if s != "" {
+			t += s + "\x00"
+		}
+	}
+	if t == "" {
+		return nil
+	}
+	t += "\x00"
+	return &utf16.Encode([]rune(t))[0]
+}
+
+// CreateService installs new service name on the system.
+// The service will be executed by running exepath binary.
+// Use config c to specify service parameters.
+// Any args will be passed as command-line arguments when
+// the service is started; these arguments are distinct from
+// the arguments passed to Service.Start or via the "Start
+// parameters" field in the service's Properties dialog box.
+func (m *Mgr) CreateService(name, exepath string, c Config, args ...string) (*Service, error) {
+	if c.StartType == 0 {
+		c.StartType = StartManual
+	}
+	if c.ServiceType == 0 {
+		c.ServiceType = windows.SERVICE_WIN32_OWN_PROCESS
+	}
+	s := syscall.EscapeArg(exepath)
+	for _, v := range args {
+		s += " " + syscall.EscapeArg(v)
+	}
+	h, err := windows.CreateService(m.Handle, toPtr(name), toPtr(c.DisplayName),
+		windows.SERVICE_ALL_ACCESS, c.ServiceType,
+		c.StartType, c.ErrorControl, toPtr(s), toPtr(c.LoadOrderGroup),
+		nil, toStringBlock(c.Dependencies), toPtr(c.ServiceStartName), toPtr(c.Password))
+	if err != nil {
+		return nil, err
+	}
+	if c.SidType != windows.SERVICE_SID_TYPE_NONE {
+		err = updateSidType(h, c.SidType)
+		if err != nil {
+			windows.DeleteService(h)
+			windows.CloseServiceHandle(h)
+			return nil, err
+		}
+	}
+	if c.Description != "" {
+		err = updateDescription(h, c.Description)
+		if err != nil {
+			windows.DeleteService(h)
+			windows.CloseServiceHandle(h)
+			return nil, err
+		}
+	}
+	if c.DelayedAutoStart {
+		err = updateStartUp(h, c.DelayedAutoStart)
+		if err != nil {
+			windows.DeleteService(h)
+			windows.CloseServiceHandle(h)
+			return nil, err
+		}
+	}
+	return &Service{Name: name, Handle: h}, nil
+}
+
+// OpenService retrieves access to service name, so it can
+// be interrogated and controlled.
+func (m *Mgr) OpenService(name string) (*Service, error) {
+	h, err := windows.OpenService(m.Handle, syscall.StringToUTF16Ptr(name), windows.SERVICE_ALL_ACCESS)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{Name: name, Handle: h}, nil
+}
+
+// ListServices enumerates services in the specified
+// service control manager database m.
+// If the caller does not have the SERVICE_QUERY_STATUS
+// access right to a service, the service is silently
+// omitted from the list of services returned.
+func (m *Mgr) ListServices() ([]string, error) {
+	var err error
+	var bytesNeeded, servicesReturned uint32
+	var buf []byte
+	for {
+		var p *byte
+		if len(buf) > 0 {
+			p = &buf[0]
+		}
+		err = windows.EnumServicesStatusEx(m.Handle, windows.SC_ENUM_PROCESS_INFO,
+			windows.SERVICE_WIN32, windows.SERVICE_STATE_ALL,
+			p, uint32(len(buf)), &bytesNeeded, &servicesReturned, nil, nil)
+		if err == nil {
+			break
+		}
+		if err != syscall.ERROR_MORE_DATA {
+			return nil, err
+		}
+		if bytesNeeded <= uint32(len(buf)) {
+			return nil, err
+		}
+		buf = make([]byte, bytesNeeded)
+	}
+	if servicesReturned == 0 {
+		return nil, nil
+	}
+
+	var services []windows.ENUM_SERVICE_STATUS_PROCESS
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&services))
+	hdr.Data = unsafe.Pointer(&buf[0])
+	hdr.Len = int(servicesReturned)
+	hdr.Cap = int(servicesReturned)
+
+	var names []string
+	for _, s := range services {
+		name := windows.UTF16PtrToString(s.ServiceName)
+		names = append(names, name)
+	}
+	return names, nil
+}

--- a/vendor/golang.org/x/sys/windows/svc/mgr/recovery.go
+++ b/vendor/golang.org/x/sys/windows/svc/mgr/recovery.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package mgr
+
+import (
+	"errors"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/internal/unsafeheader"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// Possible recovery actions that the service control manager can perform.
+	NoAction       = windows.SC_ACTION_NONE        // no action
+	ComputerReboot = windows.SC_ACTION_REBOOT      // reboot the computer
+	ServiceRestart = windows.SC_ACTION_RESTART     // restart the service
+	RunCommand     = windows.SC_ACTION_RUN_COMMAND // run a command
+)
+
+// RecoveryAction represents an action that the service control manager can perform when service fails.
+// A service is considered failed when it terminates without reporting a status of SERVICE_STOPPED to the service controller.
+type RecoveryAction struct {
+	Type  int           // one of NoAction, ComputerReboot, ServiceRestart or RunCommand
+	Delay time.Duration // the time to wait before performing the specified action
+}
+
+// SetRecoveryActions sets actions that service controller performs when service fails and
+// the time after which to reset the service failure count to zero if there are no failures, in seconds.
+// Specify INFINITE to indicate that service failure count should never be reset.
+func (s *Service) SetRecoveryActions(recoveryActions []RecoveryAction, resetPeriod uint32) error {
+	if recoveryActions == nil {
+		return errors.New("recoveryActions cannot be nil")
+	}
+	actions := []windows.SC_ACTION{}
+	for _, a := range recoveryActions {
+		action := windows.SC_ACTION{
+			Type:  uint32(a.Type),
+			Delay: uint32(a.Delay.Nanoseconds() / 1000000),
+		}
+		actions = append(actions, action)
+	}
+	rActions := windows.SERVICE_FAILURE_ACTIONS{
+		ActionsCount: uint32(len(actions)),
+		Actions:      &actions[0],
+		ResetPeriod:  resetPeriod,
+	}
+	return windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_FAILURE_ACTIONS, (*byte)(unsafe.Pointer(&rActions)))
+}
+
+// RecoveryActions returns actions that service controller performs when service fails.
+// The service control manager counts the number of times service s has failed since the system booted.
+// The count is reset to 0 if the service has not failed for ResetPeriod seconds.
+// When the service fails for the Nth time, the service controller performs the action specified in element [N-1] of returned slice.
+// If N is greater than slice length, the service controller repeats the last action in the slice.
+func (s *Service) RecoveryActions() ([]RecoveryAction, error) {
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_FAILURE_ACTIONS)
+	if err != nil {
+		return nil, err
+	}
+	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
+	if p.Actions == nil {
+		return nil, err
+	}
+
+	var actions []windows.SC_ACTION
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&actions))
+	hdr.Data = unsafe.Pointer(p.Actions)
+	hdr.Len = int(p.ActionsCount)
+	hdr.Cap = int(p.ActionsCount)
+
+	var recoveryActions []RecoveryAction
+	for _, action := range actions {
+		recoveryActions = append(recoveryActions, RecoveryAction{Type: int(action.Type), Delay: time.Duration(action.Delay) * time.Millisecond})
+	}
+	return recoveryActions, nil
+}
+
+// ResetRecoveryActions deletes both reset period and array of failure actions.
+func (s *Service) ResetRecoveryActions() error {
+	actions := make([]windows.SC_ACTION, 1)
+	rActions := windows.SERVICE_FAILURE_ACTIONS{
+		Actions: &actions[0],
+	}
+	return windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_FAILURE_ACTIONS, (*byte)(unsafe.Pointer(&rActions)))
+}
+
+// ResetPeriod is the time after which to reset the service failure
+// count to zero if there are no failures, in seconds.
+func (s *Service) ResetPeriod() (uint32, error) {
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_FAILURE_ACTIONS)
+	if err != nil {
+		return 0, err
+	}
+	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
+	return p.ResetPeriod, nil
+}
+
+// SetRebootMessage sets service s reboot message.
+// If msg is "", the reboot message is deleted and no message is broadcast.
+func (s *Service) SetRebootMessage(msg string) error {
+	rActions := windows.SERVICE_FAILURE_ACTIONS{
+		RebootMsg: syscall.StringToUTF16Ptr(msg),
+	}
+	return windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_FAILURE_ACTIONS, (*byte)(unsafe.Pointer(&rActions)))
+}
+
+// RebootMessage is broadcast to server users before rebooting in response to the ComputerReboot service controller action.
+func (s *Service) RebootMessage() (string, error) {
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_FAILURE_ACTIONS)
+	if err != nil {
+		return "", err
+	}
+	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
+	return windows.UTF16PtrToString(p.RebootMsg), nil
+}
+
+// SetRecoveryCommand sets the command line of the process to execute in response to the RunCommand service controller action.
+// If cmd is "", the command is deleted and no program is run when the service fails.
+func (s *Service) SetRecoveryCommand(cmd string) error {
+	rActions := windows.SERVICE_FAILURE_ACTIONS{
+		Command: syscall.StringToUTF16Ptr(cmd),
+	}
+	return windows.ChangeServiceConfig2(s.Handle, windows.SERVICE_CONFIG_FAILURE_ACTIONS, (*byte)(unsafe.Pointer(&rActions)))
+}
+
+// RecoveryCommand is the command line of the process to execute in response to the RunCommand service controller action. This process runs under the same account as the service.
+func (s *Service) RecoveryCommand() (string, error) {
+	b, err := s.queryServiceConfig2(windows.SERVICE_CONFIG_FAILURE_ACTIONS)
+	if err != nil {
+		return "", err
+	}
+	p := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&b[0]))
+	return windows.UTF16PtrToString(p.Command), nil
+}

--- a/vendor/golang.org/x/sys/windows/svc/mgr/service.go
+++ b/vendor/golang.org/x/sys/windows/svc/mgr/service.go
@@ -1,0 +1,77 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package mgr
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+// TODO(brainman): Use EnumDependentServices to enumerate dependent services.
+
+// Service is used to access Windows service.
+type Service struct {
+	Name   string
+	Handle windows.Handle
+}
+
+// Delete marks service s for deletion from the service control manager database.
+func (s *Service) Delete() error {
+	return windows.DeleteService(s.Handle)
+}
+
+// Close relinquish access to the service s.
+func (s *Service) Close() error {
+	return windows.CloseServiceHandle(s.Handle)
+}
+
+// Start starts service s.
+// args will be passed to svc.Handler.Execute.
+func (s *Service) Start(args ...string) error {
+	var p **uint16
+	if len(args) > 0 {
+		vs := make([]*uint16, len(args))
+		for i := range vs {
+			vs[i] = syscall.StringToUTF16Ptr(args[i])
+		}
+		p = &vs[0]
+	}
+	return windows.StartService(s.Handle, uint32(len(args)), p)
+}
+
+// Control sends state change request c to the service s.
+func (s *Service) Control(c svc.Cmd) (svc.Status, error) {
+	var t windows.SERVICE_STATUS
+	err := windows.ControlService(s.Handle, uint32(c), &t)
+	if err != nil {
+		return svc.Status{}, err
+	}
+	return svc.Status{
+		State:   svc.State(t.CurrentState),
+		Accepts: svc.Accepted(t.ControlsAccepted),
+	}, nil
+}
+
+// Query returns current status of service s.
+func (s *Service) Query() (svc.Status, error) {
+	var t windows.SERVICE_STATUS_PROCESS
+	var needed uint32
+	err := windows.QueryServiceStatusEx(s.Handle, windows.SC_STATUS_PROCESS_INFO, (*byte)(unsafe.Pointer(&t)), uint32(unsafe.Sizeof(t)), &needed)
+	if err != nil {
+		return svc.Status{}, err
+	}
+	return svc.Status{
+		State:                   svc.State(t.CurrentState),
+		Accepts:                 svc.Accepted(t.ControlsAccepted),
+		ProcessId:               t.ProcessId,
+		Win32ExitCode:           t.Win32ExitCode,
+		ServiceSpecificExitCode: t.ServiceSpecificExitCode,
+	}, nil
+}

--- a/vendor/golang.org/x/sys/windows/svc/security.go
+++ b/vendor/golang.org/x/sys/windows/svc/security.go
@@ -1,0 +1,109 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
+
+package svc
+
+import (
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func allocSid(subAuth0 uint32) (*windows.SID, error) {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(&windows.SECURITY_NT_AUTHORITY,
+		1, subAuth0, 0, 0, 0, 0, 0, 0, 0, &sid)
+	if err != nil {
+		return nil, err
+	}
+	return sid, nil
+}
+
+// IsAnInteractiveSession determines if calling process is running interactively.
+// It queries the process token for membership in the Interactive group.
+// http://stackoverflow.com/questions/2668851/how-do-i-detect-that-my-application-is-running-as-service-or-in-an-interactive-s
+//
+// Deprecated: Use IsWindowsService instead.
+func IsAnInteractiveSession() (bool, error) {
+	interSid, err := allocSid(windows.SECURITY_INTERACTIVE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(interSid)
+
+	serviceSid, err := allocSid(windows.SECURITY_SERVICE_RID)
+	if err != nil {
+		return false, err
+	}
+	defer windows.FreeSid(serviceSid)
+
+	t, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return false, err
+	}
+	defer t.Close()
+
+	gs, err := t.GetTokenGroups()
+	if err != nil {
+		return false, err
+	}
+
+	for _, g := range gs.AllGroups() {
+		if windows.EqualSid(g.Sid, interSid) {
+			return true, nil
+		}
+		if windows.EqualSid(g.Sid, serviceSid) {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// IsWindowsService reports whether the process is currently executing
+// as a Windows service.
+func IsWindowsService() (bool, error) {
+	// The below technique looks a bit hairy, but it's actually
+	// exactly what the .NET framework does for the similarly named function:
+	// https://github.com/dotnet/extensions/blob/f4066026ca06984b07e90e61a6390ac38152ba93/src/Hosting/WindowsServices/src/WindowsServiceHelpers.cs#L26-L31
+	// Specifically, it looks up whether the parent process has session ID zero
+	// and is called "services".
+
+	var pbi windows.PROCESS_BASIC_INFORMATION
+	pbiLen := uint32(unsafe.Sizeof(pbi))
+	err := windows.NtQueryInformationProcess(windows.CurrentProcess(), windows.ProcessBasicInformation, unsafe.Pointer(&pbi), pbiLen, &pbiLen)
+	if err != nil {
+		return false, err
+	}
+	var psid uint32
+	err = windows.ProcessIdToSessionId(uint32(pbi.InheritedFromUniqueProcessId), &psid)
+	if err != nil || psid != 0 {
+		return false, nil
+	}
+	pproc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pbi.InheritedFromUniqueProcessId))
+	if err != nil {
+		return false, err
+	}
+	defer windows.CloseHandle(pproc)
+	var exeNameBuf [261]uint16
+	exeNameLen := uint32(len(exeNameBuf) - 1)
+	err = windows.QueryFullProcessImageName(pproc, 0, &exeNameBuf[0], &exeNameLen)
+	if err != nil {
+		return false, err
+	}
+	exeName := windows.UTF16ToString(exeNameBuf[:exeNameLen])
+	if !strings.EqualFold(filepath.Base(exeName), "services.exe") {
+		return false, nil
+	}
+	system32, err := windows.GetSystemDirectory()
+	if err != nil {
+		return false, err
+	}
+	targetExeName := filepath.Join(system32, "services.exe")
+	return strings.EqualFold(exeName, targetExeName), nil
+}

--- a/vendor/golang.org/x/sys/windows/svc/service.go
+++ b/vendor/golang.org/x/sys/windows/svc/service.go
@@ -1,0 +1,314 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build windows
+// +build windows
+
+// Package svc provides everything required to build Windows service.
+//
+package svc
+
+import (
+	"errors"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/internal/unsafeheader"
+	"golang.org/x/sys/windows"
+)
+
+// State describes service execution state (Stopped, Running and so on).
+type State uint32
+
+const (
+	Stopped         = State(windows.SERVICE_STOPPED)
+	StartPending    = State(windows.SERVICE_START_PENDING)
+	StopPending     = State(windows.SERVICE_STOP_PENDING)
+	Running         = State(windows.SERVICE_RUNNING)
+	ContinuePending = State(windows.SERVICE_CONTINUE_PENDING)
+	PausePending    = State(windows.SERVICE_PAUSE_PENDING)
+	Paused          = State(windows.SERVICE_PAUSED)
+)
+
+// Cmd represents service state change request. It is sent to a service
+// by the service manager, and should be actioned upon by the service.
+type Cmd uint32
+
+const (
+	Stop                  = Cmd(windows.SERVICE_CONTROL_STOP)
+	Pause                 = Cmd(windows.SERVICE_CONTROL_PAUSE)
+	Continue              = Cmd(windows.SERVICE_CONTROL_CONTINUE)
+	Interrogate           = Cmd(windows.SERVICE_CONTROL_INTERROGATE)
+	Shutdown              = Cmd(windows.SERVICE_CONTROL_SHUTDOWN)
+	ParamChange           = Cmd(windows.SERVICE_CONTROL_PARAMCHANGE)
+	NetBindAdd            = Cmd(windows.SERVICE_CONTROL_NETBINDADD)
+	NetBindRemove         = Cmd(windows.SERVICE_CONTROL_NETBINDREMOVE)
+	NetBindEnable         = Cmd(windows.SERVICE_CONTROL_NETBINDENABLE)
+	NetBindDisable        = Cmd(windows.SERVICE_CONTROL_NETBINDDISABLE)
+	DeviceEvent           = Cmd(windows.SERVICE_CONTROL_DEVICEEVENT)
+	HardwareProfileChange = Cmd(windows.SERVICE_CONTROL_HARDWAREPROFILECHANGE)
+	PowerEvent            = Cmd(windows.SERVICE_CONTROL_POWEREVENT)
+	SessionChange         = Cmd(windows.SERVICE_CONTROL_SESSIONCHANGE)
+	PreShutdown           = Cmd(windows.SERVICE_CONTROL_PRESHUTDOWN)
+)
+
+// Accepted is used to describe commands accepted by the service.
+// Note that Interrogate is always accepted.
+type Accepted uint32
+
+const (
+	AcceptStop                  = Accepted(windows.SERVICE_ACCEPT_STOP)
+	AcceptShutdown              = Accepted(windows.SERVICE_ACCEPT_SHUTDOWN)
+	AcceptPauseAndContinue      = Accepted(windows.SERVICE_ACCEPT_PAUSE_CONTINUE)
+	AcceptParamChange           = Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)
+	AcceptNetBindChange         = Accepted(windows.SERVICE_ACCEPT_NETBINDCHANGE)
+	AcceptHardwareProfileChange = Accepted(windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE)
+	AcceptPowerEvent            = Accepted(windows.SERVICE_ACCEPT_POWEREVENT)
+	AcceptSessionChange         = Accepted(windows.SERVICE_ACCEPT_SESSIONCHANGE)
+	AcceptPreShutdown           = Accepted(windows.SERVICE_ACCEPT_PRESHUTDOWN)
+)
+
+// Status combines State and Accepted commands to fully describe running service.
+type Status struct {
+	State                   State
+	Accepts                 Accepted
+	CheckPoint              uint32 // used to report progress during a lengthy operation
+	WaitHint                uint32 // estimated time required for a pending operation, in milliseconds
+	ProcessId               uint32 // if the service is running, the process identifier of it, and otherwise zero
+	Win32ExitCode           uint32 // set if the service has exited with a win32 exit code
+	ServiceSpecificExitCode uint32 // set if the service has exited with a service-specific exit code
+}
+
+// StartReason is the reason that the service was started.
+type StartReason uint32
+
+const (
+	StartReasonDemand           = StartReason(windows.SERVICE_START_REASON_DEMAND)
+	StartReasonAuto             = StartReason(windows.SERVICE_START_REASON_AUTO)
+	StartReasonTrigger          = StartReason(windows.SERVICE_START_REASON_TRIGGER)
+	StartReasonRestartOnFailure = StartReason(windows.SERVICE_START_REASON_RESTART_ON_FAILURE)
+	StartReasonDelayedAuto      = StartReason(windows.SERVICE_START_REASON_DELAYEDAUTO)
+)
+
+// ChangeRequest is sent to the service Handler to request service status change.
+type ChangeRequest struct {
+	Cmd           Cmd
+	EventType     uint32
+	EventData     uintptr
+	CurrentStatus Status
+	Context       uintptr
+}
+
+// Handler is the interface that must be implemented to build Windows service.
+type Handler interface {
+	// Execute will be called by the package code at the start of
+	// the service, and the service will exit once Execute completes.
+	// Inside Execute you must read service change requests from r and
+	// act accordingly. You must keep service control manager up to date
+	// about state of your service by writing into s as required.
+	// args contains service name followed by argument strings passed
+	// to the service.
+	// You can provide service exit code in exitCode return parameter,
+	// with 0 being "no error". You can also indicate if exit code,
+	// if any, is service specific or not by using svcSpecificEC
+	// parameter.
+	Execute(args []string, r <-chan ChangeRequest, s chan<- Status) (svcSpecificEC bool, exitCode uint32)
+}
+
+type ctlEvent struct {
+	cmd       Cmd
+	eventType uint32
+	eventData uintptr
+	context   uintptr
+	errno     uint32
+}
+
+// service provides access to windows service api.
+type service struct {
+	name    string
+	h       windows.Handle
+	c       chan ctlEvent
+	handler Handler
+}
+
+type exitCode struct {
+	isSvcSpecific bool
+	errno         uint32
+}
+
+func (s *service) updateStatus(status *Status, ec *exitCode) error {
+	if s.h == 0 {
+		return errors.New("updateStatus with no service status handle")
+	}
+	var t windows.SERVICE_STATUS
+	t.ServiceType = windows.SERVICE_WIN32_OWN_PROCESS
+	t.CurrentState = uint32(status.State)
+	if status.Accepts&AcceptStop != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_STOP
+	}
+	if status.Accepts&AcceptShutdown != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SHUTDOWN
+	}
+	if status.Accepts&AcceptPauseAndContinue != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PAUSE_CONTINUE
+	}
+	if status.Accepts&AcceptParamChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PARAMCHANGE
+	}
+	if status.Accepts&AcceptNetBindChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_NETBINDCHANGE
+	}
+	if status.Accepts&AcceptHardwareProfileChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_HARDWAREPROFILECHANGE
+	}
+	if status.Accepts&AcceptPowerEvent != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_POWEREVENT
+	}
+	if status.Accepts&AcceptSessionChange != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_SESSIONCHANGE
+	}
+	if status.Accepts&AcceptPreShutdown != 0 {
+		t.ControlsAccepted |= windows.SERVICE_ACCEPT_PRESHUTDOWN
+	}
+	if ec.errno == 0 {
+		t.Win32ExitCode = windows.NO_ERROR
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	} else if ec.isSvcSpecific {
+		t.Win32ExitCode = uint32(windows.ERROR_SERVICE_SPECIFIC_ERROR)
+		t.ServiceSpecificExitCode = ec.errno
+	} else {
+		t.Win32ExitCode = ec.errno
+		t.ServiceSpecificExitCode = windows.NO_ERROR
+	}
+	t.CheckPoint = status.CheckPoint
+	t.WaitHint = status.WaitHint
+	return windows.SetServiceStatus(s.h, &t)
+}
+
+var (
+	initCallbacks       sync.Once
+	ctlHandlerCallback  uintptr
+	serviceMainCallback uintptr
+)
+
+func ctlHandler(ctl, evtype, evdata, context uintptr) uintptr {
+	s := (*service)(unsafe.Pointer(context))
+	e := ctlEvent{cmd: Cmd(ctl), eventType: uint32(evtype), eventData: evdata, context: 123456} // Set context to 123456 to test issue #25660.
+	s.c <- e
+	return 0
+}
+
+var theService service // This is, unfortunately, a global, which means only one service per process.
+
+// serviceMain is the entry point called by the service manager, registered earlier by
+// the call to StartServiceCtrlDispatcher.
+func serviceMain(argc uint32, argv **uint16) uintptr {
+	handle, err := windows.RegisterServiceCtrlHandlerEx(windows.StringToUTF16Ptr(theService.name), ctlHandlerCallback, uintptr(unsafe.Pointer(&theService)))
+	if sysErr, ok := err.(windows.Errno); ok {
+		return uintptr(sysErr)
+	} else if err != nil {
+		return uintptr(windows.ERROR_UNKNOWN_EXCEPTION)
+	}
+	theService.h = handle
+	defer func() {
+		theService.h = 0
+	}()
+	var args16 []*uint16
+	hdr := (*unsafeheader.Slice)(unsafe.Pointer(&args16))
+	hdr.Data = unsafe.Pointer(argv)
+	hdr.Len = int(argc)
+	hdr.Cap = int(argc)
+
+	args := make([]string, len(args16))
+	for i, a := range args16 {
+		args[i] = windows.UTF16PtrToString(a)
+	}
+
+	cmdsToHandler := make(chan ChangeRequest)
+	changesFromHandler := make(chan Status)
+	exitFromHandler := make(chan exitCode)
+
+	go func() {
+		ss, errno := theService.handler.Execute(args, cmdsToHandler, changesFromHandler)
+		exitFromHandler <- exitCode{ss, errno}
+	}()
+
+	ec := exitCode{isSvcSpecific: true, errno: 0}
+	outcr := ChangeRequest{
+		CurrentStatus: Status{State: Stopped},
+	}
+	var outch chan ChangeRequest
+	inch := theService.c
+loop:
+	for {
+		select {
+		case r := <-inch:
+			if r.errno != 0 {
+				ec.errno = r.errno
+				break loop
+			}
+			inch = nil
+			outch = cmdsToHandler
+			outcr.Cmd = r.cmd
+			outcr.EventType = r.eventType
+			outcr.EventData = r.eventData
+			outcr.Context = r.context
+		case outch <- outcr:
+			inch = theService.c
+			outch = nil
+		case c := <-changesFromHandler:
+			err := theService.updateStatus(&c, &ec)
+			if err != nil {
+				ec.errno = uint32(windows.ERROR_EXCEPTION_IN_SERVICE)
+				if err2, ok := err.(windows.Errno); ok {
+					ec.errno = uint32(err2)
+				}
+				break loop
+			}
+			outcr.CurrentStatus = c
+		case ec = <-exitFromHandler:
+			break loop
+		}
+	}
+
+	theService.updateStatus(&Status{State: Stopped}, &ec)
+
+	return windows.NO_ERROR
+}
+
+// Run executes service name by calling appropriate handler function.
+func Run(name string, handler Handler) error {
+	initCallbacks.Do(func() {
+		ctlHandlerCallback = windows.NewCallback(ctlHandler)
+		serviceMainCallback = windows.NewCallback(serviceMain)
+	})
+	theService.name = name
+	theService.handler = handler
+	theService.c = make(chan ctlEvent)
+	t := []windows.SERVICE_TABLE_ENTRY{
+		{ServiceName: windows.StringToUTF16Ptr(theService.name), ServiceProc: serviceMainCallback},
+		{ServiceName: nil, ServiceProc: 0},
+	}
+	return windows.StartServiceCtrlDispatcher(&t[0])
+}
+
+// StatusHandle returns service status handle. It is safe to call this function
+// from inside the Handler.Execute because then it is guaranteed to be set.
+func StatusHandle() windows.Handle {
+	return theService.h
+}
+
+// DynamicStartReason returns the reason why the service was started. It is safe
+// to call this function from inside the Handler.Execute because then it is
+// guaranteed to be set.
+func DynamicStartReason() (StartReason, error) {
+	var allocReason *uint32
+	err := windows.QueryServiceDynamicInformation(theService.h, windows.SERVICE_DYNAMIC_INFORMATION_LEVEL_START_REASON, unsafe.Pointer(&allocReason))
+	if err != nil {
+		return 0, err
+	}
+	reason := StartReason(*allocReason)
+	windows.LocalFree(windows.Handle(unsafe.Pointer(allocReason)))
+	return reason, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -391,6 +391,8 @@ golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/plan9
 golang.org/x/sys/unix
 golang.org/x/sys/windows
+golang.org/x/sys/windows/svc
+golang.org/x/sys/windows/svc/mgr
 # golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 ## explicit; go 1.17
 golang.org/x/term


### PR DESCRIPTION
This commits adds interfaces to interact with the Windows service API.
A unit tested implementation has been added, along with unit tests to
ensure the proper behavior is being maintained. These interfaces should
be used when developing WICD, to enable large portions of the program to
be unit testable.