### PR TITLE
WINC-799: [controllers] Tighten node permissions

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -200,8 +200,11 @@ spec:
           resources:
           - nodes
           verbs:
-          - '*'
+          - delete
+          - get
           - list
+          - patch
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,8 +59,11 @@ rules:
   resources:
   - nodes
   verbs:
-  - '*'
+  - delete
+  - get
   - list
+  - patch
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -52,6 +52,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 
 const (

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=*
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch;update
 
 const (

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -42,7 +42,7 @@ import (
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machinesets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=*
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;patch;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;
 //+kubebuilder:rbac:groups="",resources=events,verbs=*
 


### PR DESCRIPTION
This commit adjusts the RBAC permission for the nodes resource by
explicitly listing the required verbs.

Ran:
```
make bundle
```