### PR TITLE
WINC-805: Add support for Windows Server 2022 in AWS

### DIFF
--- a/docs/machineset-aws.md
+++ b/docs/machineset-aws.md
@@ -1,7 +1,5 @@
 # Creating an AWS Windows MachineSet
 
-_\<windows_server_ami\>_ should be replaced with the AMI ID of a [supported version](wmco-prerequisites.md#supported-windows-server-versions) of Windows Server.
-
 _\<infrastructureID\>_ should be replaced with the output of:
 ```shell script
  oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
@@ -9,6 +7,16 @@ _\<infrastructureID\>_ should be replaced with the output of:
 _\<region\>_ should be replaced with a valid AWS region like `us-east-1`.
 
 _\<zone\>_ should be replaced with a valid AWS availability zone like `us-east-1a`.
+
+_\<windows_ami_id\>_ should be replaced with the AMI ID of a [supported version](wmco-prerequisites.md#supported-windows-server-versions)
+of Windows Server. For example, for Windows Server 2022 you can find the latest AMI ID with the following command:
+```shell script
+ aws ec2 describe-images --region ${region} \
+    --filters "Name=name,Values=Windows_Server-2022*English*Core*Base*" "Name=is-public,Values=true" \
+    --query "reverse(sort_by(Images,&CreationDate))[*].{name: Name, id: ImageId}" \
+    --output json | jq -r '.[0].id'
+```
+where `${region}` is the selected AWS Region.
 
 ```
 apiVersion: machine.openshift.io/v1beta1
@@ -39,7 +47,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: <windows_server_ami>
+            id: <windows_ami_id>
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
             - ebs:

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -21,7 +21,7 @@ these errors, only use the appropriate version according to the cloud provider i
 
 | Cloud Provider | Supported Windows Server version                                                                                                  |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                                                              |
+| AWS            | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
 | Azure          | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
 | GCP            | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
 | VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -79,9 +79,12 @@ get_aws_ms() {
   local provider=$4
 
   # get the AMI id for the Windows VM
-  ami_id=$(aws ec2 describe-images --region ${region} --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output json | jq -r '.[0].id')
+  ami_id=$(aws ec2 describe-images --region ${region} \
+    --filters "Name=name,Values=Windows_Server-2022*English*Core*Base*" "Name=is-public,Values=true" \
+    --query "reverse(sort_by(Images,&CreationDate))[*].{name: Name, id: ImageId}" \
+    --output json | jq -r '.[0].id')
   if [ -z "$ami_id" ]; then
-        error-exit "unable to find AMI ID for Windows Server 2019 1809"
+        error-exit "unable to find AMI ID for Windows Server 2022"
   fi
 
   cat <<EOF

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -79,6 +79,9 @@ type testContext struct {
 	// toolsImage is the image specified by the  openshift/tools ImageStream, and is the same image used by `oc debug`.
 	// This image is available on all OpenShift Clusters, and has SSH pre-installed.
 	toolsImage string
+	// windowsServerVersion is the Windows Server version used in the e2e test suite. See https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
+	// If unset or empty, a default machine and container image are loaded.
+	windowsServerVersion string
 }
 
 // NewTestContext returns a new test context to be used by every test.
@@ -106,7 +109,8 @@ func NewTestContext() (*testContext, error) {
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{client: oc, timeout: retry.Timeout, retryInterval: retry.Interval,
 		namespace: "openshift-windows-machine-config-operator", CloudProvider: cloudProvider,
-		workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels, toolsImage: toolsImage}, nil
+		workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels, toolsImage: toolsImage,
+		windowsServerVersion: os.Getenv("WINDOWS_SERVER_VERSION")}, nil
 }
 
 // vmUsername returns the name of the user which can be used to log into each Windows instance

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -450,14 +450,16 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 	return podList.Items[0].Status.PodIP, nil
 }
 
-// getWindowsServerContainerImage gets the appropriate WindowsServer image based on the cloud provider
+// getWindowsServerContainerImage gets the appropriate WindowsServer image
 func (tc *testContext) getWindowsServerContainerImage() string {
-	if tc.CloudProvider.GetType() == config.AWSPlatformType {
-		// On AWS we are currently testing 2019
+	// check the Windows Server version to set the correct container image
+	switch tc.windowsServerVersion {
+	case "2019":
 		return "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+	default:
+		// the default container image must be compatible with Windows Server 2022
+		return "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 	}
-	// the default container image must be compatible with Windows Server 2022
-	return "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 }
 
 // createWindowsServerDeployment creates a deployment with a Windows Server container. If affinity is nil then the

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -292,10 +292,10 @@ func (tc *testContext) sshSetup() error {
 // runPowerShellSSHJob creates and waits for a Kubernetes job to run. The command provided will be executed through
 // PowerShell, on the host specified by the provided IP.
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
-	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
+	// For Windows Server 2019 use the command as is
 	powershellDefaultCommand := command
-	if tc.CloudProvider.GetType() == config.VSpherePlatformType ||
-		tc.CloudProvider.GetType() == config.GCPPlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
+	// For others, do not escape the double-quotes when default shell is Powershell, i.e. Windows Server 2022
+	if tc.windowsServerVersion != "2019" {
 		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
 	}
 


### PR DESCRIPTION
This PR updates the AWS's EC2 AMI to use Windows Server 2022
Base image without Docker container runtime, as the container runtime
(containerd) is installed by WMCO.

Leverage the environment variable introduced in the release job configuration to use Windows Server 2019 as machine and container images for the `aws-e2e-operator` test
- https://github.com/openshift/release/pull/29791
