### PR TITLE
[servicescm] Handle unmanaged dependency services

### DIFF
--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -309,7 +309,10 @@ func (s *Service) hasCycle(servicesMap map[string]*Service, state map[string]boo
 			return true
 		}
 		if _, seen := state[dependencyName]; !seen {
-			return servicesMap[dependencyName].hasCycle(servicesMap, state)
+			// Only explore a dependency service if it's also managed by the services ConfigMap. Continue otherwise
+			if dependencyService, ok := servicesMap[dependencyName]; ok {
+				return dependencyService.hasCycle(servicesMap, state)
+			}
 		}
 	}
 	// Backtracking step, remove this service from current traversal path by marking it as fully processed

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -336,6 +336,19 @@ func TestValidateDependencies(t *testing.T) {
 			expectedErr: true,
 		},
 		{
+			name: "Service depends on a service not defined in the services ConfigMap",
+			input: []Service{
+				{
+					Name:         "test-service",
+					Command:      "C:\\test-service",
+					Dependencies: []string{"external-svc"},
+					Bootstrap:    false,
+					Priority:     0,
+				},
+			},
+			expectedErr: false,
+		},
+		{
 			name: "Cyclical dependency structure",
 			input: []Service{
 				{


### PR DESCRIPTION
This PR prevents a panic during service validation if a service that is not defined in
the services ConfigMap is listed as a dependency. Cycle detection now skips over
the unmanaged service and continues as normal for any other dependencies.