### PR TITLE
WINC-737: Start hybrid-overlay with WICD

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -46,9 +46,9 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/metrics"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
+	"github.com/openshift/windows-machine-config-operator/pkg/services"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/signer"
-	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 	"github.com/openshift/windows-machine-config-operator/version"
 )
@@ -88,7 +88,7 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 	}
 
 	// Get expected state of the Windows service ConfigMap
-	svcData, err := generateServicesManifest()
+	svcData, err := services.GenerateManifest()
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating expected Windows service state")
 	}
@@ -473,20 +473,4 @@ func (r *ConfigMapReconciler) EnsureServicesConfigMapExists() error {
 func (r *ConfigMapReconciler) isKubeAPIServerServingCAConfigMap(obj client.Object) bool {
 	return obj.GetNamespace() == certificates.KubeApiServerOperatorNamespace &&
 		obj.GetName() == certificates.KubeAPIServerServingCAConfigMapName
-}
-
-// generateServicesManifest returns the expected state of the Windows service configmap
-func generateServicesManifest() (*servicescm.Data, error) {
-	services := &[]servicescm.Service{{
-		Name:                         windows.WindowsExporterServiceName,
-		Command:                      windows.WindowsExporterServiceCommand,
-		NodeVariablesInCommand:       nil,
-		PowershellVariablesInCommand: nil,
-		Dependencies:                 nil,
-		Bootstrap:                    false,
-		Priority:                     1,
-	}}
-	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847
-	files := &[]servicescm.FileInfo{}
-	return servicescm.NewData(services, files)
 }

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -88,7 +88,7 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 	}
 
 	// Get expected state of the Windows service ConfigMap
-	svcData, err := services.GenerateManifest()
+	svcData, err := services.GenerateManifest(clusterConfig.Network().VXLANPort(), ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating expected Windows service state")
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,0 +1,22 @@
+package services
+
+import (
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
+)
+
+// GenerateManifest returns the expected state of the Windows service configmap
+func GenerateManifest() (*servicescm.Data, error) {
+	services := &[]servicescm.Service{{
+		Name:                         windows.WindowsExporterServiceName,
+		Command:                      windows.WindowsExporterServiceCommand,
+		NodeVariablesInCommand:       nil,
+		PowershellVariablesInCommand: nil,
+		Dependencies:                 nil,
+		Bootstrap:                    false,
+		Priority:                     1,
+	}}
+	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847
+	files := &[]servicescm.FileInfo{}
+	return servicescm.NewData(services, files)
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,12 +1,15 @@
 package services
 
 import (
+	"fmt"
+
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
-// GenerateManifest returns the expected state of the Windows service configmap
-func GenerateManifest() (*servicescm.Data, error) {
+// GenerateManifest returns the expected state of the Windows service configmap. If debug is true, debug logging
+// will be enabled for services that support it.
+func GenerateManifest(vxlanPort string, debug bool) (*servicescm.Data, error) {
 	services := &[]servicescm.Service{{
 		Name:                         windows.WindowsExporterServiceName,
 		Command:                      windows.WindowsExporterServiceCommand,
@@ -15,8 +18,41 @@ func GenerateManifest() (*servicescm.Data, error) {
 		Dependencies:                 nil,
 		Bootstrap:                    false,
 		Priority:                     1,
-	}}
+	},
+		hybridOverlayConfiguration(vxlanPort, debug),
+	}
 	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847
 	files := &[]servicescm.FileInfo{}
 	return servicescm.NewData(services, files)
+}
+
+// hybridOverlayConfiguration returns the Service definition for hybrid-overlay
+func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service {
+	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --k8s-kubeconfig %s --windows-service "+
+		"--logfile "+"%shybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath,
+		windows.HybridOverlayLogDir)
+	if len(vxlanPort) > 0 {
+		hybridOverlayServiceCmd = fmt.Sprintf("%s --hybrid-overlay-vxlan-port %s", hybridOverlayServiceCmd, vxlanPort)
+	}
+
+	// check log level and increase hybrid-overlay verbosity if needed
+	if debug {
+		// append loglevel param using 5 for debug (default: 4)
+		// See https://github.com/openshift/ovn-kubernetes/blob/master/go-controller/pkg/config/config.go#L736
+		hybridOverlayServiceCmd = hybridOverlayServiceCmd + " --loglevel 5"
+	}
+	return servicescm.Service{
+		Name:    windows.HybridOverlayServiceName,
+		Command: hybridOverlayServiceCmd,
+		NodeVariablesInCommand: []servicescm.NodeCmdArg{
+			{
+				Name:               "NODE_NAME",
+				NodeObjectJsonPath: "{.metadata.name}",
+			},
+		},
+		PowershellVariablesInCommand: nil,
+		Dependencies:                 []string{windows.KubeletServiceName},
+		Bootstrap:                    false,
+		Priority:                     1,
+	}
 }


### PR DESCRIPTION
This commit adds the hybrid-overlay service spec to the Windows service
ConfigMap, causing WICD to start and maintain the service. WMCO will
still wait to ensure that hybrid-overlay has done its job, as kube-proxy
cannot be started until that point.