### PR TITLE
WINC-823: Test generated community manifests in WMCO e2e Followup

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# Default is false unless test is running in COMMUNITY branch
+COMMUNITY=${COMMUNITY:-false}
+
 # Location of the manifests file
 MANIFEST_LOC=bundle/
+if [ "$COMMUNITY" = "true" ]; then
+  MANIFEST_LOC="$ARTIFACT_DIR"
+fi
 
 # define namespace
 declare -r WMCO_DEPLOY_NAMESPACE=openshift-windows-machine-config-operator
@@ -52,7 +58,7 @@ OSDK_WMCO_management() {
 
   if [[ "$COMMAND" = "run" ]]; then
     local version=$(get_packagemanifests_version)
-    $OSDK_PATH run packagemanifests bundle \
+    $OSDK_PATH run packagemanifests $MANIFEST_LOC \
       --namespace $WMCO_DEPLOY_NAMESPACE \
       --install-mode=OwnNamespace \
       --version $version \

--- a/hack/community/generate.sh
+++ b/hack/community/generate.sh
@@ -61,7 +61,7 @@ generate_manifests() {
   local OUTPUT_DIR=$3
 
   echo "Update operator manifests"
-  cp -r "${BUNDLE_DIR}/manifests" "${BUNDLE_DIR}/metadata" "${OUTPUT_DIR}"
+  cp -r "${BUNDLE_DIR}/manifests" "${BUNDLE_DIR}/metadata" "${BUNDLE_DIR}/windows-machine-config-operator.package.yaml" "${OUTPUT_DIR}"
   local CO_CSV="${OUTPUT_DIR}/manifests/windows-machine-config-operator.clusterserviceversion.yaml"
   local CO_ANNOTATIONS="${OUTPUT_DIR}/metadata/annotations.yaml"
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -3,6 +3,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# If ARTIFACT_DIR is not set, create a temp directory for artifacts
+ARTIFACT_DIR=${ARTIFACT_DIR:-}
+if [ -z "$ARTIFACT_DIR" ]; then
+  ARTIFACT_DIR=`mktemp -d`
+  echo "ARTIFACT_DIR is not set. Artifacts will be stored in: $ARTIFACT_DIR"
+  export ARTIFACT_DIR=$ARTIFACT_DIR
+fi
+
 WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 source $WMCO_ROOT/hack/common.sh
 
@@ -57,14 +65,6 @@ if ! [[ "$OPENSHIFT_CI" == "true" &&  "$TEST" = "upgrade" ]]; then
 fi
 
 SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"false"}
-
-# If ARTIFACT_DIR is not set, create a temp directory for artifacts
-ARTIFACT_DIR=${ARTIFACT_DIR:-}
-if [ -z "$ARTIFACT_DIR" ]; then
-  ARTIFACT_DIR=`mktemp -d`
-  echo "ARTIFACT_DIR is not set. Artifacts will be stored in: $ARTIFACT_DIR"
-  export ARTIFACT_DIR=$ARTIFACT_DIR
-fi
 
 # OPERATOR_IMAGE defines where the WMCO image to test with is located. If $OPERATOR_IMAGE is already set, use its value.
 # Setting $OPERATOR_IMAGE is required for local testing.


### PR DESCRIPTION
Adds a check for the COMMUNITY env var. If present(true), the manifest
location is set to the artifact dir. Otherwise, it is set to the local bundle/ location.

Moves ARTIFACT_DIR check up so that nounset is not triggered. 

Adjusts generate.sh to copy over wmco-package.yaml
to the community bundle as it's needed for e2e testing.

Depends on: https://github.com/openshift/windows-machine-config-operator/pull/1151 and https://github.com/openshift/release/pull/30711