### PR TITLE
WINC-798: [build] Update missing golang1.18 bump work

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -119,7 +119,7 @@ RUN make build
 #├── windows_exporter.exe
 #└── wmcb.exe
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 LABEL stage=operator
 
 # Copy wmcb.exe


### PR DESCRIPTION
As part of golang 1.18 bump up, we missed out updating
the base image in Dockerfile.ci file's bundle section. This
commit fixes this issue.

Signed-off-by: selansen <esiva@redhat.com>