### PR TITLE
 [docs] Update on containerd pre requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ Cluster autoscaling is supported for Windows instances.
 - Define and deploy a [MachineAutoscaler](https://docs.openshift.com/container-platform/latest/machine_management/applying-autoscaling.html#configuring-machineautoscaler), referencing a Windows MachineSet.
 
 ### Container Runtime
-Windows instances brought up with WMCO are set up with the containerd container runtime.
+Windows instances brought up with WMCO are set up with the containerd container runtime. As WMCO installs and manages the container runtime,
+it is recommended not to preinstall containerd in MachineSet or BYOH Windows instances.
 
 ## Development
 

--- a/docs/byoh-instance-pre-requisites.md
+++ b/docs/byoh-instance-pre-requisites.md
@@ -9,4 +9,5 @@ The following pre-requisites must be fulfilled in order to add a Windows BYOH no
   * Contain only lowercase alphanumeric characters or '-'.
   * Start with an alphanumeric character.
   * End with an alphanumeric character.
-* A PTR record must exist corresponding to the instance address which resolves to the instance hostname for successful reverse DNS lookups. 
+* A PTR record must exist corresponding to the instance address which resolves to the instance hostname for successful reverse DNS lookups.
+* Containerd should not be installed. If it is installed already, it is recommended to uninstall as WMCO installs and manages containerd.


### PR DESCRIPTION
Update containerd pre requisites information. As WMCO installs and
manages containerd runtime, it is recommanded not to install by user.

Signed-off-by: selansen <esiva@redhat.com>