### PR TITLE
WINC-879: Introduce Pod Security admission labels

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    security.openshift.io/scc.podSecurityLabelSync: "true"
+    pod-security.kubernetes.io/enforce: "privileged"
     openshift.io/cluster-monitoring: "true"
     name: windows-machine-config-operator
   name: system

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -122,9 +122,18 @@ run_WMCO() {
       fi
   fi
 
-  # Add the "openshift.io/cluster-monitoring:"true"" label to the operator namespace to enable monitoring
-  if ! oc label ns $WMCO_DEPLOY_NAMESPACE openshift.io/cluster-monitoring=true --overwrite; then
-      return 1
+  # required labels for WMCO namespace
+  declare -a NS_LABELS=(
+    # enable monitoring
+    "openshift.io/cluster-monitoring=true"
+    # turn on the automatic label synchronization required for PodSecurity admission
+    "security.openshift.io/scc.podSecurityLabelSync=true"
+    # set pods security profile to privileged. See https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-levels
+    "pod-security.kubernetes.io/enforce=privileged"
+  )
+  # apply required labels to WMCO namespace
+  if ! oc label ns "${WMCO_DEPLOY_NAMESPACE}" "${NS_LABELS[@]}" --overwrite; then
+    error-exit "error setting labels ${NS_LABELS[@]} in namespace ${WMCO_DEPLOY_NAMESPACE}"
   fi
 
   if [ -n "$PRIVATE_KEY" ]; then

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -34,7 +34,7 @@ func TestWMCO(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the namespace test resources can be deployed in, as well as required resources within said namespace.
-	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace), "error creating test namespace")
+	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace, testCtx.workloadNamespaceLabels), "error creating test namespace")
 	require.NoError(t, testCtx.sshSetup(), "unable to setup SSH requirements")
 
 	// When the upgrade test is run from CI, the namespace that gets created does not have the required monitoring


### PR DESCRIPTION
This change adds the Pod Security admission enforcement labels to
the test namespace created in the e2e tests and to the WMCO namespace
created at deployment, allowing the automatic synchronization of privileged
pods directly without any intermediate pod controller, so that the serviceaccount
has enough privileges to run it. The WMCO namespace is a system namespace ("openshift-" prefixed)
and the `security.openshift.io/scc.podSecurityLabelSync` label is set as
`true` to ensure the automatic Pod Security label synchronization.