### PR TITLE
Point MachineSet references to the official documentation in the Red Hat released CSV

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -132,9 +132,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-aws.md)
-    - [Azure](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-azure.md)
-    - [GCP](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-gcp.md)
+    - [AWS](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -130,9 +130,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-aws.md)
-    - [Azure](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-azure.md)
-    - [GCP](https://github.com/openshift/windows-machine-config-operator/blob/master/docs/machineset-gcp.md)
+    - [AWS](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.12/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs


### PR DESCRIPTION
This change links the MachineSet references in the Red Hat released CSV to
the official OpenShift docs, so that the Red Hat released operator in the
OperatorHub for OCP points to the appropriated documentation. The links to
the WMCO repository in GitHub remain as supporting information for the
community released CSV.

Ran:
```
  make bundle
```

