### PR TITLE
[e2e] Initialize OpenShift client's cache

### DIFF
--- a/test/e2e/clusterinfo/openshift.go
+++ b/test/e2e/clusterinfo/openshift.go
@@ -69,7 +69,10 @@ func GetOpenShift() (*OpenShift, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	c, err := client.New(rc, client.Options{})
+	if err != nil {
+		return nil, err
+	}
 	return &OpenShift{
 		Config:     cc,
 		Operator:   oc,
@@ -78,6 +81,7 @@ func GetOpenShift() (*OpenShift, error) {
 		Route:      routec,
 		K8s:        kc,
 		Images:     ic,
+		Cache:      c,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds the Cache initialization to the creation of the client
for the current OpenShift cluster, so that it is available during the
e2e test suite execution.

Follow-up to https://github.com/openshift/windows-machine-config-operator/commit/f57effd61af8859236067ea3c012f64dc21fff74