### PR TITLE
Bug 2070892: Skip node addresses without PTR record during instance de-configuration

### DIFF
--- a/controllers/configmap_controller_test.go
+++ b/controllers/configmap_controller_test.go
@@ -8,6 +8,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/instance"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
@@ -92,6 +93,60 @@ func TestIsValidConfigMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			isValidConfigMap := r.isValidConfigMap(test.configMapObj)
 			require.Equal(t, test.isValidConfigMap, isValidConfigMap)
+		})
+	}
+}
+
+func TestHasAssociatedInstance(t *testing.T) {
+	type args struct {
+		nodeAddresses []core.NodeAddress
+		instances     []*instance.Info
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ignore external address with no reverse lookup record and use internal IP",
+			args: args{
+				nodeAddresses: []core.NodeAddress{
+					{Type: core.NodeExternalIP, Address: "11.22.33.44"},
+					{Type: core.NodeInternalIP, Address: "127.0.0.1"},
+				},
+				instances: []*instance.Info{{Address: "localhost"}},
+			},
+			want: true,
+		},
+		{
+			name: "valid internal IP",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalIP, Address: "1.2.3.4"}},
+				instances:     []*instance.Info{{IPv4Address: "1.2.3.4"}},
+			},
+			want: true,
+		},
+		{
+			name: "valid internal DNS",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalDNS, Address: "internal.local"}},
+				instances:     []*instance.Info{{Address: "internal.local"}},
+			},
+			want: true,
+		},
+		{
+			name: "internal IP with invalid DNS lookup",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalIP, Address: "1.2.3.4"}},
+				instances:     []*instance.Info{{Address: "invalid.dns"}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasAssociatedInstance(tt.args.nodeAddresses, tt.args.instances)
+			require.Equalf(t, tt.want, got, "hasAssociatedInstance(%s, %s)", tt.args.nodeAddresses, tt.args.instances)
 		})
 	}
 }


### PR DESCRIPTION
This PR updates the de-configuration workflow to ignore all
node addresses that fail to resolve a valid reverse lookup record
while looking for the associated Windows instance.
