### PR TITLE
WINC-731: Introduce WICD ServiceAccount

### DIFF
--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: windows-instance-config-daemon
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+  - get

--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: windows-instance-config-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: windows-instance-config-daemon
+subjects:
+- kind: ServiceAccount
+  name: windows-instance-config-daemon
+  namespace: openshift-windows-machine-config-operator

--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: windows-instance-config-daemon
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get

--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: windows-instance-config-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: windows-instance-config-daemon
+subjects:
+- kind: ServiceAccount
+  name: windows-instance-config-daemon
+  namespace: openshift-windows-machine-config-operator

--- a/bundle/manifests/windows-instance-config-daemon_v1_serviceaccount.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: windows-instance-config-daemon

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
 - ../rbac
 - ../manager
 - ../windows-exporter
+- ../wicd
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/wicd/kustomization.yaml
+++ b/config/wicd/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- windows-instance-config-daemon-role.yaml
+- windows-instance-config-daemon-role-binding.yaml
+- windows-instance-config-daemon-cluster-role.yaml
+- windows-instance-config-daemon-cluster-role-binding.yaml
+- windows-instance-config-daemon-service-account.yaml

--- a/config/wicd/windows-instance-config-daemon-cluster-role-binding.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: windows-instance-config-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: windows-instance-config-daemon
+subjects:
+  - kind: ServiceAccount
+    name: windows-instance-config-daemon

--- a/config/wicd/windows-instance-config-daemon-cluster-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: windows-instance-config-daemon
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+      - get

--- a/config/wicd/windows-instance-config-daemon-role-binding.yaml
+++ b/config/wicd/windows-instance-config-daemon-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: windows-instance-config-daemon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: windows-instance-config-daemon
+subjects:
+  - kind: ServiceAccount
+    name: windows-instance-config-daemon

--- a/config/wicd/windows-instance-config-daemon-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: windows-instance-config-daemon
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - get

--- a/config/wicd/windows-instance-config-daemon-service-account.yaml
+++ b/config/wicd/windows-instance-config-daemon-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: windows-instance-config-daemon

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -503,8 +503,7 @@ func (nc *nodeConfig) UpdateKubeletClientCA(contents []byte) error {
 
 // configureWICD configures and ensures WICD is running
 func (nc *nodeConfig) configureWICD() error {
-	// TODO: This ideally would use a separate WICD SA, with only the necessary permissions
-	tokenSecretPrefix := "windows-machine-config-operator-token-"
+	tokenSecretPrefix := "windows-instance-config-daemon-token-"
 	secrets, err := nc.k8sclientset.CoreV1().Secrets("openshift-windows-machine-config-operator").
 		List(context.TODO(), meta.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
This PR adds a new WICD ServiceAccount with only the required permissions for WICD.
WICD will now use this SA instead of the WMCO SA.