### PR TITLE
[e2e] CustomVXLANPort no longer relevant in AWS

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -62,7 +62,7 @@ func newSession(credentialPath, credentialAccountID, region string) (*awssession
 // credentialAccountID is the account name the user uses to create VM instance.
 // The credentialAccountID should exist in the AWS credentials file pointing at one specific credential.
 func newAWSProvider(openShiftClient *clusterinfo.OpenShift, credentialPath,
-	credentialAccountID, instanceType, region string, hasCustomVXLANPort bool) (*awsProvider, error) {
+	credentialAccountID, instanceType, region string) (*awsProvider, error) {
 	session, err := newSession(credentialPath, credentialAccountID, region)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new AWS session: %v", err)
@@ -72,7 +72,7 @@ func newAWSProvider(openShiftClient *clusterinfo.OpenShift, credentialPath,
 
 	iamClient := iam.New(session, aws.NewConfig())
 
-	imageID, err := getLatestWindowsAMI(ec2Client, hasCustomVXLANPort)
+	imageID, err := getLatestWindowsAMI(ec2Client)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get latest Windows AMI: %v", err)
 	}
@@ -86,7 +86,7 @@ func newAWSProvider(openShiftClient *clusterinfo.OpenShift, credentialPath,
 
 // SetupAWSCloudProvider creates AWS provider using the give OpenShift client
 // This is the first step of the e2e test and fails the test upon error.
-func SetupAWSCloudProvider(region string, hasCustomVXLANPort bool) (*awsProvider, error) {
+func SetupAWSCloudProvider(region string) (*awsProvider, error) {
 	oc, err := clusterinfo.GetOpenShift()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize OpenShift client with error: %v", err)
@@ -96,7 +96,7 @@ func SetupAWSCloudProvider(region string, hasCustomVXLANPort bool) (*awsProvider
 	if len(awsCredentials) == 0 {
 		return nil, fmt.Errorf("AWS_SHARED_CREDENTIALS_FILE env var is empty")
 	}
-	awsProvider, err := newAWSProvider(oc, awsCredentials, "default", instanceType, region, hasCustomVXLANPort)
+	awsProvider, err := newAWSProvider(oc, awsCredentials, "default", instanceType, region)
 	if err != nil {
 		return nil, fmt.Errorf("error obtaining aws interface object: %v", err)
 	}
@@ -115,23 +115,17 @@ func (a *awsProvider) getInfraID() (string, error) {
 }
 
 // getLatestWindowsAMI returns the imageid of the latest released "Windows Server with Containers" image
-func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, error) {
+func getLatestWindowsAMI(ec2Client *ec2.EC2) (string, error) {
 	// Have to create these variables, as the below functions require pointers to them
 	windowsAMIOwner := "amazon"
 	windowsAMIFilterName := "name"
-	windowsAMIFilterValue := ""
+	windowsAMIFilterValue := "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
 	// The ami's will have the name format: Windows_Server-2022-English-Full-ContainersLatest-2022.01.19
 	// so the question marks will match the date of creation
 	// The image obtained by using windowsAMIFilterValue is compatible with the test container image -
 	// "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
 	// If the windowsAMIFilterValue changes, the test container image also needs to be changed.
-	// if hasCustomVXLANPort is set use 2022 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
-	if hasCustomVXLANPort {
-		windowsAMIFilterValue = "Windows_Server-2022-English-Full-ContainersLatest-????.??.??"
-	} else {
-		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
-	}
 	searchFilter := ec2.Filter{Name: &windowsAMIFilterName, Values: []*string{&windowsAMIFilterValue}}
 
 	describedImages, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -33,7 +33,7 @@ func NewCloudProvider(hasCustomVXLANPort bool) (CloudProvider, error) {
 	switch provider := platformStatus.Type; provider {
 	case config.AWSPlatformType:
 		// 	Setup the AWS cloud provider in the same region where the cluster is running
-		return awsProvider.SetupAWSCloudProvider(platformStatus.AWS.Region, hasCustomVXLANPort)
+		return awsProvider.SetupAWSCloudProvider(platformStatus.AWS.Region)
 	case config.AzurePlatformType:
 		return azureProvider.New(openshift, hasCustomVXLANPort)
 	case config.VSpherePlatformType:


### PR DESCRIPTION
This PR removes the hasCustomVXLANPort parameter from the
AWS provider initialization. The CustomVXLANPort is no longer a valid
decision element to choose between Windows Server 2022 or 2019 in AWS,
because there is no corresponding CI job definition for a cluster with
a HybridOverlay network and a CustomVXLANPort in AWS.