### PR TITLE
[docs] Use KMS key in sysprep answer file

### DIFF
--- a/docs/vsphere_ci/scripts/autounattend.xml
+++ b/docs/vsphere_ci/scripts/autounattend.xml
@@ -62,8 +62,11 @@
             </ImageInstall>
             <UserData>
                 <AcceptEula>true</AcceptEula>
+                <!-- Product Key from https://learn.microsoft.com/en-us/windows-server/get-started/kms-client-activation-keys#windows-server-2022 -->
+                <!-- This allows us to get around having to intervene and skip entering the key during the packer build -->
                 <ProductKey>
                     <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>
+                    <Key>VDYBN-27WPP-V4HQT-9VMD4-VMK7H</Key>
                 </ProductKey>
             </UserData>
         </component>


### PR DESCRIPTION
Use the KMS product key to get around manual intervention to skip entering the key during the packer build