### PR TITLE
Bug 2107261: Maintain endpoint subsets on restart

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -224,11 +224,20 @@ func (c *Config) Configure(ctx context.Context) error {
 	}
 	// In the case of an operator restart, a previous Endpoint object will be deleted and a new one will
 	// be created to ensure we have a correct spec.
-	err = c.CoreV1().Endpoints(c.namespace).Delete(ctx, WindowsMetricsResource, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrap(err, "error deleting existing metrics Endpoint")
+	var subsets []v1.EndpointSubset
+	existingEndpoint, err := c.CoreV1().Endpoints(c.namespace).Get(ctx, WindowsMetricsResource, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error retrieving %s endpoint", WindowsMetricsResource)
+		}
+	} else {
+		subsets = existingEndpoint.Subsets
+		err = c.CoreV1().Endpoints(c.namespace).Delete(ctx, WindowsMetricsResource, metav1.DeleteOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "error deleting %s endpoint", WindowsMetricsResource)
+		}
 	}
-	if err := c.createEndpoint(); err != nil {
+	if err := c.createEndpoint(subsets); err != nil {
 		return errors.Wrap(err, "error creating metrics Endpoint")
 	}
 	return nil
@@ -297,7 +306,7 @@ func (c *Config) RemoveStaleResources(ctx context.Context) {
 // object is created and WMCO needs to create the Endpoint object.
 // We cannot create endpoints as a part of manifests deployment as
 // Endpoints resources are not currently OLM-supported for bundle creation.
-func (c *Config) createEndpoint() error {
+func (c *Config) createEndpoint(subsets []v1.EndpointSubset) error {
 	// create new Endpoint
 	newEndpoint := &v1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
@@ -308,7 +317,7 @@ func (c *Config) createEndpoint() error {
 			Namespace: c.namespace,
 			Labels:    map[string]string{"name": WindowsMetricsResource},
 		},
-		Subsets: nil,
+		Subsets: subsets,
 	}
 	_, err := c.CoreV1().Endpoints(c.namespace).Create(context.TODO(),
 		newEndpoint, metav1.CreateOptions{})


### PR DESCRIPTION
WMCO deletes and recreates the windows-exporter endpoint upon each
operator start. This is resulting in an issue where the correct
endpoint subsets would be missing upon operator restart, stopping
metrics collection for Windows nodes.

This is being fixed by including the existing endpoint subsets in the
new endpoint created on restart.

A better approach would be to create a controller which maintains the
windows exporter endpoint. That is a larger change and should be done in
the future. This approach was taken as it is the smallest change which
can resolve this bug.

Fixes BZ#2107261