### PR TITLE
Prefer using DNS over IP address to connect to Windows instances

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -162,10 +162,15 @@ func (r *instanceReconciler) reconcileKubeletClientCA(ctx context.Context, bundl
 }
 
 // GetAddress returns a non-ipv6 address that can be used to reach a Windows node. This can be either an ipv4
-// or dns address.
+// or dns address. DNS will be preferred, if available.
 func GetAddress(addresses []core.NodeAddress) (string, error) {
 	for _, addr := range addresses {
-		if addr.Type == core.NodeInternalIP || addr.Type == core.NodeInternalDNS {
+		if addr.Type == core.NodeInternalDNS {
+			return addr.Address, nil
+		}
+	}
+	for _, addr := range addresses {
+		if addr.Type == core.NodeInternalIP {
 			// filter out ipv6
 			if net.ParseIP(addr.Address) != nil && net.ParseIP(addr.Address).To4() == nil {
 				continue

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -12,31 +12,31 @@ func TestGetAddress(t *testing.T) {
 	testCases := []struct {
 		name        string
 		input       []core.NodeAddress
-		expectedOut []string
+		expectedOut string
 		expectedErr bool
 	}{
 		{
 			name:        "no addresses",
 			input:       []core.NodeAddress{{}},
-			expectedOut: []string{""},
+			expectedOut: "",
 			expectedErr: true,
 		},
 		{
 			name:        "ipv6",
 			input:       []core.NodeAddress{{Type: core.NodeInternalIP, Address: "::1"}},
-			expectedOut: []string{""},
+			expectedOut: "",
 			expectedErr: true,
 		},
 		{
 			name:        "ipv4",
 			input:       []core.NodeAddress{{Type: core.NodeInternalIP, Address: "127.0.0.1"}},
-			expectedOut: []string{"127.0.0.1"},
+			expectedOut: "127.0.0.1",
 			expectedErr: false,
 		},
 		{
 			name:        "dns",
 			input:       []core.NodeAddress{{Type: core.NodeInternalDNS, Address: "localhost"}},
-			expectedOut: []string{"localhost"},
+			expectedOut: "localhost",
 			expectedErr: false,
 		},
 		{
@@ -44,7 +44,7 @@ func TestGetAddress(t *testing.T) {
 			input: []core.NodeAddress{
 				{Type: core.NodeInternalDNS, Address: "localhost"},
 				{Type: core.NodeInternalIP, Address: "127.0.0.1"}},
-			expectedOut: []string{"localhost", "127.0.0.1"},
+			expectedOut: "localhost",
 			expectedErr: false,
 		},
 	}
@@ -58,7 +58,7 @@ func TestGetAddress(t *testing.T) {
 			require.NoError(t, err)
 			// The output can be any valid address in the expected list, so check that the output is one of the possible
 			// correct ones
-			assert.Contains(t, test.expectedOut, out)
+			assert.Equal(t, test.expectedOut, out)
 		})
 	}
 }


### PR DESCRIPTION
I'm seeing a behavior where Machines will be allocated a new IP address
shortly after WMCO attempts to reconcile them. Using DNS will allow us
to safely retry connecting to the instance, without wasting time by
trying to connect to the wrong IP.