### PR TITLE
[release-4.8] [docs] Clarify storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ deploy workloads.
 ### Cluster-wide proxy 
 WMCO does not support adding Windows workloads using a [cluster-wide proxy](https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html) config for the OpenShift Container Platform. WMCO will not be able to automatically route proxy connections for Windows workloads.
 
+### Storage
+At this time, only in-tree storage is supported in all cloud providers.
+
 ## Development
 
 See [HACKING.md](docs/HACKING.md).


### PR DESCRIPTION
This commit adds a supported storage section to our docs that specifies that
only in-tree storage methods are supported in each cloud platform.

Signed-off-by: Alina Ryan <aliryan@redhat.com>
(cherry picked from commit faa4ae134c6465962e11a0a2030e504f998f1845)