### PR TITLE
[build] Bump to go 1.18.1

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.18
+  tag: golang-1.18.1

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as build
+FROM registry.ci.openshift.org/openshift/release:golang-1.18.1 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as build
+FROM registry.ci.openshift.org/openshift/release:golang-1.18.1 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18.1-openshift-4.11 as build
 LABEL stage=build
 WORKDIR /build/
 

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as build
+FROM registry.ci.openshift.org/openshift/release:golang-1.18.1 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18.1') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
This commit is to build WMCO with golang 1.18.1, in line with the OCP bump
Also ran below command go mod edit -go=1.18 && go mod tidy && go mod vendor.

Signed-off-by: selansen <esiva@redhat.com>