### PR TITLE
WINC-807: Add OpenShift versions annotation to bundle metadata and prep for 6.0.0 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 5.0.0
+WMCO_VERSION ?= 6.0.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.10"
+LABEL com.redhat.openshift.versions="=v4.11"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=4.0.0 <5.0.0'
+    olm.skipRange: '>=5.0.0 <6.0.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -17,7 +17,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v5.0.0
+  name: windows-machine-config-operator.v6.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -25,8 +25,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.11/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.11/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -35,9 +35,9 @@ spec:
     official support.
 
     ### Pre-requisites
-    * A Red Hat OpenShift Container Platform for Windows Containers subscription [subscription page](https://access.redhat.com/support/policy/updates/openshift#windows)
-    * OCP 4.10 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.10/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
+    * OCP 4.11 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.11/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -47,7 +47,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.6/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.11/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -137,7 +137,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.6/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.11/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:
@@ -443,4 +443,4 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat
-  version: 5.0.0
+  version: 6.0.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,6 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v2.0.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  com.redhat.openshift.versions: "=v4.11"
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v5.0.0
+  - currentCSV: windows-machine-config-operator.v6.0.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=4.0.0 <5.0.0'
+    olm.skipRange: '>=5.0.0 <6.0.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -23,8 +23,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/latest/windows_containers/configuring-byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.11/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.11/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -33,9 +33,9 @@ spec:
     official support.
 
     ### Pre-requisites
-    * A Red Hat OpenShift Container Platform for Windows Containers subscription
-    * OCP 4.10 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.10/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
+    * OCP 4.11 cluster running on Azure, AWS or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.11/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -45,7 +45,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.6/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.11/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -135,7 +135,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.6/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.11/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,8 +1,7 @@
 # Troubleshooting guide
 
 ## WMCO does not go to running
-Please check if you are using an OKD/OCP 4.6 cluster running on Azure or AWS, configured with
-[hybrid OVN Kubernetes networking](setup-hybrid-OVNKubernetes-cluster.md).
+Please check if you are using an OKD/OCP cluster adhering to the [operator pre-requisites](wmco-prerequisites.md).
 
 ## Windows Machine does not become a worker node
 There could be various reasons as to why a Windows Machine does not become a worker node. Please collect the WMCO logs
@@ -22,7 +21,7 @@ not yet supported for Windows. Instead, a Windows node can be accessed using SSH
 [SSH bastion](https://github.com/eparis/ssh-bastion) needs to be setup for both methods. The following information is
 common across both methods:
 * The key used in the *cloud-private-key* [secret](../README.md#Usage) and the key used when creating the cluster should
-  be added to the [ssh-agent](https://docs.openshift.com/container-platform/4.6/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default).
+  be added to the [ssh-agent](https://docs.openshift.com/container-platform/latest/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default).
   For [security reasons](https://manpages.debian.org/buster/openssh-client/ssh.1.en.html#A) we suggest removing the keys
   from the ssh-agent after use.
 * *\<username\>* is *Administrator* (AWS) or *capi* (Azure)

--- a/docs/setup-hybrid-OVNKubernetes-cluster.md
+++ b/docs/setup-hybrid-OVNKubernetes-cluster.md
@@ -1,7 +1,7 @@
 # Setup hybrid OVNKubernetes cluster
 
 This guide assumes the user has installed current versions of the OpenShift installer (`openshift-install`) and client (`oc`) binaries.
-Please refer to the [official OpenShift Container Platform documentation](https://docs.openshift.com/container-platform/4.5/welcome/index.html) for details.
+Please refer to the [official OpenShift Container Platform documentation](https://docs.openshift.com/container-platform/latest/welcome/index.html) for details.
 
 ## Create install-config
 

--- a/docs/vsphere-prerequisites.md
+++ b/docs/vsphere-prerequisites.md
@@ -31,4 +31,4 @@ Note: The DNS entry can be a CNAME or an additional A record.
 The above DNS entry ensures that Windows VM can download the ignition file from the internal API server 
 and the `kubelet` on the configured VM can communicate with the internal API server. In the case of Linux nodes,
 CoreDNS is running on every node which helps in resolving the internal API server URL. The external API endpoint
-should have been created as part of the [cluster install](https://docs.openshift.com/container-platform/4.7/installing/installing_vsphere/installing-vsphere-installer-provisioned.html).
+should have been created as part of the [cluster install](https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html).


### PR DESCRIPTION
In order to properly control operator version availability in the OperatorHub 
catalog on different OCP versions, this ticket annotates our bundle image 
with a specific OCP version as per [OpenShift docs](https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-working-bundle-images.html#osdk-control-compat_osdk-working-bundle-images). This, in conjunction with
[setting the label in the bundle.Dockerfile](https://github.com/openshift/windows-machine-config-operator/blob/master/bundle.Dockerfile#L18), maintains WMCO major version 
availability is properly tied in 1:1 mapping with OCP versions.

This PR also bumps the WMCO and OCP version number in prep for the 6.0.0 release.