### PR TITLE
[release-4.11] WINC-858: Prep for 6.0.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 6.0.0
+WMCO_VERSION ?= 6.0.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v6.0.0
+  name: windows-machine-config-operator.v6.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -440,4 +440,4 @@ spec:
   minKubeVersion: 1.24.0
   provider:
     name: Red Hat
-  version: 6.0.0
+  version: 6.0.1

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v6.0.0
+  - currentCSV: windows-machine-config-operator.v6.0.1
     channels: alpha
 packageName: windows-machine-config-operator


### PR DESCRIPTION
This change bumps the patch version in prep for the next release.

Ran `make bundle`