### PR TITLE
WINC-888: Use platform-specific tags in userData

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -185,7 +185,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	secretReconciler := controllers.NewSecretReconciler(mgr, watchNamespace)
+	secretReconciler := controllers.NewSecretReconciler(mgr, clusterConfig.Platform(), watchNamespace)
 	if err = secretReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Secret controller")
 		os.Exit(1)

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -450,7 +450,7 @@ func (r *WindowsMachineReconciler) validateUserData() error {
 	}
 
 	secretData := string(userDataSecret.Data["userData"][:])
-	desiredUserDataSecret, err := secrets.GenerateUserData(r.signer.PublicKey())
+	desiredUserDataSecret, err := secrets.GenerateUserData(r.platform, r.signer.PublicKey())
 	if err != nil {
 		return err
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,36 @@
+package secrets
+
+import (
+	"testing"
+
+	oconfig "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformType oconfig.PlatformType
+		userData     string
+		expected     string
+	}{
+		{
+			name:         "GCP user data",
+			platformType: oconfig.GCPPlatformType,
+			userData:     "gcp-user-data",
+			expected:     "gcp-user-data",
+		},
+		{
+			name:         "default user data",
+			platformType: "",
+			userData:     "default-user-data",
+			expected:     "<powershell>default-user-data</powershell>\n<persist>true</persist>\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := processTags(test.platformType, test.userData)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This change introduces a logic to process platform-specific
tags in the windows-user-data secret.