### PR TITLE
WINC-746: Enable running WICD as a Windows service

### DIFF
--- a/cmd/daemon/controller.go
+++ b/cmd/daemon/controller.go
@@ -19,6 +19,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -38,16 +39,26 @@ var (
 	}
 	kubeconfig     string
 	windowsService bool
+	logDir         string
 )
 
 func init() {
 	rootCmd.AddCommand(controllerCmd)
 	controllerCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig")
+	controllerCmd.PersistentFlags().StringVar(&logDir, "log-dir", "", "Directory to write logs to, "+
+		"if not provided, the command will log to stdout/stderr")
 	controllerCmd.PersistentFlags().BoolVar(&windowsService, "windows-service", false,
 		"Enables running as a Windows service")
 }
 
 func runControllerCmd(cmd *cobra.Command, args []string) {
+	if logDir != "" {
+		var fs flag.FlagSet
+		klog.InitFlags(&fs)
+		// When the logtostderr flag is set to true, which is the default, the log_dir arg is ignored
+		fs.Set("logtostderr", "false")
+		fs.Set("log_dir", logDir)
+	}
 	ctx := ctrl.SetupSignalHandler()
 	if windowsService {
 		if err := initService(ctx); err != nil {

--- a/cmd/daemon/service.go
+++ b/cmd/daemon/service.go
@@ -53,6 +53,7 @@ func initService(ctx context.Context) error {
 	return err
 }
 
+// Execute is a required function of the Handler interface, it will be called when there is a Windows service request
 func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
 	// Set the status of the Windows service to start pending and allow initService() to return
 	s <- svc.Status{State: svc.StartPending}
@@ -65,6 +66,8 @@ func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.S
 
 	// Handle any incoming requests from the service manager
 	ctx, cancel := context.WithCancel(h.ctx)
+
+	// break will only end the current select, include this label to break to, in order to break from the loop + select
 loop:
 	for {
 		select {

--- a/cmd/daemon/service.go
+++ b/cmd/daemon/service.go
@@ -1,0 +1,88 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+type handler struct {
+	ctx context.Context
+	wg  sync.WaitGroup
+}
+
+func initService(ctx context.Context) error {
+	h := &handler{
+		ctx: ctx,
+	}
+
+	var err error
+	h.wg.Add(1)
+	go func() {
+		err = svc.Run("windows-instance-config-daemon", h)
+		if err != nil {
+			// Failure before Execute() is called
+			h.wg.Done()
+		}
+	}()
+	// Wait for h.Execute to be called through the service manager
+	h.wg.Wait()
+
+	return err
+}
+
+func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	// Set the status of the Windows service to start pending and allow initService() to return
+	s <- svc.Status{State: svc.StartPending}
+	h.wg.Done()
+
+	// Set the service to running
+	cmdsAccepted := svc.AcceptStop | svc.AcceptShutdown
+	s <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+	klog.Info("Running as a Windows service")
+
+	// Handle any incoming requests from the service manager
+	ctx, cancel := context.WithCancel(h.ctx)
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			s <- svc.Status{State: svc.StopPending}
+			break loop
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				// The Interrogate command is always accepted by default
+				s <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				klog.Info("Service stopping")
+				s <- svc.Status{State: svc.StopPending}
+				cancel()
+				break loop
+			}
+		}
+	}
+	return false, 0
+}

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -63,7 +63,7 @@ type ServiceController struct {
 }
 
 // RunController is the entry point of WICD's controller functionality
-func RunController(kubeconfigPath string) error {
+func RunController(ctx context.Context, kubeconfigPath string) error {
 	svcMgr, err := winsvc.NewMgr()
 	if err != nil {
 		return err
@@ -86,7 +86,6 @@ func RunController(kubeconfigPath string) error {
 	}
 
 	// use the client to find the name of the node associated with the VM this is running on
-	ctx := ctrl.SetupSignalHandler()
 	var nodes core.NodeList
 	err = directClient.List(ctx, &nodes)
 	if err != nil {


### PR DESCRIPTION
Adds the --windows-service flag to enable running as a Windows service.
Also adds the --log-dir flag so that logs can be accessible when running as a Windows service.