### PR TITLE
WINC-731: Run WICD on Windows nodes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -78,6 +78,7 @@ COPY controllers controllers
 COPY hack hack
 COPY pkg pkg
 RUN make build
+RUN make build-daemon
 
 # Build the operator image with following payload structure
 # /payload/
@@ -100,6 +101,7 @@ RUN make build
 #│   └── wget-ignore-cert.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
+#├── windows-instance-config-daemon.exe
 #└── wmcb.exe
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -108,6 +110,9 @@ LABEL stage=operator
 # Copy wmcb.exe
 WORKDIR /payload/
 COPY --from=build /build/windows-machine-config-operator/windows-machine-config-bootstrapper/wmcb.exe .
+
+# Copy WICD
+COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-instance-config-daemon.exe .
 
 # Copy hybrid-overlay-node.exe
 COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -95,6 +95,7 @@ COPY Makefile Makefile
 COPY tools.go tools.go
 COPY .gitignore .gitignore
 RUN make build
+RUN make build-daemon
 
 # Build the operator image with following payload structure
 # /payload/
@@ -117,6 +118,7 @@ RUN make build
 #│   └── wget-ignore-cert.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
+#├── windows-instance-config-daemon.exe
 #└── wmcb.exe
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10
@@ -125,6 +127,9 @@ LABEL stage=operator
 # Copy wmcb.exe
 WORKDIR /payload/
 COPY --from=build /build/windows-machine-config-operator/windows-machine-config-bootstrapper/wmcb.exe .
+
+# Copy WICD
+COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-instance-config-daemon.exe .
 
 # Copy hybrid-overlay-node.exe
 COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -20,9 +20,14 @@ COPY hack hack
 COPY pkg pkg
 COPY .git .git
 RUN make build
+RUN make build-daemon
 
 FROM wmco-base:latest
 LABEL stage=operator
+
+# Copy WICD to payload
+WORKDIR /payload/
+COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-instance-config-daemon.exe .
 
 # Copy required powershell scripts
 WORKDIR /payload/powershell/

--- a/cmd/daemon/controller.go
+++ b/cmd/daemon/controller.go
@@ -37,14 +37,21 @@ var (
 			"present within the cluster",
 		Run: runControllerCmd,
 	}
-	kubeconfig     string
+	saToken        string
+	saCA           string
+	apiServerURL   string
 	windowsService bool
 	logDir         string
 )
 
 func init() {
 	rootCmd.AddCommand(controllerCmd)
-	controllerCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig")
+	controllerCmd.PersistentFlags().StringVar(&saToken, "sa-token", "", "Path to service account token file")
+	controllerCmd.MarkPersistentFlagRequired("sa-token")
+	controllerCmd.PersistentFlags().StringVar(&saCA, "sa-ca", "", "Path to service account CA file")
+	controllerCmd.MarkPersistentFlagRequired("sa-ca")
+	controllerCmd.PersistentFlags().StringVar(&apiServerURL, "api-server", "", "URL of API server")
+	controllerCmd.MarkPersistentFlagRequired("api-server")
 	controllerCmd.PersistentFlags().StringVar(&logDir, "log-dir", "", "Directory to write logs to, "+
 		"if not provided, the command will log to stdout/stderr")
 	controllerCmd.PersistentFlags().BoolVar(&windowsService, "windows-service", false,
@@ -67,7 +74,7 @@ func runControllerCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 	klog.Info("service controller running")
-	if err := controller.RunController(ctx, kubeconfig); err != nil {
+	if err := controller.RunController(ctx, apiServerURL, saCA, saToken); err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -113,6 +113,7 @@ func main() {
 		payload.KubeProxyPath,
 		payload.IgnoreWgetPowerShellPath,
 		payload.WmcbPath,
+		payload.WICDPath,
 		payload.CNIConfigTemplatePath,
 		payload.HNSPSModule,
 		payload.WindowsExporterPath,

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -299,20 +299,13 @@ func TestReconcile(t *testing.T) {
 			cm, err := servicescm.GenerateWithData(servicescm.NamePrefix+desiredVersion,
 				"openshift-windows-machine-config-operator", &test.configMapServices, &[]servicescm.FileInfo{})
 			require.NoError(t, err)
-			// TODO: When the controller is able to watch ConfigMaps, the CM data does not need to be added as a
-			//       Node annotation
-			data, err := servicescm.Parse(cm.Data)
-			require.NoError(t, err)
-			encodedData, err := data.MarshallAndEncode()
-			require.NoError(t, err)
 			clusterObjs := []client.Object{
 				// This is the node object that will be used in these test cases
 				&core.Node{
 					ObjectMeta: meta.ObjectMeta{
 						Name: "node",
 						Annotations: map[string]string{
-							desiredVersionAnnotation:    desiredVersion,
-							servicescm.CMDataAnnotation: encodedData,
+							desiredVersionAnnotation: desiredVersion,
 						},
 					},
 				},

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/winsvc"
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
@@ -305,7 +306,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: meta.ObjectMeta{
 						Name: "node",
 						Annotations: map[string]string{
-							desiredVersionAnnotation: desiredVersion,
+							nodeconfig.DesiredVersionAnnotation: desiredVersion,
 						},
 					},
 				},

--- a/pkg/nodeconfig/init.go
+++ b/pkg/nodeconfig/init.go
@@ -15,6 +15,8 @@ type cache struct {
 	// workerIgnitionEndpoint is the Machine Config Server(MCS) endpoint from which we can download the
 	// the OpenShift worker ignition file.
 	workerIgnitionEndPoint string
+	// apiServerEndpoint is the address which clients can interact with the API server through
+	apiServerEndpoint string
 }
 
 // cache has the information related to nodeConfig that should not be changed.
@@ -36,5 +38,6 @@ func init() {
 		return
 	}
 	// populate the cache
+	nodeConfigCache.apiServerEndpoint = kubeAPIServerEndpoint
 	nodeConfigCache.workerIgnitionEndPoint = "https://" + clusterAddress + ":22623/config/worker"
 }

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -15,6 +15,8 @@ const (
 	// WmcbPath contains the path of the Windows Machine Config Bootstrapper binary. The container image should already
 	// have this binary mounted
 	WmcbPath = payloadDirectory + "wmcb.exe"
+	// WICDPath is the path to the Windows Instance Config Daemon exe
+	WICDPath = payloadDirectory + "windows-instance-config-daemon.exe"
 	// KubeletPath contains the path of the kubelet binary. The container image should already have this binary mounted
 	KubeletPath = payloadDirectory + "/kube-node/kubelet.exe"
 	// KubeProxyPath contains the path of the kube-proxy binary. The container image should already have this binary

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -22,6 +22,7 @@ func testNodeLogs(t *testing.T) {
 		"hybrid-overlay/hybrid-overlay.log",
 		"kubelet/kubelet.log",
 		"containerd/containerd.log",
+		"wicd/windows-instance-config-daemon.exe.INFO",
 	}
 	optionalLogs := []string{
 		"kube-proxy/kube-proxy.exe.ERROR",


### PR DESCRIPTION
This PR includes changes required to run WICD on Windows nodes as part of the WMCO node configuration process.
* Allow WICD to use the windows services configmap by authenticating to the cluster with a ServiceAccount. This commit is being included within this PR as without the other commits in this PR there is no way to test this change in CI. 
* Build WICD and include it in the WMCO container image.
* Run WICD on Windows nodes.