### PR TITLE
[community-4.10] WINC-745: Clean up dockershim related flags

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -419,9 +419,9 @@ func (nc *nodeConfig) configureCNI() error {
 	if err != nil {
 		return errors.Wrapf(err, "error populating CNI config file %s", configFile)
 	}
-	// configure CNI in the Windows VM
-	if err = nc.Windows.ConfigureCNI(configFile); err != nil {
-		return errors.Wrapf(err, "error configuring CNI for %s", nc.node.GetName())
+	// Copy CNI config file
+	if err = nc.Windows.EnsureCNIConfig(configFile); err != nil {
+		return errors.Wrapf(err, "error ensuring CNI config file for %s", nc.node.GetName())
 	}
 	if err = nc.network.cleanupTempConfig(configFile); err != nil {
 		nc.log.Error(err, " error deleting temp CNI config", "file",


### PR DESCRIPTION
Update to https://github.com/openshift/windows-machine-config-bootstrapper/commit/1ad93f2f015b1152885a0bc60edb9004e3147312
Adapt to the WMCB submodule updates.

