### PR TITLE
[release-4.11] Revert "[e2e] unblock aws CI failure"

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -120,8 +120,6 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 	windowsAMIOwner := "amazon"
 	windowsAMIFilterName := "name"
 	windowsAMIFilterValue := ""
-	winDateFilterName := "creation-date"
-	winDateFilterVal := "2022-05-11T*"
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
 	// The ami's will have the name format: Windows_Server-2022-English-Full-ContainersLatest-2022.01.19
 	// so the question marks will match the date of creation
@@ -135,10 +133,9 @@ func getLatestWindowsAMI(ec2Client *ec2.EC2, hasCustomVXLANPort bool) (string, e
 		windowsAMIFilterValue = "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
 	}
 	searchFilter := ec2.Filter{Name: &windowsAMIFilterName, Values: []*string{&windowsAMIFilterValue}}
-	dateFilter := ec2.Filter{Name: &winDateFilterName, Values: []*string{&winDateFilterVal}}
 
 	describedImages, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{&searchFilter, &dateFilter},
+		Filters: []*ec2.Filter{&searchFilter},
 		Owners:  []*string{&windowsAMIOwner},
 	})
 	if err != nil {


### PR DESCRIPTION
This reverts commit 67305ad023f0011a1d006be5e5f2b913bfe12ef7.

openshift-ci bot cannot do this as the cherry-picked commit 7f73878dcc3c33d5a6a3d2e557655e7bae2d84e7 was made directly to the master branch, and does not have a PR associated with it.