### PR TITLE
WINC-755: Use patched Windows Server 2022 golden image in vSphere CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The following template variables need to be replaced as follows with values from
 * *\<vCenter Server FQDN/IP\>*: IP address or FQDN of the vCenter server
 
 *IMPORTANT*:
-- The template used in the MachineSet must be a Windows Server 1909
-  image as described in [vSphere prerequisites](docs/vsphere-prerequisites.md).
+- The VM template provided in the MachineSet must use a supported Windows Server
+  version, as described in [vSphere prerequisites](docs/vsphere-prerequisites.md).
 - On vSphere, Windows Machine names cannot be more than 15 characters long. The
   MachineSet name, therefore, cannot be more than 9 characters long, due to the
   way Machine names are generated from it.

--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -111,7 +111,20 @@ on TCP port `10250` by running the following PowerShell command:
     New-NetFirewallRule -DisplayName "ContainerLogsPort" -LocalPort 10250 -Enabled True -Direction Inbound -Protocol TCP -Action Allow -EdgeTraversalPolicy Allow
 ```
 
-## 6. Generalize the virtual machine installation
+## 6. Install OS-level container networking patch KB5012637 
+
+Download the patch files from the [Microsoft Update Catalog](https://www.catalog.update.microsoft.com/Search.aspx?q=KB5012637).
+Then, install the patch. Windows Command Prompt example:
+* `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet /norestart`
+
+Alternatively, you can use the PowerShell script [install-kb5012637.ps1](vsphere_ci/scripts/install-kb5012637.ps1) to 
+programmatically download and install the required patch:
+
+```powershell
+    ./install-kb5012637.ps1
+```
+
+## 7. Generalize the virtual machine installation
 
 To deploy the Windows VM as a reusable image, you have to first generalize the VM removing computer-specific information 
 such as installed drivers. Running the `sysprep` command with a *unattend* answer file generalizes the image and 
@@ -138,7 +151,7 @@ where `<path/to/unattend.xml>` is the path to the customized answer file.
 Note: There is [a limit](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation#limits-on-how-many-times-you-can-run-sysprep)
 on how many times you can run the `sysprep` command.
 
-## 7. Set up the virtual machine template
+## 8. Set up the virtual machine template
 
 Once the `sysprep` command completes the Windows virtual machine will power off. 
 
@@ -150,7 +163,7 @@ Next, you need to convert this virtual machine, in Power-Off status, to a Templa
 |:---|
 |Figure 1. Steps to convert a VM to Template in vCenter|
 
-## 8. Using the virtual machine template
+## 9. Using the virtual machine template
 
 In order to use the recently created template, enter the template name in the [machineset](../README.md#configuring-windows-instances-provisioned-through-machinesets).
 

--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -4,13 +4,12 @@ This guide describes the thought process of creating a Windows virtual machine b
 
 ## 1. Select a compatible Windows Server version
 
-Currently, the Windows Machine Config Operator (WMCO) stable version only supports Windows Server Semi-Annual
-Channel (SAC): Windows Server 2004, that includes the patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351), 
-required by the operating system to allow using the [hybrid OVN Kubernetes networking with a 
-custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.
+Currently, the Windows Machine Config Operator (WMCO) stable version supports:
+* Windows Server 2022 Long-Term Servicing Channel (must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d))
+* Windows Server 20H2 Semi-Annual Channel
 
-*Please note that Windows Server Long-Term Servicing Channel (LTSC): Windows Server 1809 cannot be used, since 
-the patch is not available.*
+*Please note that Windows Server 2019 is unsupported, as patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351)
+is not included. This is a requirement of the [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.*
 
 ## 2. Create the virtual machine
 

--- a/docs/vsphere-prerequisites.md
+++ b/docs/vsphere-prerequisites.md
@@ -5,7 +5,7 @@ the following pre-requisites are required:
 
 * The vSphere cluster must be configured with [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere)
   to work around the pod-to-pod connectivity between hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere)
-* Set up a [Windows Server Semi-Annual Channel (SAC): Windows Server 2004 VM golden image](vsphere-golden-image.md)
+* Set up a [VM golden image with a compatible Windows Server version](vsphere-golden-image.md#1-select-a-compatible-windows-server-version).
 * Add a [DNS entry](#adding-a-dns-entry-in-vsphere-environment) for the internal API endpoint in the vSphere environment
 
 Alternatively, a programmatic approach for the creation of the Windows VM golden image can be found [here.](vsphere_ci/README.md)

--- a/docs/vsphere_ci/README.md
+++ b/docs/vsphere_ci/README.md
@@ -37,6 +37,7 @@ bastion host and has the following files:
     - install-openssh.ps1
     - install-docker.ps1
     - install-firewall-rules.ps1
+    - install-kb5012637.ps1
 
 The [authorized_keys](scripts/authorized_keys) file must contain a public key, where the private key 
 associated with this public key is what will be used by WMCO to configure VMs created from Windows VM. After 
@@ -50,6 +51,7 @@ The [autounattend.xml](scripts/autounattend.xml) file must be edited to update t
 - Runs `install-openssh.ps1` script which installs and configures OpenSSH Server
 - Runs `install-docker.ps1` script which installs Docker
 - Runs `install-firewall-rules.ps1` script which configures the firewall rules
+- Runs `install-kb5012637.ps1` script which installs a required Windows OS-level container networking patch
 
 The above [autounattend.xml](scripts/autounattend.xml) script is different from the [unattend.xml](../unattend.xml)
 as this script does Windows OS installation as well.
@@ -111,7 +113,7 @@ VM starts. You can specify all the commands that needs to executed on first boot
 
 Once the Packer build completes successfully, a new VM template with name `<vm-template-name>` will be created in
 the folder `<vm-template-folder>` following the [Variables](#variables). The later VM template is ready to use as a
-golden image, as described in [the documentation](../vsphere-golden-image.md#8-using-the-virtual-machine-template).
+golden image, as described in [the documentation](../vsphere-golden-image.md#9-using-the-virtual-machine-template).
 
 ## References
 - [Sample autounattend](https://github.com/guillermo-musumeci/packer-vsphere-iso-windows/blob/master/win2019.base/win2019.base.json)

--- a/docs/vsphere_ci/README.md
+++ b/docs/vsphere_ci/README.md
@@ -44,7 +44,8 @@ associated with this public key is what will be used by WMCO to configure VMs cr
 deploying WMCO, this private key will be provided by the user in the form of a Secret.
 
 The [autounattend.xml](scripts/autounattend.xml) file must be edited to update the value of 
-`WindowsPassword` with a user provided password. Then, it executes the following steps:
+`WindowsPassword` with a user provided password. The `ProductKey` must also be updated with a proper value.
+autounattend.xml specifies that the following steps should occur:
 
 - Runs `install-vm-tools.cmd` script which installs VMWare tools
 - Runs `configure-vm-tools.ps1` script which configures VMWare tools
@@ -100,6 +101,16 @@ To enable detailed logging:
 ```bash
   PACKER_LOG=1 packer build build.json
 ```
+
+### What to do during the Packer build
+
+During the golden image creation, it is highly recommended to establish access to the virtual machine by launching a
+Web Console through the vCenter web client. This can be done after the Packer build has powered on the VM (while it is
+*Waiting for IP...*).
+
+If the build halts and prompts for a product key during the Windows OS setup, manual intervention will be required.
+When accessing the vitual machine via Web Console, send a `Ctrl+Alt+Del` then tab over to `I don't have a product key`,
+and hit `Enter` on the keyboard. This should start the OS setup as intended.
 
 ## What actually happens during build
 

--- a/docs/vsphere_ci/build.json
+++ b/docs/vsphere_ci/build.json
@@ -1,9 +1,9 @@
 {
   "variables": {
-    "os-iso-path": "[WorkloadDatastore] windows-iso-images/winsrv2004_sep_2020_x64_dvd.iso",
+    "os-iso-path": "[WorkloadDatastore] windows-iso-images/winsrv2022_sep_2021_x64_dvd.iso",
     "vmtools-iso-path": "[WorkloadDatastore] windows-iso-images/vmtools-v11360-windows.iso",
     "vm-template-folder": "windows-golden-images",
-    "vm-template-name": "windows-server-2004-template",
+    "vm-template-name": "windows-server-2022-template-withDocker",
     "vm-elevated-password": "WindowsPassword",
     "vsphere-cluster": "Cluster-1",
     "vsphere-datacenter": "SDDC-Datacenter",

--- a/docs/vsphere_ci/build.json
+++ b/docs/vsphere_ci/build.json
@@ -18,7 +18,7 @@
   ],
   "provisioners": [
     {
-      "pause_before": "3m",
+      "pause_before": "10m",
       "inline": [
         "ipconfig"
       ],
@@ -48,7 +48,8 @@
         "scripts/configure-vm-tools.ps1",
         "scripts/install-openssh.ps1",
         "scripts/install-docker.ps1",
-        "scripts/install-firewall-rules.ps1"
+        "scripts/install-firewall-rules.ps1",
+        "scripts/install-kb5012637.ps1"
       ],
       "vm_version": 15,
       "guest_os_type": "windows9Server64Guest",

--- a/docs/vsphere_ci/scripts/autounattend.xml
+++ b/docs/vsphere_ci/scripts/autounattend.xml
@@ -117,6 +117,11 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>7</Order>
+                    <Description>Install Windows Patch KB5012637</Description>
+                    <CommandLine>cmd.exe /c powershell.exe -File a:\install-kb5012637.ps1</CommandLine>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>8</Order>
                     <Description>Install Docker</Description>
                     <CommandLine>cmd.exe /c powershell.exe -File a:\install-docker.ps1</CommandLine>
                 </SynchronousCommand>

--- a/docs/vsphere_ci/scripts/autounattend.xml
+++ b/docs/vsphere_ci/scripts/autounattend.xml
@@ -62,6 +62,9 @@
             </ImageInstall>
             <UserData>
                 <AcceptEula>true</AcceptEula>
+                <ProductKey>
+                    <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>
+                </ProductKey>
             </UserData>
         </component>
     </settings>
@@ -144,5 +147,5 @@
             </UserAccounts>
         </component>
     </settings>
-    <cpi:offlineImage cpi:source="wim:c:/wim/install.wim#Windows Server 2019 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
+    <cpi:offlineImage cpi:source="wim:c:/wim/install.wim#Windows Server 2022 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
 </unattend>

--- a/docs/vsphere_ci/scripts/install-kb5012637.ps1
+++ b/docs/vsphere_ci/scripts/install-kb5012637.ps1
@@ -1,0 +1,13 @@
+# Powershell script to download and install Windows OS patch KB5012637
+#
+# USAGE
+#    ./install-kb5012637.ps1
+
+# Download the patch file from MSFT
+$patchFile = "windows10.0-kb5012637-x64_6a7459b60e226b0ad0d30b34a4be069bee4d2867.msu"
+$url = "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/04/$patchFile"
+$dest = "C:\Windows\Temp\$patchFile"
+Invoke-WebRequest -Uri $url -OutFile $dest
+
+# Install the patch, bypassing any prompts
+cmd.exe /c wusa.exe $dest /quiet /norestart

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -18,11 +18,13 @@ applicable cloud provider.
 Note: Any unlisted Windows Server version are NOT supported, and will cause errors. To prevent 
 these errors, only use the appropriate version according to the cloud provider in use. 
 
-| Cloud Provider | Supported Windows Server version                                       |
-|----------------|------------------------------------------------------------------------|
-| AWS            | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| Azure          | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| VMware vSphere | Windows Server Semi-Annual Channel (SAC): Windows Server 20H2          |
+| Cloud Provider | Supported Windows Server version                                                     |
+|----------------|--------------------------------------------------------------------------------------|
+| AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| Azure          | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| VMware vSphere | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
+
+*Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
 
 ## Supported Networking
 [OVNKubernetes hybrid networking](setup-hybrid-OVNKubernetes-cluster.md) is the only supported networking configuration.
@@ -39,10 +41,10 @@ Note:
 | Azure          | Hybrid OVNKubernetes                                                                           |
 | VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vsphere) |
 
-| Hybrid OVNKubernetes | Supported Windows Server version                                       |
-|----------------------|------------------------------------------------------------------------|
-| Default VXLAN port   | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| Custom VXLAN port    | Windows Server Semi-Annual Channel (SAC): Windows Server 20H2          |
+| Hybrid OVNKubernetes | Supported Windows Server version                                                     |
+|----------------------|--------------------------------------------------------------------------------------|
+| Default VXLAN port   | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| Custom VXLAN port    | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
 
 ## Supported Installation method
 * Installer-Provisioned Infrastructure installation method is the only supported installation method. This is 

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -185,7 +185,7 @@ get_vsphere_ms() {
 
   # set golden image template name
   # TODO: read from parameter
-  template="windows-golden-images/windows-server-2022-template-networkHotfix"
+  template="windows-golden-images/windows-server-2022-template-withDocker"
 
   # TODO: Reduce the number of API calls, make just one call
   #       to `oc get machines` and pass the data around. This is the

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -47,7 +47,7 @@ func (p *Provider) newVSphereMachineProviderSpec(clusterID string) (*mapi.VSpher
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2022-template-networkHotfix"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-withDocker"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)


### PR DESCRIPTION
Manual backport of relevant commits from #1052:

- Use patched Windows Server 2022 image (with Docker) in vSphere CI
- Update golden image creation docs + scripts with steps to install OS patch
- Announce Windows Server 2022 Support for vSphere