### PR TITLE
WINC-718: WICD cleanup command

### DIFF
--- a/cmd/daemon/cleanup.go
+++ b/cmd/daemon/cleanup.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/cleanup"
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/config"
+)
+
+var (
+	cleanupCmd = &cobra.Command{
+		Use:   "cleanup",
+		Short: "Cleans up WMCO-managed Windows services",
+		Long: "Stops and removes all Windows services as part of Node deconfiguration, " +
+			"according to information given by Windows Service ConfigMaps present within the cluster",
+		Run: runCleanupCmd,
+	}
+	// preserveNode is an optional flag that instructs WICD to deconfigure an instance without deleting the Node object.
+	// This is useful in the node upgrade scenario.
+	preserveNode bool
+)
+
+func init() {
+	rootCmd.AddCommand(cleanupCmd)
+	cleanupCmd.PersistentFlags().BoolVar(&preserveNode, "preserveNode", false,
+		"If set to true, preserves the Node associated with this instance. Defaults to false.")
+}
+
+func runCleanupCmd(cmd *cobra.Command, args []string) {
+	cfg, err := config.FromServiceAccount(apiServerURL, saCA, saToken)
+	if err != nil {
+		klog.Exitf("error using service account to build config: %s", err.Error())
+	}
+	ctx := ctrl.SetupSignalHandler()
+	if err := cleanup.Deconfigure(cfg, ctx, preserveNode); err != nil {
+		klog.Exitf(err.Error())
+	}
+}

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -200,7 +200,7 @@ func (r *ConfigMapReconciler) removeOutdatedServicesConfigMaps(ctx context.Conte
 	}
 	versionAnnotations := getVersionAnnotations(nodes.Items)
 
-	servicesConfigMaps, err := r.listServiceConfigMaps(ctx)
+	servicesConfigMaps, err := servicescm.List(r.client, ctx, r.watchNamespace)
 	if err != nil {
 		return errors.Wrapf(err, "unable to retrieve list of services ConfigMaps")
 	}
@@ -231,21 +231,6 @@ func isTiedToRelevantVersion(v string, versions map[string]struct{}) bool {
 		}
 	}
 	return false
-}
-
-// listServiceConfigMaps returns a list of all windows-services ConfigMaps in the operator namespace
-func (r *ConfigMapReconciler) listServiceConfigMaps(ctx context.Context) ([]core.ConfigMap, error) {
-	watchNamespaceCMs := &core.ConfigMapList{}
-	if err := r.client.List(ctx, watchNamespaceCMs, &client.ListOptions{Namespace: r.watchNamespace}); err != nil {
-		return nil, err
-	}
-	servicesConfigMaps := []core.ConfigMap{}
-	for _, cm := range watchNamespaceCMs.Items {
-		if strings.HasPrefix(cm.Name, servicescm.NamePrefix) {
-			servicesConfigMaps = append(servicesConfigMaps, cm)
-		}
-	}
-	return servicesConfigMaps, nil
 }
 
 // reconcileNodes corrects the discrepancy between the "expected" instances, and the "actual" Node list

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -1,0 +1,111 @@
+//go:build windows
+
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/controller"
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
+)
+
+// Deconfigure removes an instance from the cluster. If preserveNode is true, the node object is not deleted.
+// If we are able to get the services ConfigMap tied to the desired version, all services defined in it are cleaned up.
+// TODO: Otherwise, perform cleanup based on a combination of the OpenShift managed tag and latest services ConfigMap.
+func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool) error {
+	// Cannot use a cached client as no manager will be started to populate cache
+	directClient, err := controller.NewDirectClient(cfg)
+	if err != nil {
+		return errors.Wrap(err, "could not create authenticated client from service account")
+	}
+	addrs, err := controller.LocalInterfaceAddresses()
+	if err != nil {
+		return err
+	}
+	var node *core.Node
+	var cmData *servicescm.Data
+	err = func() error {
+		node, err = controller.GetAssociatedNode(directClient, addrs)
+		if err != nil {
+			return err
+		}
+		desiredVersion, present := node.Annotations[nodeconfig.DesiredVersionAnnotation]
+		if !present {
+			return errors.Wrapf(err, "node missing desired version annotation")
+		}
+		// Fetch the CM of the desired version
+		cm := &core.ConfigMap{}
+		err = directClient.Get(ctx,
+			client.ObjectKey{Namespace: controller.WMCONamespace, Name: servicescm.NamePrefix + desiredVersion}, cm)
+		if err != nil {
+			return err
+		}
+		cmData, err = servicescm.Parse(cm.Data)
+		return err
+	}()
+	if err != nil {
+		// TODO: best effort cleanup of all OpenShift managed services and those in the latest services ConfigMap
+		// https://issues.redhat.com/browse/WINC-733
+		return err
+	}
+
+	svcMgr, err := manager.New()
+	if err != nil {
+		klog.Exitf("could not create service manager: %s", err.Error())
+	}
+	if err = removeServices(svcMgr, cmData.Services); err != nil {
+		return err
+	}
+
+	// Delete node if needed
+	if preserveNode || node == nil {
+		return nil
+	}
+	klog.Infof("deleting node %s", node.GetName())
+	return directClient.Delete(ctx, node)
+}
+
+// removeServices uses the given manager to remove all the given Windows services from this instance.
+func removeServices(svcMgr manager.Manager, services []servicescm.Service) error {
+	// Build up log message and failures
+	servicesRemoved := []string{}
+	failedRemovals := []error{}
+	// The services are ordered by increasing priority already, so stop them in reverse order to avoid dependency issues
+	for i := len(services) - 1; i >= 0; i-- {
+		service := services[i]
+		if err := svcMgr.DeleteService(service.Name); err != nil {
+			failedRemovals = append(failedRemovals, err)
+		} else {
+			servicesRemoved = append(servicesRemoved, service.Name)
+		}
+	}
+	klog.Infof("removed services: %q", servicesRemoved)
+	if len(failedRemovals) > 0 {
+		return errors.Errorf("%#v", failedRemovals)
+	}
+	return nil
+}

--- a/pkg/daemon/cleanup/cleanup_test.go
+++ b/pkg/daemon/cleanup/cleanup_test.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package cleanup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/fake"
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
+)
+
+func TestRemoveServices(t *testing.T) {
+	testIO := []struct {
+		name              string
+		existingServices  map[string]*fake.FakeService
+		configMapServices []servicescm.Service
+		expectedServices  map[string]struct{}
+	}{
+		{
+			name:              "No services",
+			existingServices:  map[string]*fake.FakeService{},
+			configMapServices: []servicescm.Service{},
+			expectedServices:  map[string]struct{}{},
+		},
+		{
+			name:              "Upgrade scenario with no services",
+			existingServices:  map[string]*fake.FakeService{},
+			configMapServices: []servicescm.Service{},
+			expectedServices:  map[string]struct{}{},
+		},
+		{
+			name:             "ConfigMap managed service doesn't exist on node",
+			existingServices: map[string]*fake.FakeService{},
+			configMapServices: []servicescm.Service{
+				{Name: "test1", Dependencies: nil, Priority: 0},
+			},
+			expectedServices: map[string]struct{}{},
+		},
+		{
+			name: "Single service",
+			existingServices: map[string]*fake.FakeService{
+				"test1": newTestService("test1", []string{}),
+			},
+			configMapServices: []servicescm.Service{
+				{Name: "test1", Dependencies: nil, Priority: 0},
+			},
+			expectedServices: map[string]struct{}{},
+		},
+		{
+			name: "Multiple services",
+			existingServices: map[string]*fake.FakeService{
+				"test1": newTestService("test1", []string{}),
+				"test2": newTestService("test2", []string{}),
+				"test3": newTestService("test3", []string{}),
+			},
+			configMapServices: []servicescm.Service{
+				{Name: "test1", Dependencies: nil, Priority: 0},
+				{Name: "test2", Dependencies: nil, Priority: 1},
+			},
+			expectedServices: map[string]struct{}{"test3": {}},
+		},
+		{
+			name: "Multiple services with dependencies",
+			existingServices: map[string]*fake.FakeService{
+				"test1": newTestService("test1", []string{}),
+				"test2": newTestService("test2", []string{}),
+				"test3": newTestService("test3", []string{}),
+				"test4": newTestService("test4", []string{"test3"}),
+				"test5": newTestService("test5", []string{"test1", "test3"}),
+			},
+			configMapServices: []servicescm.Service{
+				{Name: "test1", Dependencies: nil, Priority: 0},
+				{Name: "test3", Dependencies: nil, Priority: 0},
+				{Name: "test4", Dependencies: []string{"test3"}, Priority: 1},
+				{Name: "test5", Dependencies: []string{"test1", "test3"}, Priority: 2},
+			},
+			expectedServices: map[string]struct{}{"test2": {}},
+		},
+	}
+
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			winSvcMgr := fake.NewTestMgr(test.existingServices)
+			err := removeServices(winSvcMgr, test.configMapServices)
+			require.NoError(t, err)
+			allServices, err := winSvcMgr.GetServices()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedServices, allServices)
+		})
+	}
+}
+
+func newTestService(name string, dependencies []string) *fake.FakeService {
+	return fake.NewFakeService(
+		name,
+		mgr.Config{
+			Description:  windows.ManagedTag + name,
+			Dependencies: dependencies,
+		},
+		svc.Status{State: svc.Running},
+	)
+}

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -55,8 +55,8 @@ import (
 )
 
 const (
-	// wmcoNamespace defines the namespace service ConfigMaps are expected to be in
-	wmcoNamespace = "openshift-windows-machine-config-operator"
+	// WMCONamespace defines the namespace service ConfigMaps are expected to be in
+	WMCONamespace = "openshift-windows-machine-config-operator"
 )
 
 type ServiceController struct {
@@ -100,7 +100,7 @@ func RunController(ctx context.Context, apiServerURL, saCA, saToken string) erro
 		return err
 	}
 
-	addrs, err := localInterfaceAddresses()
+	addrs, err := LocalInterfaceAddresses()
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func RunController(ctx context.Context, apiServerURL, saCA, saToken string) erro
 	}
 
 	ctrlMgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Namespace: wmcoNamespace,
+		Namespace: WMCONamespace,
 		Scheme:    directClient.Scheme(),
 	})
 	if err != nil {
@@ -130,7 +130,7 @@ func RunController(ctx context.Context, apiServerURL, saCA, saToken string) erro
 // NewServiceController returns a pointer to a ServiceController object
 func NewServiceController(ctx context.Context, client client.Client, mgr manager.Manager, nodeName string) *ServiceController {
 	return &ServiceController{client: client, Manager: mgr, ctx: ctx, nodeName: nodeName,
-		watchNamespace: wmcoNamespace}
+		watchNamespace: WMCONamespace}
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -380,8 +380,8 @@ func GetAssociatedNode(c client.Client, addrs []net.Addr) (*core.Node, error) {
 	return node, nil
 }
 
-// localInterfaceAddresses returns a slice of all addresses associated with local network interfaces
-func localInterfaceAddresses() ([]net.Addr, error) {
+// LocalInterfaceAddresses returns a slice of all addresses associated with local network interfaces
+func LocalInterfaceAddresses() ([]net.Addr, error) {
 	var addresses []net.Addr
 	netIfs, err := net.Interfaces()
 	if err != nil {

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -210,26 +210,10 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 	return ctrl.Result{}, nil
 }
 
-// getExistingServices returns a map with the keys being all Windows services currently present on the VM
-func (sc *ServiceController) getExistingServices() (map[string]struct{}, error) {
-	// The most reliable way to determine if a service exists or not is to do a 'list' API call. It is possible to
-	// remove this call, and parse the error messages of a service 'open' API call, but I find that relying on human
-	// readable errors could cause issues when providing compatibility across different versions of Windows.
-	svcList, err := sc.ListServices()
-	if err != nil {
-		return nil, err
-	}
-	svcs := make(map[string]struct{})
-	for _, service := range svcList {
-		svcs[service] = struct{}{}
-	}
-	return svcs, nil
-}
-
 // reconcileServices ensures that all the services passed in via the services slice are created, configured properly
 // and started
 func (sc *ServiceController) reconcileServices(services []servicescm.Service) error {
-	existingSvcs, err := sc.getExistingServices()
+	existingSvcs, err := sc.GetServices()
 	if err != nil {
 		return errors.Wrap(err, "could not determine existing Windows services")
 	}

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -448,12 +448,12 @@ func testServicesCreatedAsExpected(t *testing.T, createdServices map[string]fake
 // getAllFakeServices accepts a mocked Windows service manager, and returns a map of copies of all existing Windows
 // services
 func getAllFakeServices(svcMgr manager.Manager) (map[string]fake.FakeService, error) {
-	svcs, err := svcMgr.ListServices()
+	svcs, err := svcMgr.GetServices()
 	if err != nil {
 		return nil, err
 	}
 	fakeServices := make(map[string]fake.FakeService)
-	for _, winServiceName := range svcs {
+	for winServiceName := range svcs {
 		winService, err := svcMgr.OpenService(winServiceName)
 		if err != nil {
 			return nil, err

--- a/pkg/daemon/fake/manager.go
+++ b/pkg/daemon/fake/manager.go
@@ -93,8 +93,13 @@ func (t *testMgr) CreateService(name, exepath string, config mgr.Config, args ..
 	return &service, nil
 }
 
-func (t *testMgr) ListServices() ([]string, error) {
-	return t.svcList.listServiceNames(), nil
+func (t *testMgr) GetServices() (map[string]struct{}, error) {
+	svcsList := t.svcList.listServiceNames()
+	svcsMap := make(map[string]struct{})
+	for _, svc := range svcsList {
+		svcsMap[svc] = struct{}{}
+	}
+	return svcsMap, nil
 }
 
 func (t *testMgr) OpenService(name string) (winsvc.Service, error) {

--- a/pkg/daemon/fake/manager.go
+++ b/pkg/daemon/fake/manager.go
@@ -111,10 +111,14 @@ func (t *testMgr) OpenService(name string) (winsvc.Service, error) {
 }
 
 func (t *testMgr) DeleteService(name string) error {
-	_, exists := t.svcList.read(name)
+	winSvc, exists := t.svcList.read(name)
 	if !exists {
-		// This is to mimic the behavior of the Windows OS. Trying to delete a nonexistant service results in an error.
-		return fmt.Errorf("service %s does not exist", name)
+		// Nothing to do if it already does not exist
+		return nil
+	}
+	// Ensure service is stopped before deleting
+	if err := winsvc.EnsureServiceState(winSvc, svc.Stopped); err != nil {
+		return errors.Wrapf(err, "failed to stop service %q", name)
 	}
 	return t.svcList.remove(name)
 }

--- a/pkg/daemon/fake/manager_test.go
+++ b/pkg/daemon/fake/manager_test.go
@@ -144,29 +144,22 @@ func TestDeleteService(t *testing.T) {
 		name         string
 		svcName      string
 		existingSvcs map[string]*FakeService
-		expectErr    bool
 	}{
 		{
 			name:         "service exists",
 			svcName:      "svc-one",
 			existingSvcs: map[string]*FakeService{"svc-one": {name: "svc-one", config: mgr.Config{Description: "testsvc"}}},
-			expectErr:    false,
 		},
 		{
 			name:         "delete non-existant service",
 			svcName:      "svc-one",
 			existingSvcs: map[string]*FakeService{},
-			expectErr:    true,
 		},
 	}
 	for _, test := range testIO {
 		t.Run(test.name, func(t *testing.T) {
 			testMgr := NewTestMgr(test.existingSvcs)
 			err := testMgr.DeleteService(test.svcName)
-			if test.expectErr {
-				assert.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 			// Check that the service is no longer present
 			svcs, err := testMgr.GetServices()

--- a/pkg/daemon/fake/manager_test.go
+++ b/pkg/daemon/fake/manager_test.go
@@ -77,29 +77,29 @@ func TestCreateService(t *testing.T) {
 	}
 }
 
-func TestListServices(t *testing.T) {
+func TestGetServices(t *testing.T) {
 	testIO := []struct {
 		name         string
 		existingSvcs map[string]*FakeService
-		expected     []string
+		expected     map[string]struct{}
 	}{
 		{
 			name:         "no services",
 			existingSvcs: map[string]*FakeService{},
-			expected:     []string{},
+			expected:     map[string]struct{}{},
 		},
 		{
 			name:         "some services",
 			existingSvcs: map[string]*FakeService{"svc-one": {}, "svc-two": {}},
-			expected:     []string{"svc-one", "svc-two"},
+			expected:     map[string]struct{}{"svc-one": {}, "svc-two": {}},
 		},
 	}
 	for _, test := range testIO {
 		t.Run(test.name, func(t *testing.T) {
 			testMgr := NewTestMgr(test.existingSvcs)
-			list, err := testMgr.ListServices()
+			svcs, err := testMgr.GetServices()
 			require.NoError(t, err)
-			assert.ElementsMatch(t, test.expected, list)
+			assert.Equal(t, test.expected, svcs)
 		})
 	}
 }
@@ -168,10 +168,10 @@ func TestDeleteService(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			// Check that the service is no longer present in the service list
-			list, err := testMgr.ListServices()
+			// Check that the service is no longer present
+			svcs, err := testMgr.GetServices()
 			require.NoError(t, err)
-			assert.NotContains(t, list, test.svcName)
+			assert.NotContains(t, svcs, test.svcName)
 		})
 	}
 }


### PR DESCRIPTION
WMCO will invoke WICD `cleanup` to remove an instance from the cluster. 
This PR covers the initial implementation of said command to remove services.

When the WICD cleanup command is executed, all services managed by us 
(as defined in the expected services ConfigMap) will be stopped and deleted. 

It will then delete the instance's Node object by default. 
When ran with the optional `--preserveNode` arg, the Node object won't be deleted.