### PR TITLE
[wicd] Make manager in charge of closing services

### DIFF
--- a/pkg/daemon/fake/manager.go
+++ b/pkg/daemon/fake/manager.go
@@ -105,6 +105,12 @@ func (t *testMgr) OpenService(name string) (winsvc.Service, error) {
 	return service, nil
 }
 
+func (t *testMgr) CloseService(name string) error {
+	// Closing a Windows service frees up OS-level resources.
+	// There is nothing to cleanup in our mock service objects.
+	return nil
+}
+
 func (t *testMgr) DeleteService(name string) error {
 	_, exists := t.svcList.read(name)
 	if !exists {

--- a/pkg/daemon/manager/manager.go
+++ b/pkg/daemon/manager/manager.go
@@ -15,6 +15,8 @@ type Manager interface {
 	ListServices() ([]string, error)
 	// OpenService gets the Windows service of the given name if it exists, by which it can be queried or controlled
 	OpenService(string) (winsvc.Service, error)
+	// CloseService closes access to the handle of the given service
+	CloseService(string) error
 	// DeleteService marks a Windows service of the given name for deletion, or an error if it does not exist
 	DeleteService(string) error
 }
@@ -31,14 +33,26 @@ func (m *manager) CreateService(name, exepath string, config mgr.Config, args ..
 	service, err := underlyingMgr.CreateService(name, exepath, config, args...)
 	return winsvc.Service(service), err
 }
+
 func (m *manager) ListServices() ([]string, error) {
 	underlyingMgr := (*mgr.Mgr)(m)
 	return underlyingMgr.ListServices()
 }
+
 func (m *manager) OpenService(name string) (winsvc.Service, error) {
 	underlyingMgr := (*mgr.Mgr)(m)
 	return underlyingMgr.OpenService(name)
 }
+
+func (m *manager) CloseService(name string) error {
+	underlyingMgr := (*mgr.Mgr)(m)
+	winSvc, err := underlyingMgr.OpenService(name)
+	if err != nil {
+		return err
+	}
+	return winSvc.Close()
+}
+
 func (m *manager) DeleteService(name string) error {
 	underlyingMgr := (*mgr.Mgr)(m)
 	winSvc, err := underlyingMgr.OpenService(name)

--- a/pkg/daemon/winsvc/winsvc.go
+++ b/pkg/daemon/winsvc/winsvc.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Service interface {
-	Close() error
 	Start(...string) error
 	Config() (mgr.Config, error)
 	Control(svc.Cmd) (svc.Status, error)


### PR DESCRIPTION
This PR makes the Windows service manager interface own the closing of
Windows services, instead of the service itself. As the manager
is in charge of opening services, it should also be in charge of closing.

Follow-up to https://github.com/openshift/windows-machine-config-operator/pull/1166