### PR TITLE
[WIP] Remove userdata PowerShell tags

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -51,7 +51,7 @@ func GenerateUserData(publicKey ssh.PublicKey) (*core.Secret, error) {
 			Namespace: UserDataNamespace,
 		},
 		Data: map[string][]byte{
-			"userData": []byte(`<powershell>
+			"userData": []byte(`
 			Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 			$firewallRuleName = "ContainerLogsPort"
 			$containerLogsPort = "10250"
@@ -73,8 +73,7 @@ func GenerateUserData(publicKey ssh.PublicKey) (*core.Secret, error) {
 			$acl.SetAccessRule($systemRule)
 			$acl | Set-Acl
 			Restart-Service sshd
-			</powershell>
-			<persist>true</persist>`),
+			`),
 		},
 	}
 


### PR DESCRIPTION
The tags <powershell> and <persist> are now applied when necessary, as
of https://github.com/openshift/machine-api-operator/pull/1049
The windows-user-data should now only include the PowerShell commands
that should be ran as part of VM creation.