### PR TITLE
WINC-823: Test generated community manifests in WMCO e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ lint:
 unit:
 	hack/unit.sh ${GO_MOD_FLAGS}
 
+.PHONY: community-bundle
+community-bundle:
+	hack/community/generate.sh ${WMCO_VERSION} ${ARTIFACT_DIR}
+
 .PHONY: wicd-unit
 wicd-unit:
 	hack/wicd-unit.sh

--- a/hack/community/csv/description.md
+++ b/hack/community/csv/description.md
@@ -11,8 +11,7 @@ version of OKD/OCP you are using. This CSV is meant for OKD/OCP COMMUNITY_VERSIO
 The Windows Machine Config Operator configures Windows instances into nodes, enabling Windows container workloads
 to be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
 or by specifying existing instances through a [ConfigMap](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/README.md#configuring-byoh-bring-your-own-host-windows-instances).
-Through either method, the Windows instance must have the containerd container runtime installed. The operator will do 
-all the necessary steps to configure the instance so that it can join the cluster as a worker node.
+The operator will do all the necessary steps to configure the instance so that it can join the cluster as a worker node.
 ### Pre-requisites
 - [Cluster and OS pre-requisites](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/docs/wmco-prerequisites.md)
 ### Usage

--- a/hack/community/readme.md
+++ b/hack/community/readme.md
@@ -1,45 +1,21 @@
 # Cut a new community release
-The generate.sh script automates the community release process by copying over 
-the latest WMCO manifests to a new community-WMCO folder while also replacing 
-necessary fields such as the name, description, and image. It also generates a 
-signed commit ready to be pushed to community-operators-prod repo. 
+The generate.sh script is called in the pre step to set up for the 
+aws-e2e-operator-test. The script copies over the WMCO community 
+bundle to the artifact directory while also replacing csv fields such as the 
+name, description, and date. Once generated into the artifact directory, the 
+bundle is used in the windows-e2e-operator test. After it passes, the bundle can
+be used to release a new community WMCO.
 
-## Pre-requisites
-Before running generate.sh, please ensure the following has merged:
-- openshift/release PR to add CI jobs to relevant community branch.
-[Example](https://github.com/openshift/release/pull/27081)
-- Submodule update PR for the relevant community branch. 
-- Ensure WMCB submodule is pointing to relevant community branch.
-[Example](https://github.com/openshift/windows-machine-config-operator/blob/community-4.10/.gitmodules#L4)
-- Fork and clone [community-operators-prod repo](https://github.com/redhat-openshift-ecosystem/community-operators-prod) 
-- Install yq:
-```shell script
-  curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64 -o /tmp/yq && chmod +x /tmp/yq
-```
-
-### From WMCO root, run:
-Parameter 3 can be grabbed from our [Quay repo](https://quay.io/repository/openshift-windows/community-windows-machine-config-operator?tab=tags).
-```shell script
-bash ./hack/community/generate.sh <community_wmco_version> <community_ocp_version> <latest_community-4.x_tag-commit-hash> <path/to/community-operators-prod>
-```
-Example: Cut community release v5.1.0 for community-4.10
-```shell script
-bash ./hack/community/generate.sh 5.1.0 community-4.10 community-4.10-hash ../community-operators-prod
-```
-
-### Review and test the operator
-- Scan over the newly generated CSV to ensure all the necessary fields were replaced
-- Follow: https://github.com/openshift/windows-machine-config-operator/blob/master/docs/HACKING.md#i-want-to-try-the-unreleased-wmco-and-deploy-it-mimicking-the-official-deployment-method 
-  You may skip step: Building the bundle image.
-- [CSV validation](https://operatorhub.io/preview) - paste in the CSV contents to
-preview what the community operator will look like in Operator Hub.
-
+### After the test passes
+- Fork and clone [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+repo.
+- Copy the community bundle from the ARTIFACT_DIR.
+- Paste the bundle contents into a new folder under 
+community-windows-machine-config-operator. The folder title should be the
+next version of the community WMCO that is to be released.
+- Scan over the bundle CSV and annotations to ensure all the necessary fields
+were replaced. Add or adjust fields as needed including olm.skipRange, name, 
+version, and replaces-mode.
 
 ### Ask for reviews
 - Tag WINC team for review
-- Tag your community-operators-prod PR reviewer to ask for a manual override to 
-merge. Sample message: 
-  - “This PR has been tested locally. OCP v4.x will not pass CI 
-  since our operator requires a cluster with hybrid-ovn networking for it to 
-  start up properly. This is by design. Will need a manual override for this to 
-  merge.”


### PR DESCRIPTION
Adds the 'community' target to our Makefile that calls the generate.sh
script in order to generate a community bundle in the artifact dir to be used in
our CI e2e test for community branch PRs.

Adjusts generate.sh to ensure it aligns with the
aws-e2e-operator platform test in CI.