### PR TITLE
[config] Replace namespace placeholder

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
   name: windows-machine-config-operator.v5.0.0
-  namespace: placeholder
+  namespace: openshift-windows-machine-config-operator
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
   name: windows-machine-config-operator.v0.0.0
-  namespace: placeholder
+  namespace: openshift-windows-machine-config-operator
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}


### PR DESCRIPTION
This PR removes the namespace placeholder and replaces it with:
'openshift-windows-machine-config-operator'.