### PR TITLE
WINC-700: [hack] Introduce community manifests generation script

### DIFF
--- a/hack/community/csv/description.md
+++ b/hack/community/csv/description.md
@@ -1,0 +1,19 @@
+## WARNING
+Community distribution of the Windows Machine Config Operator.
+This is a preview build, and is not meant for production workloads.
+Issues with this distribution of WMCO can be opened against the [WMCO repository](https://github.com/openshift/windows-machine-config-operator).
+Please read through the [troubleshooting doc](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/docs/TROUBLESHOOTING.md)
+before opening an issue.
+Please ensure that when installing this operator the starting CSV you subscribe to is supported on the
+version of OKD/OCP you are using. This CSV is meant for OKD/OCP COMMUNITY_VERSION.
+## Documentation
+### Introduction
+The Windows Machine Config Operator configures Windows instances into nodes, enabling Windows container workloads
+to be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+or by specifying existing instances through a [ConfigMap](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/README.md#configuring-byoh-bring-your-own-host-windows-instances).
+Through either method, the Windows instance must have the containerd container runtime installed. The operator will do 
+all the necessary steps to configure the instance so that it can join the cluster as a worker node.
+### Pre-requisites
+- [Cluster and OS pre-requisites](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/docs/wmco-prerequisites.md)
+### Usage
+Please see the usage section of [README.md](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/README.md#usage).

--- a/hack/community/generate.sh
+++ b/hack/community/generate.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Given the current WMCO manifests, generate new community manifests.
+
+# Must be ran within WMCO root.
+
+# Example:
+# Cut community v5.1.0 for community-4.10
+# Run: bash ./hack/community/generate.sh 5.1.0 community-4.10 community-4.10-hash ../community-operators-prod
+
+# replace necessary fields with the yq tool
+replace() {
+    local CO_CSV=$1
+    local OPERATOR_VERSION=$2
+    local DESCRIPTION=$3
+    local QUAY_IMAGE=$4
+    local CO_ANNOTATIONS=$5
+    local CREATED_AT=$(date +"%Y-%m-%dT%H:%M:%SZ")
+    local OPERATOR_NAME="community-windows-machine-config-operator"
+    local NAME="${OPERATOR_NAME}.v$OPERATOR_VERSION"
+    local CO_DESCRIPTION=$DESCRIPTION
+    local DISPLAY_NAME="Community Windows Machine Config Operator"
+    local IMAGE=$QUAY_IMAGE
+    local MATURITY="preview"
+    local VERSION="$OPERATOR_VERSION"
+
+    # TODO: description contains \n literals, user will have to manually turn this into a multi-line string
+    # Replace CSV fields
+    yq eval --exit-status --inplace "
+      .metadata.annotations.createdAt |= \"$CREATED_AT\" |
+      .metadata.name |= \"$NAME\" |
+      .spec.description |= \"$CO_DESCRIPTION\" |
+      .spec.displayName |= \"$DISPLAY_NAME\" |
+      .spec.install.spec.deployments[0].spec.template.spec.containers[0].env[2].value |= \"$OPERATOR_NAME\" |
+      .spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= \"$IMAGE\" |
+      .spec.maturity |= \"$MATURITY\" |
+      .spec.version |= \"$VERSION\"
+    " "${CO_CSV}"
+
+    # Delete the subscription line
+    yq eval --exit-status --inplace 'del(.metadata.annotations."operators.openshift.io/valid-subscription")' "${CO_CSV}"
+
+    # Replace annotations fields
+    # TODO: use yq for the annotations.yaml replacement
+    sed -i -e "s/"preview,stable"/$MATURITY/" -e "s/"stable"/$MATURITY/" "${CO_ANNOTATIONS}"
+}
+
+# copy the WMCO bundle and its contents to a new community folder. Rename files
+# as needed.
+generate_manifests() {
+  local OPERATOR_VERSION=$1
+  local BUNDLE_DIR=$2
+  local DESCRIPTION=$3
+  local QUAY_IMAGE=$4
+  local CO_OPERATOR_DIR="$(pwd)/operators/community-windows-machine-config-operator"
+
+  echo "Update operator manifests"
+  mkdir -p "${CO_OPERATOR_DIR}/${OPERATOR_VERSION}"
+  cp -r "${BUNDLE_DIR}/manifests" "${BUNDLE_DIR}/metadata" "${CO_OPERATOR_DIR}/${OPERATOR_VERSION}"
+  mv "${CO_OPERATOR_DIR}/${OPERATOR_VERSION}/manifests/windows-machine-config-operator.clusterserviceversion.yaml" "${CO_OPERATOR_DIR}/${OPERATOR_VERSION}/manifests/community-windows-machine-config-operator.${OPERATOR_VERSION}.clusterserviceversion.yaml"
+  local CO_CSV="${CO_OPERATOR_DIR}/${OPERATOR_VERSION}/manifests/community-windows-machine-config-operator.${OPERATOR_VERSION}.clusterserviceversion.yaml"
+  local CO_ANNOTATIONS="${CO_OPERATOR_DIR}/${OPERATOR_VERSION}/metadata/annotations.yaml"
+
+  replace "$CO_CSV" "$OPERATOR_VERSION" "$DESCRIPTION" "$QUAY_IMAGE" "$CO_ANNOTATIONS"
+}
+
+# Create a signed commit for the community-operators-prod repo
+commit() {
+  local OPERATOR_VERSION=$1
+  TITLE="operators community-windows-machine-config-operator.v$OPERATOR_VERSION"
+
+  echo "commit changes"
+  git add --all
+  git commit -s -m "${TITLE}"
+}
+
+OPERATOR_VERSION="$1"
+COMMUNITY_VERSION="$2"
+QUAY_IMAGE="$3"
+CO_DIR="$4"
+OPERATOR_MANIFESTS="bundle/manifests"
+OPERATOR_METADATA="bundle/metadata"
+
+if [ -z "$QUAY_IMAGE" ]; then
+    echo "Must set QUAY_IMAGE to latest community tag"
+    exit 1
+fi
+
+if [ -z $CO_DIR ]; then
+  echo "CO_DIR not set"
+  exit 1
+fi
+
+# Check if yq is installed
+if ! command -v which yq &> /dev/null; then
+  echo "Please install yq before running generate.sh. Directions to install yq are in the readme.md"
+  exit 1
+fi
+
+echo "Cutting community release for v${OPERATOR_VERSION}"
+
+# Inject appropriate community-version into the description
+DESCRIPTION=$(cat hack/community/csv/description.md)
+DESCRIPTION=${DESCRIPTION//COMMUNITY_VERSION/$COMMUNITY_VERSION}
+
+BUNDLE_DIR=$(pwd)/bundle
+pushd "${CO_DIR}"
+git checkout -B "${OPERATOR_VERSION}"
+generate_manifests "$OPERATOR_VERSION" "$BUNDLE_DIR" "$DESCRIPTION" "$QUAY_IMAGE"
+commit "$OPERATOR_VERSION"
+popd

--- a/hack/community/readme.md
+++ b/hack/community/readme.md
@@ -1,0 +1,45 @@
+# Cut a new community release
+The generate.sh script automates the community release process by copying over 
+the latest WMCO manifests to a new community-WMCO folder while also replacing 
+necessary fields such as the name, description, and image. It also generates a 
+signed commit ready to be pushed to community-operators-prod repo. 
+
+## Pre-requisites
+Before running generate.sh, please ensure the following has merged:
+- openshift/release PR to add CI jobs to relevant community branch.
+[Example](https://github.com/openshift/release/pull/27081)
+- Submodule update PR for the relevant community branch. 
+- Ensure WMCB submodule is pointing to relevant community branch.
+[Example](https://github.com/openshift/windows-machine-config-operator/blob/community-4.10/.gitmodules#L4)
+- Fork and clone [community-operators-prod repo](https://github.com/redhat-openshift-ecosystem/community-operators-prod) 
+- Install yq:
+```shell script
+  curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64 -o /tmp/yq && chmod +x /tmp/yq
+```
+
+### From WMCO root, run:
+Parameter 3 can be grabbed from our [Quay repo](https://quay.io/repository/openshift-windows/community-windows-machine-config-operator?tab=tags).
+```shell script
+bash ./hack/community/generate.sh <community_wmco_version> <community_ocp_version> <latest_community-4.x_tag-commit-hash> <path/to/community-operators-prod>
+```
+Example: Cut community release v5.1.0 for community-4.10
+```shell script
+bash ./hack/community/generate.sh 5.1.0 community-4.10 community-4.10-hash ../community-operators-prod
+```
+
+### Review and test the operator
+- Scan over the newly generated CSV to ensure all the necessary fields were replaced
+- Follow: https://github.com/openshift/windows-machine-config-operator/blob/master/docs/HACKING.md#i-want-to-try-the-unreleased-wmco-and-deploy-it-mimicking-the-official-deployment-method 
+  You may skip step: Building the bundle image.
+- [CSV validation](https://operatorhub.io/preview) - paste in the CSV contents to
+preview what the community operator will look like in Operator Hub.
+
+
+### Ask for reviews
+- Tag WINC team for review
+- Tag your community-operators-prod PR reviewer to ask for a manual override to 
+merge. Sample message: 
+  - “This PR has been tested locally. OCP v4.x will not pass CI 
+  since our operator requires a cluster with hybrid-ovn networking for it to 
+  start up properly. This is by design. Will need a manual override for this to 
+  merge.”


### PR DESCRIPTION
This PR automates the community release process through a bash
script that generates the community manifests and commits them to the
community-operator-prod repo.

[readme.md preview](https://github.com/alinaryan/windows-machine-config-operator/blob/WINC-700/hack/community/readme.md)
[description.md preview](https://github.com/alinaryan/windows-machine-config-operator/blob/WINC-700/hack/community/csv/description.md)