### PR TITLE
[release-4.10] WINC-806: Add support for Windows Server 2022 in Azure

### DIFF
--- a/docs/machineset-azure.md
+++ b/docs/machineset-azure.md
@@ -9,17 +9,13 @@ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 
 `<zone>` should be replaced with a valid Azure availability zone like `us-east-1a`.
 
-`<image>` should be a WindowsServer image offering that defines the 2019-Datacenter-with-Containers SKU with version
-          17763.1457.2009030514 or earlier. Run the following command to list Azure image info:
+Run the following command to list Azure WS2022 image info:
 ```shell script
   az vm image list --all --location <location> \
       --publisher MicrosoftWindowsServer \
       --offer WindowsServer \
-      --sku 2019-Datacenter-with-Containers \
-      --query "[?contains(version, '17763.1457.2009030514')]"
+      --sku 2022-datacenter
 ```
-This is to work around Windows containers behind a Kubernetes load balancer
-becoming unreachable [issue](https://github.com/microsoft/Windows-Containers/issues/78).
 
 Please note that on Azure, Windows Machine names cannot be more than 15 characters long.
 The MachineSet name can therefore not be more than 9 characters long, due to the way Machine names are generated from it.
@@ -59,7 +55,7 @@ spec:
             offer: WindowsServer
             publisher: MicrosoftWindowsServer
             resourceID: ""
-            sku: 2019-Datacenter-with-Containers
+            sku: 2022-datacenter
             version: latest
           kind: AzureMachineProviderSpec
           location: <location>

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -18,10 +18,10 @@ applicable cloud provider.
 Note: Any unlisted Windows Server version are NOT supported, and will cause errors. To prevent 
 these errors, only use the appropriate version according to the cloud provider in use. 
 
-| Cloud Provider | Supported Windows Server version                                                     |
-|----------------|--------------------------------------------------------------------------------------|
-| AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
-| Azure          | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                 |
+| Cloud Provider | Supported Windows Server version                                                                                                  |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| AWS            | Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)                                                              |
+| Azure          | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
 | VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                               |
 
 *Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*

--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -148,7 +148,7 @@ $(get_spec $infraID $az $provider)
             offer: WindowsServer
             publisher: MicrosoftWindowsServer
             resourceID: ""
-            sku: 2019-Datacenter-with-Containers
+            sku: 2022-datacenter
             version: latest
           kind: AzureMachineProviderSpec
           location: ${region}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -56,7 +56,7 @@ func GenerateUserData(publicKey ssh.PublicKey) (*core.Secret, error) {
 			$firewallRuleName = "ContainerLogsPort"
 			$containerLogsPort = "10250"
 			New-NetFirewallRule -DisplayName $firewallRuleName -Direction Inbound -Action Allow -Protocol TCP -LocalPort $containerLogsPort -EdgeTraversalPolicy Allow
-			Set-Service -Name sshd -StartupType ‘Automatic’
+			Set-Service -Name sshd -StartupType 'Automatic'
 			Start-Service sshd
 			$pubKeyConf = (Get-Content -path C:\ProgramData\ssh\sshd_config) -replace '#PubkeyAuthentication yes','PubkeyAuthentication yes'
 			$pubKeyConf | Set-Content -Path C:\ProgramData\ssh\sshd_config

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -442,22 +442,17 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 
 // getWindowsServerContainerImage gets the appropriate WindowsServer image based on VXLAN port
 func (tc *testContext) getWindowsServerContainerImage() string {
-	var windowsServerImage string
-	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
-		// If we're on vSphere we will use 2022
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
-	} else if tc.CloudProvider.GetType() == config.NonePlatformType {
+	if tc.CloudProvider.GetType() == config.NonePlatformType {
 		// TODO: On platform=none we have to use 2004 since the job points to the WS2004 golden image via release repo
 		// When the release repo is updated to use 2022, this clause should be squashed with the above to use 2022
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-2004"
-	} else if tc.CloudProvider.GetType() == config.AzurePlatformType {
-		// On Azure we are testing 20H2
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-20h2"
-	} else {
-		// For other providers we use 1809
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+		return "mcr.microsoft.com/powershell:lts-nanoserver-2004"
 	}
-	return windowsServerImage
+	if tc.CloudProvider.GetType() == config.AWSPlatformType {
+		// On AWS we are currently testing 2019
+		return "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+	}
+	// the default container image must be compatible with Windows Server 2022
+	return "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 }
 
 // createWindowsServerDeployment creates a deployment with a Windows Server container. If affinity is nil then the

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -18,7 +18,7 @@ const (
 	defaultCredentialsSecretName = "azure-cloud-credentials"
 	defaultImageOffer            = "WindowsServer"
 	defaultImagePublisher        = "MicrosoftWindowsServer"
-	defaultImageSKU              = "datacenter-core-20h2-with-containers-smalldisk"
+	defaultImageSKU              = "2022-datacenter-smalldisk"
 	defaultImageVersion          = "latest"
 	defaultOSDiskSizeGB          = 128
 	defaultStorageAccountType    = "Premium_LRS"

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -306,9 +306,8 @@ func (tc *testContext) sshSetup() error {
 // PowerShell, on the host specified by the provided IP.
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
 	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
-	// We only test Windows Server 2022 if a custom VXLAN port is used (i.e. vSphere)
 	powershellDefaultCommand := command
-	if tc.hasCustomVXLAN {
+	if tc.CloudProvider.GetType() == config.VSpherePlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
 		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
 	}
 

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	nodeCreationTime     = time.Minute * 30
+	nodeCreationTime     = time.Minute * 35
 	nodeRetryInterval    = time.Minute * 1
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5


### PR DESCRIPTION
Manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1093