### PR TITLE
Correct Windows service start/stop behavior

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -194,8 +194,8 @@ func (sc *ServiceController) reconcileService(service winsvc.Service, expected s
 	}
 
 	if updateRequired {
-		// Always stop the service before updating its config, just to be safe
-		if _, err := service.Control(svc.Stop); err != nil {
+		// Always ensure the service isn't running before updating its config, just to be safe
+		if err := winsvc.EnsureServiceState(service, svc.Stopped); err != nil {
 			return err
 		}
 		err = service.UpdateConfig(config)
@@ -203,9 +203,8 @@ func (sc *ServiceController) reconcileService(service winsvc.Service, expected s
 			return errors.Wrap(err, "error updating service config")
 		}
 	}
-
 	// always ensure service is started
-	return service.Start()
+	return winsvc.EnsureServiceState(service, svc.Running)
 }
 
 // expectedServiceCommand returns the full command that the given service should run with

--- a/pkg/daemon/winsvc/winsvc_test.go
+++ b/pkg/daemon/winsvc/winsvc_test.go
@@ -173,3 +173,136 @@ func TestDeleteService(t *testing.T) {
 		})
 	}
 }
+
+func TestStartService(t *testing.T) {
+	testIO := []struct {
+		name          string
+		startingState svc.State
+		expectedState svc.State
+		expectErr     bool
+	}{
+		{
+			name:          "service not running",
+			startingState: svc.Stopped,
+			expectedState: svc.Running,
+			expectErr:     false,
+		},
+		{
+			name:          "service running",
+			startingState: svc.Running,
+			expectedState: svc.Running,
+			expectErr:     true,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			svcName := "testsvc"
+			svcs := map[string]*FakeService{svcName: {name: svcName, status: svc.Status{State: test.startingState}}}
+			manager := NewTestMgr(svcs)
+			service, err := manager.OpenService(svcName)
+			require.NoError(t, err)
+			err = service.Start()
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			newStatus, err := service.Query()
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedState, newStatus.State)
+		})
+	}
+}
+func TestStopService(t *testing.T) {
+	testIO := []struct {
+		name          string
+		startingState svc.State
+		expectedState svc.State
+		expectErr     bool
+	}{
+		{
+			name:          "service not running",
+			startingState: svc.Stopped,
+			expectedState: svc.Stopped,
+			expectErr:     true,
+		},
+		{
+			name:          "service running",
+			startingState: svc.Running,
+			expectedState: svc.Stopped,
+			expectErr:     false,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			svcName := "testsvc"
+			svcs := map[string]*FakeService{svcName: {name: svcName, status: svc.Status{State: test.startingState}}}
+			manager := NewTestMgr(svcs)
+			service, err := manager.OpenService(svcName)
+			require.NoError(t, err)
+			_, err = service.Control(svc.Stop)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			newStatus, err := service.Query()
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedState, newStatus.State)
+		})
+	}
+}
+
+func TestEnsureService(t *testing.T) {
+	testIO := []struct {
+		name          string
+		signal        svc.Cmd
+		startingState svc.State
+		expectedState svc.State
+		expectErr     bool
+	}{
+		{
+			name:          "stop a stopped service",
+			startingState: svc.Stopped,
+			expectedState: svc.Stopped,
+			expectErr:     false,
+		},
+		{
+			name:          "stop a running service",
+			startingState: svc.Running,
+			expectedState: svc.Stopped,
+			expectErr:     false,
+		},
+		{
+			name:          "start a stopped service",
+			startingState: svc.Stopped,
+			expectedState: svc.Running,
+			expectErr:     false,
+		},
+		{
+			name:          "stop a running service",
+			startingState: svc.Running,
+			expectedState: svc.Running,
+			expectErr:     false,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			svcName := "testsvc"
+			svcs := map[string]*FakeService{svcName: {name: svcName, status: svc.Status{State: test.startingState}}}
+			manager := NewTestMgr(svcs)
+			service, err := manager.OpenService(svcName)
+			require.NoError(t, err)
+			err = EnsureServiceState(service, test.expectedState)
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			newStatus, err := service.Query()
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedState, newStatus.State)
+
+		})
+	}
+}


### PR DESCRIPTION
This commit corrects an issue where trying to start/stop an already started/stopped
Windows service would error out. The ServiceController now checks that
the service is not already in the correct state before telling Windows
to start/stop the service. Additionally, the mock service API used in
the unit tests has been altered to enact the behavior that the actual
service API has.