### PR TITLE
Enable generation of custom service CMs

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -168,7 +168,8 @@ func (r *ConfigMapReconciler) reconcileServices(ctx context.Context, windowsServ
 	}
 
 	// If a ConfigMap with invalid values is found, WMCO will delete and recreate it with proper values
-	if _, err := servicescm.Parse(windowsServices.Data); err != nil {
+	data, err := servicescm.Parse(windowsServices.Data)
+	if err != nil || data.ValidateRequiredContent() != nil {
 		// Deleting will trigger an event for the configmap_controller, which will re-create a proper ConfigMap
 		if err = r.client.Delete(ctx, windowsServices); err != nil {
 			return err
@@ -444,7 +445,8 @@ func (r *ConfigMapReconciler) EnsureServicesConfigMapExists() error {
 	}
 
 	// If a ConfigMap with incorrect values is found, WMCO will delete and recreate it with the proper values
-	if _, err := servicescm.Parse(windowsServices.Data); err != nil {
+	data, err := servicescm.Parse(windowsServices.Data)
+	if err != nil || data.ValidateRequiredContent() != nil {
 		if err = r.k8sclientset.CoreV1().ConfigMaps(r.watchNamespace).Delete(context.TODO(), windowsServices.Name,
 			meta.DeleteOptions{}); err != nil {
 			return err

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -73,8 +73,9 @@ func TestGenerate(t *testing.T) {
 	configMap, err := Generate(Name, "testNamespace")
 	require.NoError(t, err)
 
-	_, err = Parse(configMap.Data)
+	data, err := Parse(configMap.Data)
 	require.NoError(t, err)
+	assert.NoError(t, data.ValidateRequiredContent())
 }
 
 func TestValidateDependencies(t *testing.T) {


### PR DESCRIPTION
This commit adds the function GenerateWithData which allows for the
creation of service ConfigMaps with custom file and Windows service
specifications. This will be helpful for testing.