### PR TITLE
[community-4.10] WINC-828: Re-add image-pull-progress deadline feature

### DIFF
--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -49,6 +49,7 @@ version = 2
     enable_selinux = false
     enable_tls_streaming = false
     ignore_image_defined_volumes = false
+    image_pull_progress_timeout = "30m0s"
     max_concurrent_downloads = 3
     max_container_log_line_size = 16384
     netns_mounts_under_state_dir = false


### PR DESCRIPTION
This PR updates to https://github.com/openshift/containerd/commit/8100cdb4fa50c8c9888f2c3ad08f413e407fe567
and adds the image pull progress timeout feature argument to the Containerd config file.