### PR TITLE
[winsvc] Wait for service state changes

### DIFF
--- a/pkg/daemon/winsvc/winsvc.go
+++ b/pkg/daemon/winsvc/winsvc.go
@@ -6,6 +6,9 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 )
 
 type Service interface {
@@ -28,11 +31,27 @@ func EnsureServiceState(service Service, state svc.State) error {
 	}
 	switch state {
 	case svc.Running:
-		return service.Start()
+		err = service.Start()
+		if err != nil {
+			return err
+		}
 	case svc.Stopped:
 		_, err = service.Control(svc.Stop)
-		return err
+		if err != nil {
+			return err
+		}
 	default:
 		return errors.New("unexpected state request")
 	}
+	// Wait for the state change to actually take place
+	return wait.PollImmediate(retry.WindowsAPIInterval, retry.ResourceChangeTimeout, func() (bool, error) {
+		status, err := service.Query()
+		if err != nil {
+			return false, errors.Wrap(err, "error querying service state")
+		}
+		if status.State == state {
+			return true, nil
+		}
+		return false, nil
+	})
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -5,6 +5,8 @@ import "time"
 const (
 	// Count is the number of times we will retry an API call
 	Count = 20
+	// WindowsAPIInterval is the wait time between calls to the Windows OS API in case of failure
+	WindowsAPIInterval = 5 * time.Second
 	// Interval is the wait time between API calls on a failure
 	Interval = 15 * time.Second
 	// Timeout is the total time we will wait for an event to occur.


### PR DESCRIPTION
This PR adds a wait to EnsureServiceState, ensuring that the Windows
service actually has the desired state when the function returns. This makes
any operations that occur after calling this function safe (for example, 
deleting after changing state to stopped).