### PR TITLE
[metrics] Remove old cleanup code

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -313,14 +313,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - delete
-          - get
-          - list
-        - apiGroups:
           - operators.coreos.com
           resources:
           - operatorconditions

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -218,10 +218,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Best effort to delete stale metric resources from previous operator version.
-	// Logs and creates events if stale resource deletion fails.
-	metricsConfig.RemoveStaleResources(ctx)
-
 	// Configure the metric resources
 	if err := metricsConfig.Configure(ctx); err != nil {
 		setupLog.Error(err, "error setting up metrics")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -172,14 +172,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - delete
-  - get
-  - list
-- apiGroups:
   - operators.coreos.com
   resources:
   - operatorconditions


### PR DESCRIPTION
This code was added to transition from the old metrics resources to the
new resources. This is no longer relevant now that it is not possible
to upgrade from a version with the old resource type.

This was added in commit f7d52ed9f2567ad8abd81d798ece5f3acfbfcbd3