### PR TITLE
[docs] Clarify storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ WMCO does not support adding Windows workloads using a [cluster-wide proxy](http
 config for the OpenShift Container Platform. WMCO will not be able to automatically route proxy connections for Windows
 workloads.
 
+### Storage
+At this time, only in-tree storage is supported in all cloud providers.
+
 ### Other limitations
 WMCO / Windows nodes does not work with the following products:
 * [odo](https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/understanding-odo.html)


### PR DESCRIPTION
Adds a supported storage section to our docs that specifies that
only in-tree storage methods are supported in each cloud platform.