### PR TITLE
WINC-833: [e2e] unblock aws CI failure

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -79,7 +79,7 @@ get_aws_ms() {
   local provider=$4
 
   # get the AMI id for the Windows VM
-  ami_id=$(aws ec2 describe-images --region ${region} --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output json | jq -r '.[0].id')
+  ami_id=$(aws ec2 describe-images --region ${region} --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output json | jq -r '.[2].id')
   if [ -z "$ami_id" ]; then
         error-exit "unable to find AMI ID for Windows Server 2019 1809"
   fi

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -120,6 +120,8 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 	windowsAMIOwner := "amazon"
 	windowsAMIFilterName := "name"
 	windowsAMIFilterValue := ""
+	winDateFilterName := "creation-date"
+	winDateFilterVal := "2022-05-11T*"
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
 	// The ami's will have the name format: Windows_Server-2022-English-Full-ContainersLatest-2022.01.19
 	// so the question marks will match the date of creation
@@ -133,9 +135,10 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	}
 	searchFilter := ec2.Filter{Name: &windowsAMIFilterName, Values: []*string{&windowsAMIFilterValue}}
+	dateFilter := ec2.Filter{Name: &winDateFilterName, Values: []*string{&winDateFilterVal}}
 
 	describedImages, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{&searchFilter},
+		Filters: []*ec2.Filter{&searchFilter, &dateFilter},
 		Owners:  []*string{&windowsAMIOwner},
 	})
 	if err != nil {


### PR DESCRIPTION
This commit addresses CI failures on AWS platform.
the AMI which is created on May 25th is causing the issue, so
as a temp workaround we will be pointing to the older AMI image until
we figure out what is the real issue with the new AMI.

Signed-off-by: selansen <esiva@redhat.com>