### PR TITLE
Refactor providers package

### DIFF
--- a/test/e2e/clusterinfo/constants.go
+++ b/test/e2e/clusterinfo/constants.go
@@ -10,15 +10,3 @@ const (
 	MachineAPINamespace = "openshift-machine-api"
 	UserDataSecretName  = "windows-user-data"
 )
-
-// WindowsMachineSetName returns the name of the Windows MachineSet created in the e2e tests depending on if the
-// Windows label is set or not
-// TODO: Move this function to the providers package as part of https://issues.redhat.com/browse/WINC-608
-func WindowsMachineSetName(isWindowsLabelSet bool) string {
-	if isWindowsLabelSet {
-		// Designate MachineSets that set a Windows label on the Machine with
-		// "e2e-wm", to signify they should be configured by the Windows Machine controller
-		return "e2e-wm"
-	}
-	return "e2e"
-}

--- a/test/e2e/clusterinfo/openshift.go
+++ b/test/e2e/clusterinfo/openshift.go
@@ -85,50 +85,11 @@ func GetOpenShift() (*OpenShift, error) {
 	}, nil
 }
 
-// GetInfrastructureID returns the infrastructure ID of the OpenShift cluster or an error.
-func (o *OpenShift) GetInfrastructureID() (string, error) {
-	infra, err := o.getInfrastructure()
-	if err != nil {
-		return "", err
-	}
-	if infra.Status == (config.InfrastructureStatus{}) {
-		return "", fmt.Errorf("infrastructure status is nil")
-	}
-	return infra.Status.InfrastructureName, nil
-}
-
-// GetCloudProvider returns the Provider details of a given OpenShift client including provider type and region or
-// an error.
-func (o *OpenShift) GetCloudProvider() (*config.PlatformStatus, error) {
-	infra, err := o.getInfrastructure()
-	if err != nil {
-		return nil, err
-	}
-	if infra.Status == (config.InfrastructureStatus{}) || infra.Status.PlatformStatus == nil {
-		return nil, fmt.Errorf("error getting infrastructure status")
-	}
-	return infra.Status.PlatformStatus, nil
-}
-
-// getInfrastructure returns the information of current Infrastructure referred by the OpenShift client or an error.
-func (o *OpenShift) getInfrastructure() (*config.Infrastructure, error) {
+// GetInfrastructure returns the information of current Infrastructure referred by the OpenShift client or an error.
+func (o *OpenShift) GetInfrastructure() (*config.Infrastructure, error) {
 	infra, err := o.Config.ConfigV1().Infrastructures().Get(context.TODO(), "cluster", meta.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return infra, nil
-}
-
-// HasCustomVXLANPort tells if the custom VXLAN port is set or not in the cluster
-func (o *OpenShift) HasCustomVXLANPort() (bool, error) {
-	networkCR, err := o.Operator.Networks().Get(context.TODO(), "cluster", meta.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	if networkCR.Spec.DefaultNetwork.OVNKubernetesConfig != nil &&
-		networkCR.Spec.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig != nil &&
-		networkCR.Spec.DefaultNetwork.OVNKubernetesConfig.HybridOverlayConfig.HybridOverlayVXLANPort != nil {
-		return true, nil
-	}
-	return false, nil
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -72,8 +72,6 @@ type testContext struct {
 	timeout time.Duration
 	// CloudProvider to talk to various cloud providers
 	providers.CloudProvider
-	// hasCustomVXLAN tells if the cluster is using a custom VXLAN port for communication
-	hasCustomVXLAN bool
 	// workloadNamespace is the namespace to deploy our test pods on
 	workloadNamespace string
 	// toolsImage is the image specified by the  openshift/tools ImageStream, and is the same image used by `oc debug`.
@@ -87,11 +85,7 @@ func NewTestContext() (*testContext, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize OpenShift client")
 	}
-	hasCustomVXLANPort, err := oc.HasCustomVXLANPort()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to determine if cluster is using custom VXLAN port")
-	}
-	cloudProvider, err := providers.NewCloudProvider(hasCustomVXLANPort)
+	cloudProvider, err := providers.NewCloudProvider()
 	if err != nil {
 		return nil, errors.Wrap(err, "cloud provider creation failed")
 	}
@@ -103,7 +97,7 @@ func NewTestContext() (*testContext, error) {
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{client: oc, timeout: retry.Timeout, retryInterval: retry.Interval,
 		namespace: "openshift-windows-machine-config-operator", CloudProvider: cloudProvider,
-		hasCustomVXLAN: hasCustomVXLANPort, workloadNamespace: "wmco-test", toolsImage: toolsImage}, nil
+		workloadNamespace: "wmco-test", toolsImage: toolsImage}, nil
 }
 
 // vmUsername returns the name of the user which can be used to log into each Windows instance

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -9,9 +9,9 @@ import (
 	mapi "github.com/openshift/api/machine/v1beta1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
 )
 
 const (
@@ -109,63 +109,7 @@ func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*m
 		return nil, fmt.Errorf("failed to marshal azure machine provider spec: %v", err)
 	}
 
-	matchLabels := map[string]string{
-		mapi.MachineClusterIDLabel:  p.InfrastructureName,
-		clusterinfo.MachineE2ELabel: "true",
-	}
-
-	// On Azure the machine name for Windows VMs cannot be more than 15 characters long
-	// The machine-api-operator derives the name from the MachineSet name,
-	// adding '"-" + rand.String(5)'.
-	// This leaves a max. 9 characters for the MachineSet name
-	machineSetName := clusterinfo.WindowsMachineSetName(withWindowsLabel)
-	if withWindowsLabel {
-		matchLabels[clusterinfo.MachineOSIDLabel] = "Windows"
-	}
-	matchLabels[clusterinfo.MachineSetLabel] = machineSetName
-
-	machineLabels := map[string]string{
-		clusterinfo.MachineRoleLabel: "worker",
-		clusterinfo.MachineTypeLabel: "worker",
-	}
-	// append matchlabels to machinelabels
-	for k, v := range matchLabels {
-		machineLabels[k] = v
-	}
-
-	// Set up the test machineSet
-	machineSet := &mapi.MachineSet{
-		ObjectMeta: meta.ObjectMeta{
-			Name:      machineSetName,
-			Namespace: clusterinfo.MachineAPINamespace,
-			Labels: map[string]string{
-				mapi.MachineClusterIDLabel:  p.InfrastructureName,
-				clusterinfo.MachineE2ELabel: "true",
-			},
-		},
-		Spec: mapi.MachineSetSpec{
-			Selector: meta.LabelSelector{
-				MatchLabels: matchLabels,
-			},
-			Replicas: &replicas,
-			Template: mapi.MachineTemplateSpec{
-				ObjectMeta: mapi.ObjectMeta{Labels: machineLabels},
-				Spec: mapi.MachineSpec{
-					ObjectMeta: mapi.ObjectMeta{
-						Labels: map[string]string{
-							"node-role.kubernetes.io/worker": "",
-						},
-					},
-					ProviderSpec: mapi.ProviderSpec{
-						Value: &runtime.RawExtension{
-							Raw: rawProviderSpec,
-						},
-					},
-				},
-			},
-		},
-	}
-	return machineSet, nil
+	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withWindowsLabel), nil
 }
 
 func (p *Provider) GetType() config.PlatformType {

--- a/test/e2e/providers/machineset/machineset.go
+++ b/test/e2e/providers/machineset/machineset.go
@@ -1,0 +1,73 @@
+package machineset
+
+import (
+	mapi "github.com/openshift/api/machine/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+)
+
+// New returns a new MachineSet for use with the e2e test suite
+func New(rawProvider []byte, infrastructureName string, replicas int32, withWindowsLabel bool) *mapi.MachineSet {
+	machineSetName := machineSetName(withWindowsLabel)
+	matchLabels := map[string]string{
+		mapi.MachineClusterIDLabel:  infrastructureName,
+		clusterinfo.MachineE2ELabel: "true",
+	}
+	if withWindowsLabel {
+		matchLabels[clusterinfo.MachineOSIDLabel] = "Windows"
+	}
+	matchLabels[clusterinfo.MachineSetLabel] = machineSetName
+
+	machineLabels := map[string]string{
+		clusterinfo.MachineRoleLabel: "worker",
+		clusterinfo.MachineTypeLabel: "worker",
+	}
+	// append matchlabels to machinelabels
+	for k, v := range matchLabels {
+		machineLabels[k] = v
+	}
+
+	// Set up the test machineSet
+	return &mapi.MachineSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      machineSetName,
+			Namespace: clusterinfo.MachineAPINamespace,
+			Labels: map[string]string{
+				mapi.MachineClusterIDLabel:  infrastructureName,
+				clusterinfo.MachineE2ELabel: "true",
+			},
+		},
+		Spec: mapi.MachineSetSpec{
+			Selector: meta.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+			Replicas: &replicas,
+			Template: mapi.MachineTemplateSpec{
+				ObjectMeta: mapi.ObjectMeta{Labels: machineLabels},
+				Spec: mapi.MachineSpec{
+					ObjectMeta: mapi.ObjectMeta{
+						Labels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					ProviderSpec: mapi.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProvider},
+					},
+				},
+			},
+		},
+	}
+}
+
+// machineSetName returns the name of the Windows MachineSet created in the e2e tests depending on if the
+// Windows label is set or not
+func machineSetName(isWindowsLabelSet bool) string {
+	if isWindowsLabelSet {
+		// Designate MachineSets that set a Windows label on the Machine with
+		// "e2e-wm", to signify they should be configured by the Windows Machine controller
+		return "e2e-wm"
+	}
+	return "e2e"
+}


### PR DESCRIPTION
This PR contains commits relating to refactoring the providers packages, used by the WMCO e2e tests to generate MachineSet specs. This will make adding additional platform easier.