### PR TITLE
WINC-829: [release-4.9] Windows Server 2022 support on vSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The following template variables need to be replaced as follows with values from
 * *\<vCenter Server FQDN/IP\>*: IP address or FQDN of the vCenter server
 
 *IMPORTANT*:
-- The template used in the MachineSet must be a Windows Server 1909
-  image as described in [vSphere prerequisites](docs/vsphere-prerequisites.md).
+- The VM template provided in the MachineSet must use a supported Windows Server
+  version, as described in [vSphere prerequisites](docs/vsphere-prerequisites.md).
 - On vSphere, Windows Machine names cannot be more than 15 characters long. The
   MachineSet name, therefore, cannot be more than 9 characters long, due to the
   way Machine names are generated from it.

--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -4,13 +4,12 @@ This guide describes the thought process of creating a Windows virtual machine b
 
 ## 1. Select a compatible Windows Server version
 
-Currently, the Windows Machine Config Operator (WMCO) stable version only supports Windows Server Semi-Annual
-Channel (SAC): Windows Server 2004, that includes the patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351), 
-required by the operating system to allow using the [hybrid OVN Kubernetes networking with a 
-custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.
+Currently, the Windows Machine Config Operator (WMCO) stable version supports:
+* Windows Server 2022 Long-Term Servicing Channel (must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d))
+* Windows Server 20H2 Semi-Annual Channel
 
-*Please note that Windows Server Long-Term Servicing Channel (LTSC): Windows Server 1809 cannot be used, since 
-the patch is not available.*
+*Please note that Windows Server 2019 is unsupported, as patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351)
+is not included. This is a requirement of the [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.*
 
 ## 2. Create the virtual machine
 

--- a/docs/vsphere-prerequisites.md
+++ b/docs/vsphere-prerequisites.md
@@ -5,7 +5,7 @@ the following pre-requisites are required:
 
 * The vSphere cluster must be configured with [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere)
   to work around the pod-to-pod connectivity between hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere)
-* Set up a [Windows Server Semi-Annual Channel (SAC): Windows Server 2004 VM golden image](vsphere-golden-image.md)
+* Set up a [VM golden image with a compatible Windows Server version](vsphere-golden-image.md#1-select-a-compatible-windows-server-version).
 * Add a [DNS entry](#adding-a-dns-entry-in-vsphere-environment) for the internal API endpoint in the vSphere environment
 
 Alternatively, a programmatic approach for the creation of the Windows VM golden image can be found [here.](vsphere_ci/README.md)

--- a/docs/vsphere_ci/README.md
+++ b/docs/vsphere_ci/README.md
@@ -43,7 +43,8 @@ associated with this public key is what will be used by WMCO to configure VMs cr
 deploying WMCO, this private key will be provided by the user in the form of a Secret.
 
 The [autounattend.xml](scripts/autounattend.xml) file must be edited to update the value of 
-`WindowsPassword` with a user provided password. Then, it executes the following steps:
+`WindowsPassword` with a user provided password. The `ProductKey` must also be updated with a proper value.
+autounattend.xml specifies that the following steps should occur:
 
 - Runs `install-vm-tools.cmd` script which installs VMWare tools
 - Runs `configure-vm-tools.ps1` script which configures VMWare tools
@@ -98,6 +99,16 @@ To enable detailed logging:
 ```bash
   PACKER_LOG=1 packer build build.json
 ```
+
+### What to do during the Packer build
+
+During the golden image creation, it is highly recommended to establish access to the virtual machine by launching a
+Web Console through the vCenter web client. This can be done after the Packer build has powered on the VM (while it is
+*Waiting for IP...*).
+
+If the build halts and prompts for a product key during the Windows OS setup, manual intervention will be required.
+When accessing the vitual machine via Web Console, send a `Ctrl+Alt+Del` then tab over to `I don't have a product key`,
+and hit `Enter` on the keyboard. This should start the OS setup as intended.
 
 ## What actually happens during build
 

--- a/docs/vsphere_ci/build.json
+++ b/docs/vsphere_ci/build.json
@@ -1,9 +1,9 @@
 {
   "variables": {
-    "os-iso-path": "[WorkloadDatastore] windows-iso-images/winsrv2004_sep_2020_x64_dvd.iso",
+    "os-iso-path": "[WorkloadDatastore] windows-iso-images/winsrv2022_sep_2021_x64_dvd.iso",
     "vmtools-iso-path": "[WorkloadDatastore] windows-iso-images/vmtools-v11360-windows.iso",
     "vm-template-folder": "windows-golden-images",
-    "vm-template-name": "windows-server-2004-template",
+    "vm-template-name": "windows-server-2022-template-withDocker",
     "vm-elevated-password": "WindowsPassword",
     "vsphere-cluster": "Cluster-1",
     "vsphere-datacenter": "SDDC-Datacenter",

--- a/docs/vsphere_ci/scripts/autounattend.xml
+++ b/docs/vsphere_ci/scripts/autounattend.xml
@@ -62,6 +62,9 @@
             </ImageInstall>
             <UserData>
                 <AcceptEula>true</AcceptEula>
+                <ProductKey>
+                    <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>
+                </ProductKey>
             </UserData>
         </component>
     </settings>
@@ -139,5 +142,5 @@
             </UserAccounts>
         </component>
     </settings>
-    <cpi:offlineImage cpi:source="wim:c:/wim/install.wim#Windows Server 2019 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
+    <cpi:offlineImage cpi:source="wim:c:/wim/install.wim#Windows Server 2022 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
 </unattend>

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -18,11 +18,13 @@ applicable cloud provider.
 Note: Any unlisted Windows Server version are NOT supported, and will cause errors. To prevent 
 these errors, only use the appropriate version according to the cloud provider in use. 
 
-| Cloud Provider | Supported Windows Server version                                       |
-|----------------|------------------------------------------------------------------------|
-| AWS            | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| Azure          | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| VMware vSphere | Windows Server Semi-Annual Channel (SAC): Windows Server 20H2          |
+| Cloud Provider | Supported Windows Server version                                                     |
+|----------------|--------------------------------------------------------------------------------------|
+| AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| Azure          | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| VMware vSphere | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
+
+*Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
 
 ## Supported Networking
 [OVNKubernetes hybrid networking](setup-hybrid-OVNKubernetes-cluster.md) is the only supported networking configuration.
@@ -39,10 +41,10 @@ Note:
 | Azure          | Hybrid OVNKubernetes                                                                           |
 | VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vsphere) |
 
-| Hybrid OVNKubernetes | Supported Windows Server version                                       |
-|----------------------|------------------------------------------------------------------------|
-| Default VXLAN port   | Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 |
-| Custom VXLAN port    | Windows Server Semi-Annual Channel (SAC): Windows Server 20H2          |
+| Hybrid OVNKubernetes | Supported Windows Server version                                                     |
+|----------------------|--------------------------------------------------------------------------------------|
+| Default VXLAN port   | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| Custom VXLAN port    | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
 
 ## Supported Installation method
 * Installer-Provisioned Infrastructure installation method is the only supported installation method. This is 

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -185,7 +185,7 @@ get_vsphere_ms() {
 
   # set golden image template name
   # TODO: read from parameter
-  template="windows-golden-images/windows-server-2004-template"
+  template="windows-golden-images/windows-server-2022-template-withDocker"
 
   # TODO: Reduce the number of API calls, make just one call
   #       to `oc get machines` and pass the data around. This is the

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -122,14 +122,14 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 	windowsAMIFilterName := "name"
 	windowsAMIFilterValue := ""
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
-	// The ami's will have the name format: Windows_Server-2019-English-Full-ContainersLatest-2020.01.15
+	// The ami's will have the name format: Windows_Server-2022-English-Full-ContainersLatest-2022.01.19
 	// so the question marks will match the date of creation
 	// The image obtained by using windowsAMIFilterValue is compatible with the test container image -
-	// "mcr.microsoft.com/powershell:lts-nanoserver-2004" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
+	// "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022" or "mcr.microsoft.com/powershell:lts-nanoserver-1809".
 	// If the windowsAMIFilterValue changes, the test container image also needs to be changed.
-	// if hasCustomVXLANPort is set use 2004 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
+	// if hasCustomVXLANPort is set use 2022 image as it has the custom VXLAN port changes, if not use Windows Server 2019 image
 	if hasCustomVXLANPort {
-		windowsAMIFilterValue = "Windows_Server-2004-English-Core-ContainersLatest-????.??.??"
+		windowsAMIFilterValue = "Windows_Server-2022-English-Full-ContainersLatest-????.??.??"
 	} else {
 		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	}

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -48,7 +48,7 @@ func (p *Provider) newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSp
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2004-template"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-withDocker"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -298,6 +298,13 @@ func (tc *testContext) sshSetup() error {
 // runPowerShellSSHJob creates and waits for a Kubernetes job to run. The command provided will be executed through
 // PowerShell, on the host specified by the provided IP.
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
+	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
+	// We only test Windows Server 2022 if a custom VXLAN port is used (i.e. vSphere)
+	powershellDefaultCommand := command
+	if tc.hasCustomVXLAN {
+		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
+	}
+
 	keyMountDir := "/private-key"
 	sshCommand := []string{"bash", "-c",
 		fmt.Sprintf(
@@ -305,12 +312,16 @@ func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, er
 			// command. If it succeeds, then the host's default shell is PowerShell
 			"if ssh -o StrictHostKeyChecking=no -i %s %s@%s 'Get-Help';"+
 				"then CMD_PREFIX=\"\";CMD_SUFFIX=\"\";"+
-				// if PowerShell is not the default shell, explicitly run the command through PowerShell
+				// to respect quoting within the given command, wrap the command as a script block
+				"COMMAND='{"+powershellDefaultCommand+"}';"+
+				// if PowerShell is not the default shell, explicitly run the unmodified command through PowerShell
 				"else CMD_PREFIX=\""+remotePowerShellCmdPrefix+" \\\"\";CMD_SUFFIX=\"\\\"\";"+
+				"COMMAND='{"+command+"}';"+
 				"fi;"+
-				"ssh -o StrictHostKeyChecking=no -i %s %s@%s ${CMD_PREFIX}' %s '${CMD_SUFFIX}",
+				// execute the command as a script block via the PowerShell call operator `&`
+				"ssh -o StrictHostKeyChecking=no -i %s %s@%s ${CMD_PREFIX}\" & $COMMAND \"${CMD_SUFFIX}",
 			filepath.Join(keyMountDir, secrets.PrivateKeySecretKey), tc.vmUsername(), ip,
-			filepath.Join(keyMountDir, secrets.PrivateKeySecretKey), tc.vmUsername(), ip, command)}
+			filepath.Join(keyMountDir, secrets.PrivateKeySecretKey), tc.vmUsername(), ip)}
 
 	return tc.runJob(name, sshCommand)
 }

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -16,7 +16,7 @@ var (
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 	// deploymentRetries is the amount of time to retry creating a Windows Server deployment, to compensate for the
-	// time it takes to download the Server2019 image to the node
+	// time it takes to download the Server image to the node
 	deploymentRetries = 10
 )
 


### PR DESCRIPTION
This PR covers backporting Windows Server 2022 support on vSphere to the WMCO 4.x. This is relevant as version 20H2 support comes to an end in August 2022.

- WMCB submodule bump to pick up [release-4.9 pause image change](https://github.com/openshift/windows-machine-config-bootstrapper/pull/332)
- backporting support for newer Powershell version
- changing the golden image used in vSphere CI to Windows Server 2022 golden image with Docker
- Announce support through docs/support matrix changes