### PR TITLE
WINC-815: Add support for Windows Server 2022 on GCP clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ spec:
 Example MachineSet for other cloud providers:
 - [AWS](docs/machineset-aws.md)
 - [Azure](docs/machineset-azure.md)
+- [GCP](docs/machineset-gcp.md)
 
 Alternatively, the [hack/machineset.sh](hack/machineset.sh) script can be used to generate MachineSets for AWS and Azure platforms.
 The hack script will generate a `MachineSet.yaml` file which can be edited before using or can be used as it is.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -249,3 +249,8 @@ git submodule update --recursive
 # To update a specific submodule
 git submodule update --remote <path_to_submodule>
 ```
+
+## Preventing Windows Machines from being configured by WMCO
+
+If the Machine spec has the label `windowsmachineconfig.openshift.io/ignore=true`, the Machine will be ignored by WMCO,
+and will not be configured into a Windows node. This can be helpful when debugging userdata changes.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -252,5 +252,6 @@ git submodule update --remote <path_to_submodule>
 
 ## Preventing Windows Machines from being configured by WMCO
 
-If the Machine spec has the label `windowsmachineconfig.openshift.io/ignore=true`, the Machine will be ignored by WMCO,
-and will not be configured into a Windows node. This can be helpful when debugging userdata changes.
+If the Machine spec has the label `windowsmachineconfig.openshift.io/ignore=true`, the Machine will be ignored by
+WMCO's Machine controller, and will not be configured into a Windows node. This can be helpful when debugging userdata
+changes.

--- a/docs/machineset-gcp.md
+++ b/docs/machineset-gcp.md
@@ -1,0 +1,74 @@
+# Creating a GCP Windows MachineSet
+
+_\<windows_server_image \>_ should be replaced with the full path to an image of a [supported version](wmco-prerequisites.md#supported-windows-server-versions) of Windows.
+For example, to use the latest image from the `windows-2022-core` family in the `windows-cloud` project, you would use:
+`projects/windows-cloud/global/images/family/windows-2022-core`
+
+
+_\<infrastructure_id\>_ should be replaced with the output of:
+```shell script
+ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+```
+_\<region\>_ should be replaced with a region, such as `us-central1`.
+
+_\<zone\>_ should be replaced with a zone within the chosen region, such as `us-central1-a`.
+
+_\<zone_suffix\>_ should be replaced with the suffix of the chosen zone, such as `a`.
+
+_\<project_id\>_ should be replaced with the GCP project this cluster was created under.
+```
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-windows-worker-<zone_suffix>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-windows-worker-<zone_suffix>
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-windows-worker-<zone_suffix>
+        machine.openshift.io/os-id: Windows
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/worker: ""
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+          - autoDelete: true
+            boot: true
+            image: <windows_server_image>
+            sizeGb: 128
+            type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-4
+          networkInterfaces:
+          - network: <infrastructure_id>-network
+            subnetwork: <infrastructure_id>-worker-subnet
+          projectID: <project_id>
+          region: <region>
+          serviceAccounts:
+          - email: <infrastructure_id>-w@<project_id>.iam.gserviceaccount.com
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+          tags:
+          - <infrastructure_id>-worker
+          userDataSecret:
+            name: windows-user-data
+          zone: <zone>
+```

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -7,6 +7,7 @@ may be relevant.
 |---------------------------|---------------------------|------------------------|
 | Amazon Web Services (AWS) | 4.6+                      | WMCO 1.0+              |
 | Azure                     | 4.6+                      | WMCO 1.0+              |
+| GCP                       | 4.12+                     | WMCO 7.0+              |
 | VMware vSphere            | 4.7+                      | WMCO 2.0+              |
 | Platform none (BYOH)      | 4.8+                      | WMCO 3.1.0+            |
 
@@ -22,6 +23,7 @@ these errors, only use the appropriate version according to the cloud provider i
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                                                              |
 | Azure          | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
+| GCP            | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
 | VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
 
 *Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
@@ -39,6 +41,7 @@ Note:
 |----------------|------------------------------------------------------------------------------------------------|
 | AWS            | Hybrid OVNKubernetes                                                                           |
 | Azure          | Hybrid OVNKubernetes                                                                           |
+| GCP            | Hybrid OVNKubernetes                                                                           |
 | VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vsphere) |
 
 | Hybrid OVNKubernetes | Supported Windows Server version                                                     |

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -279,7 +279,7 @@ func (a *awsProvider) getIAMWorkerRole() (*ec2.IamInstanceProfileSpecification, 
 }
 
 // GenerateMachineSet generates the machineset object which is aws provider specific
-func (a *awsProvider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*mapi.MachineSet, error) {
+func (a *awsProvider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
 	instanceProfile, err := a.getIAMWorkerRole()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get instance profile %v", err)
@@ -326,7 +326,7 @@ func (a *awsProvider) GenerateMachineSet(withWindowsLabel bool, replicas int32) 
 		return nil, err
 	}
 
-	return machineset.New(rawBytes, a.InfrastructureName, replicas, withWindowsLabel), nil
+	return machineset.New(rawBytes, a.InfrastructureName, replicas, withIgnoreLabel), nil
 }
 
 func (a *awsProvider) GetType() config.PlatformType {

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -85,7 +85,7 @@ func (p *Provider) newAzureMachineProviderSpec(location, zone string) (*mapi.Azu
 }
 
 // GenerateMachineSet generates the machineset object which is aws provider specific
-func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*mapi.MachineSet, error) {
+func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
 	// Inspect master-0 to get Azure Location and Zone
 	machines, err := p.oc.Machine.Machines("openshift-machine-api").Get(context.TODO(),
 		p.InfrastructureName+"-master-0", meta.GetOptions{})
@@ -109,7 +109,7 @@ func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*m
 		return nil, fmt.Errorf("failed to marshal azure machine provider spec: %v", err)
 	}
 
-	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withWindowsLabel), nil
+	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
 }
 
 func (p *Provider) GetType() config.PlatformType {

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -10,6 +10,7 @@ import (
 	oc "github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	awsProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/aws"
 	azureProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/azure"
+	gcpProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/gcp"
 	noneProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/none"
 	vSphereProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
@@ -35,6 +36,8 @@ func NewCloudProvider() (CloudProvider, error) {
 		return awsProvider.New(openshift, &infra.Status)
 	case config.AzurePlatformType:
 		return azureProvider.New(openshift, &infra.Status), nil
+	case config.GCPPlatformType:
+		return gcpProvider.New(openshift, &infra.Status), nil
 	case config.VSpherePlatformType:
 		return vSphereProvider.New(openshift, &infra.Status)
 	case config.NonePlatformType:

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -1,0 +1,96 @@
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	config "github.com/openshift/api/config/v1"
+	mapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
+)
+
+// Provider is a provider struct for testing GCP
+type Provider struct {
+	oc *clusterinfo.OpenShift
+	*config.InfrastructureStatus
+}
+
+// New returns a new GCP provider
+func New(clientset *clusterinfo.OpenShift, infraStatus *config.InfrastructureStatus) *Provider {
+	return &Provider{
+		oc:                   clientset,
+		InfrastructureStatus: infraStatus,
+	}
+}
+
+// GenerateMachineSet generates a MachineSet object which is GCP provider specific
+func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
+	gcpSpec, err := p.newGCPProviderSpec()
+	if err != nil {
+		return nil, err
+	}
+	rawSpec, err := json.Marshal(gcpSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshalling gcp provider spec")
+	}
+	return machineset.New(rawSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
+}
+
+// newGCPProviderSpec returns a GCPMachineProviderSpec which describes a Windows server 2022 VM
+func (p *Provider) newGCPProviderSpec() (*mapi.GCPMachineProviderSpec, error) {
+	listOptions := meta.ListOptions{LabelSelector: "machine.openshift.io/cluster-api-machine-role=worker"}
+	machines, err := p.oc.Machine.Machines(clusterinfo.MachineAPINamespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+	if len(machines.Items) == 0 {
+		return nil, fmt.Errorf("found 0 worker role machines")
+	}
+	foundSpec := &mapi.GCPMachineProviderSpec{}
+	err = json.Unmarshal(machines.Items[0].Spec.ProviderSpec.Value.Raw, foundSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal raw machine provider spec: %v", err)
+	}
+
+	return &mapi.GCPMachineProviderSpec{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: "machine.openshift.io/v1beta1",
+			Kind:       "GCPMachineProviderSpec",
+		},
+		ObjectMeta: meta.ObjectMeta{},
+		UserDataSecret: &core.LocalObjectReference{
+			Name: clusterinfo.UserDataSecretName,
+		},
+		CredentialsSecret: &core.LocalObjectReference{
+			Name: foundSpec.CredentialsSecret.Name,
+		},
+		CanIPForward:       false,
+		DeletionProtection: false,
+		Disks: []*mapi.GCPDisk{{
+			AutoDelete: true,
+			Boot:       true,
+			SizeGB:     128,
+			Type:       "pd-ssd",
+			// use the latest image from the `windows-2022-core` family in the `windows-cloud` project
+			Image: "projects/windows-cloud/global/images/family/windows-2022-core",
+		}},
+		NetworkInterfaces: foundSpec.NetworkInterfaces,
+		ServiceAccounts:   foundSpec.ServiceAccounts,
+		Tags:              foundSpec.Tags,
+		MachineType:       foundSpec.MachineType,
+		Region:            foundSpec.Region,
+		Zone:              foundSpec.Zone,
+		ProjectID:         foundSpec.ProjectID,
+	}, nil
+}
+
+// GetType returns the GCP platform type
+func (p *Provider) GetType() config.PlatformType {
+	return config.GCPPlatformType
+}

--- a/test/e2e/providers/machineset/machineset.go
+++ b/test/e2e/providers/machineset/machineset.go
@@ -5,18 +5,20 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/openshift/windows-machine-config-operator/controllers"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 )
 
 // New returns a new MachineSet for use with the e2e test suite
-func New(rawProvider []byte, infrastructureName string, replicas int32, withWindowsLabel bool) *mapi.MachineSet {
-	machineSetName := machineSetName(withWindowsLabel)
+func New(rawProvider []byte, infrastructureName string, replicas int32, withIgnoreLabel bool) *mapi.MachineSet {
+	machineSetName := machineSetName(withIgnoreLabel)
 	matchLabels := map[string]string{
-		mapi.MachineClusterIDLabel:  infrastructureName,
-		clusterinfo.MachineE2ELabel: "true",
+		mapi.MachineClusterIDLabel:   infrastructureName,
+		clusterinfo.MachineE2ELabel:  "true",
+		clusterinfo.MachineOSIDLabel: "Windows",
 	}
-	if withWindowsLabel {
-		matchLabels[clusterinfo.MachineOSIDLabel] = "Windows"
+	if withIgnoreLabel {
+		matchLabels[controllers.IgnoreLabel] = "true"
 	}
 	matchLabels[clusterinfo.MachineSetLabel] = machineSetName
 
@@ -62,12 +64,11 @@ func New(rawProvider []byte, infrastructureName string, replicas int32, withWind
 }
 
 // machineSetName returns the name of the Windows MachineSet created in the e2e tests depending on if the
-// Windows label is set or not
-func machineSetName(isWindowsLabelSet bool) string {
-	if isWindowsLabelSet {
-		// Designate MachineSets that set a Windows label on the Machine with
-		// "e2e-wm", to signify they should be configured by the Windows Machine controller
-		return "e2e-wm"
+// ignore label is set or not
+func machineSetName(isIgnoreLabelSet bool) string {
+	if isIgnoreLabelSet {
+		return "e2e"
 	}
-	return "e2e"
+	// Designate MachineSets that will be configured by the Windows Machine controller "e2e-wm"
+	return "e2e-wm"
 }

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -21,7 +21,7 @@ func New(clientset *clusterinfo.OpenShift) (*Provider, error) {
 }
 
 // GenerateMachineSet is not supported for platform=none and throws an exception
-func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*mapi.MachineSet, error) {
+func (p *Provider) GenerateMachineSet(_ bool, replicas int32) (*mapi.MachineSet, error) {
 	return nil, errors.New("MachineSet generation not supported for platform=none")
 }
 

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -113,7 +113,7 @@ func getNetwork() string {
 }
 
 // GenerateMachineSet generates the MachineSet object which is vSphere provider specific
-func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*mapi.MachineSet, error) {
+func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
 	// create new machine provider spec for deploying Windows node
 	providerSpec, err := p.newVSphereMachineProviderSpec()
 	if err != nil {
@@ -125,7 +125,7 @@ func (p *Provider) GenerateMachineSet(withWindowsLabel bool, replicas int32) (*m
 		return nil, errors.Wrap(err, "failed to marshal vSphere machine provider spec")
 	}
 
-	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withWindowsLabel), nil
+	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
 }
 
 func (p *Provider) GetType() config.PlatformType {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -310,7 +310,8 @@ func (tc *testContext) sshSetup() error {
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
 	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
 	powershellDefaultCommand := command
-	if tc.CloudProvider.GetType() == config.VSpherePlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
+	if tc.CloudProvider.GetType() == config.VSpherePlatformType ||
+		tc.CloudProvider.GetType() == config.GCPPlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
 		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
 	}
 


### PR DESCRIPTION
This PR adds multiple commits around providing WMCO support for GCP clusters
* Commits to have GCP to work with our test suite:
   * [controllers] Add ignore label to filter Machines 
   * [e2e] Add GCP provider

*  Commits to add GCP functionality and docs to WMCO:
   * [secrets] Enable Administrator account if needed
   * [docs] Document GCP support 