### PR TITLE
[build] Switch to golang 1.18 in Dockerfile.ci

### DIFF
--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -114,7 +114,7 @@ RUN make build-daemon
 #├── windows-instance-config-daemon.exe
 #└── wmcb.exe
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 LABEL stage=operator
 
 # Copy wmcb.exe
@@ -161,11 +161,6 @@ WORKDIR /
 ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_UID=1001 \
     USER_NAME=windows-machine-config-operator
-
-# Changes needed for our CI
-
-# jq is needed in e2e test script to count the number of data items in the windows-instances ConfigMap
-RUN yum install -y jq
 
 # Copy the source code to be used by our ci infra
 WORKDIR /go/src/github.com/openshift/windows-machine-config-operator/


### PR DESCRIPTION
This was missed in openshift/windows-machine-config-operator#1075. `registry.ci.openshift.org/openshift/release:golang-1.18` comes with `jq` pre-installed and we no longer need to install it.