### PR TITLE
[community-4.10] OCPBUGSM-42819: Skip node addresses without PTR record during instance de-configuration

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -223,11 +223,7 @@ func (r *ConfigMapReconciler) deconfigureInstances(instances []*instance.Info, n
 		Namespace: r.watchNamespace}}
 	for _, node := range nodes.Items {
 		// Check for instances associated with this node
-		hasEntry, err := hasAssociatedInstance(node.Status.Addresses, instances)
-		if err != nil {
-			return errors.Wrapf(err, "unable to find instance associated with node %s", node.GetName())
-		}
-		if hasEntry {
+		if hasAssociatedInstance(node.Status.Addresses, instances) {
 			continue
 		}
 
@@ -243,30 +239,31 @@ func (r *ConfigMapReconciler) deconfigureInstances(instances []*instance.Info, n
 
 // hasAssociatedInstance returns true if any of the given addresses is associated with any instance in the given slice.
 // The instance's network address must be a valid IPv4 address or resolve to one.
-func hasAssociatedInstance(nodeAddresses []core.NodeAddress, instances []*instance.Info) (bool, error) {
+func hasAssociatedInstance(nodeAddresses []core.NodeAddress, instances []*instance.Info) bool {
 	for _, nodeAddress := range nodeAddresses {
 		for _, instanceInfo := range instances {
 			// Direct match node network address whether it is a DNS name or an IP address
 			if nodeAddress.Address == instanceInfo.Address || nodeAddress.Address == instanceInfo.IPv4Address {
-				return true, nil
+				return true
 			}
 		}
 		// Reverse lookup on node IP trying to find a match to an instance specified by DNS entry
 		if parseAddr := net.ParseIP(nodeAddress.Address); parseAddr != nil {
 			dnsAddresses, err := net.LookupAddr(nodeAddress.Address)
 			if err != nil {
-				return false, errors.Wrapf(err, "failed to lookup DNS for IP %s", nodeAddress.Address)
+				// skip node's address without reverse lookup records
+				continue
 			}
 			for _, dns := range dnsAddresses {
 				for _, instanceInfo := range instances {
 					if dns == instanceInfo.Address {
-						return true, nil
+						return true
 					}
 				}
 			}
 		}
 	}
-	return false, nil
+	return false
 }
 
 // mapToConfigMap fulfills the MapFn type, while always returning a request to the windows-instance ConfigMap

--- a/controllers/configmap_controller_test.go
+++ b/controllers/configmap_controller_test.go
@@ -8,6 +8,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/instance"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
@@ -71,6 +72,60 @@ func TestIsValidConfigMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			isValidConfigMap := r.isValidConfigMap(test.configMapObj)
 			require.Equal(t, test.isValidConfigMap, isValidConfigMap)
+		})
+	}
+}
+
+func TestHasAssociatedInstance(t *testing.T) {
+	type args struct {
+		nodeAddresses []core.NodeAddress
+		instances     []*instance.Info
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ignore external address with no reverse lookup record and use internal IP",
+			args: args{
+				nodeAddresses: []core.NodeAddress{
+					{Type: core.NodeExternalIP, Address: "11.22.33.44"},
+					{Type: core.NodeInternalIP, Address: "127.0.0.1"},
+				},
+				instances: []*instance.Info{{Address: "localhost"}},
+			},
+			want: true,
+		},
+		{
+			name: "valid internal IP",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalIP, Address: "1.2.3.4"}},
+				instances:     []*instance.Info{{IPv4Address: "1.2.3.4"}},
+			},
+			want: true,
+		},
+		{
+			name: "valid internal DNS",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalDNS, Address: "internal.local"}},
+				instances:     []*instance.Info{{Address: "internal.local"}},
+			},
+			want: true,
+		},
+		{
+			name: "internal IP with invalid DNS lookup",
+			args: args{
+				nodeAddresses: []core.NodeAddress{{Type: core.NodeInternalIP, Address: "1.2.3.4"}},
+				instances:     []*instance.Info{{Address: "invalid.dns"}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasAssociatedInstance(tt.args.nodeAddresses, tt.args.instances)
+			require.Equalf(t, tt.want, got, "hasAssociatedInstance(%s, %s)", tt.args.nodeAddresses, tt.args.instances)
 		})
 	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/windows-machine-config-operator/pull/1045