### PR TITLE
[hack] Update community script

### DIFF
--- a/hack/community/csv/description.md
+++ b/hack/community/csv/description.md
@@ -11,8 +11,7 @@ version of OKD/OCP you are using. This CSV is meant for OKD/OCP COMMUNITY_VERSIO
 The Windows Machine Config Operator configures Windows instances into nodes, enabling Windows container workloads
 to be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
 or by specifying existing instances through a [ConfigMap](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/README.md#configuring-byoh-bring-your-own-host-windows-instances).
-Through either method, the Windows instance must have the containerd container runtime installed. The operator will do 
-all the necessary steps to configure the instance so that it can join the cluster as a worker node.
+The operator will do all the necessary steps to configure the instance so that it can join the cluster as a worker node.
 ### Pre-requisites
 - [Cluster and OS pre-requisites](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/docs/wmco-prerequisites.md)
 ### Usage

--- a/hack/community/generate.sh
+++ b/hack/community/generate.sh
@@ -40,6 +40,9 @@ replace() {
     # Delete the subscription line
     yq eval --exit-status --inplace 'del(.metadata.annotations."operators.openshift.io/valid-subscription")' "${CO_CSV}"
 
+    # Delete the testing line
+    yq eval --exit-status --inplace 'del(.annotations."operators.operatorframework.io.test.config.v1")' "${CO_ANNOTATIONS}"
+
     # Replace annotations fields
     # TODO: use yq for the annotations.yaml replacement
     sed -i -e "s/"preview,stable"/$MATURITY/" -e "s/"stable"/$MATURITY/" "${CO_ANNOTATIONS}"

--- a/hack/community/readme.md
+++ b/hack/community/readme.md
@@ -20,11 +20,11 @@ Before running generate.sh, please ensure the following has merged:
 ### From WMCO root, run:
 Parameter 3 can be grabbed from our [Quay repo](https://quay.io/repository/openshift-windows/community-windows-machine-config-operator?tab=tags).
 ```shell script
-bash ./hack/community/generate.sh <community_wmco_version> <community_ocp_version> <latest_community-4.x_tag-commit-hash> <path/to/community-operators-prod>
+bash ./hack/community/generate.sh <community_wmco_version> <community_ocp_version> <path/to/latest_community-4.x_tag> <path/to/community-operators-prod>
 ```
 Example: Cut community release v5.1.0 for community-4.10
 ```shell script
-bash ./hack/community/generate.sh 5.1.0 community-4.10 community-4.10-hash ../community-operators-prod
+bash ./hack/community/generate.sh 5.1.0 community-4.10 quay.io/openshift-windows/community-windows-machine-config-operator:community-4.10-hash ../community-operators-prod
 ```
 
 ### Review and test the operator


### PR DESCRIPTION
This PR removes containerd as a pre-requisite to align with the description
in the WMCO community-4.10 branch. The readme was also changed to specify
that the entire image path must be used as the third parameter when running the
script. Lastly, the script handles removing the scorecard command from the
annotations file as having it causes community-operators-prod CI to fail.

Signed-off-by: Alina Ryan <aliryan@redhat.com>