### PR TITLE
[WIP] WINC-838: Add OS field to pod spec in Windows Server deployment

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -490,6 +490,9 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 				},
 				Spec: v1.PodSpec{
 					Affinity: affinity,
+					OS: &v1.PodOS{
+						Name: v1.Windows,
+					},
 					Tolerations: []v1.Toleration{
 						{
 							Key:    "os",


### PR DESCRIPTION
This PR adds the OS field in the pod specification for the
Windows Server deployment used in the network test. This ensures that
Windows pods can be identified authoritatively at admission time. As of
now, the SCC Admission Plugin does not perform any validation for Windows
pods, it ignores them. See to https://github.com/openshift/apiserver-library-go/pull/82

Fixes a CI issue introduced by https://github.com/openshift/kubernetes/pull/1290
where SCC Admission Plugin defaults the `runAsNonRoot` with value `true`.
