### PR TITLE
[release-4.9] WINC-820: [docs] Remove Windows Server 20H2 support

### DIFF
--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -6,7 +6,6 @@ This guide describes the thought process of creating a Windows virtual machine b
 
 Currently, the Windows Machine Config Operator (WMCO) stable version supports:
 * Windows Server 2022 Long-Term Servicing Channel (must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d))
-* Windows Server 20H2 Semi-Annual Channel
 
 *Please note that Windows Server 2019 is unsupported, as patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351)
 is not included. This is a requirement of the [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.*

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -22,7 +22,7 @@ these errors, only use the appropriate version according to the cloud provider i
 |----------------|--------------------------------------------------------------------------------------|
 | AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
 | Azure          | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
-| VMware vSphere | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
+| VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                               |
 
 *Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
 
@@ -44,7 +44,7 @@ Note:
 | Hybrid OVNKubernetes | Supported Windows Server version                                                     |
 |----------------------|--------------------------------------------------------------------------------------|
 | Default VXLAN port   | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
-| Custom VXLAN port    | - Windows Server 2022 Long-Term Servicing Channel (LTSC)<br>- Windows Server 20H2 Semi-Annual Channel (SAC) |
+| Custom VXLAN port    | Windows Server 2022 Long-Term Servicing Channel (LTSC)                               |
 
 ## Supported Installation method
 * Installer-Provisioned Infrastructure installation method is the only supported installation method. This is 


### PR DESCRIPTION
Microsoft will drop support for Windows Server 20H2 on 2022-08-09.
In line with this, WMCO no longer supports this version, leaving
Windows Server 2022 LTSC as the recommended version for vSphere worker nodes.

Manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1145.