### PR TITLE
Log WMCO timestamps in RFC3339 format

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -11,6 +11,7 @@ import (
 	operators "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/operator-framework/operator-lib/leader"
 	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -60,7 +61,7 @@ func main() {
 
 	pflag.Parse()
 
-	opts := zap.Options{Development: debugLogging}
+	opts := zap.Options{Development: debugLogging, TimeEncoder: zapcore.RFC3339TimeEncoder}
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// add version subcommand to query the operator version

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
@@ -94,7 +95,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect


### PR DESCRIPTION
Makes timestamps human readable for easier use