### PR TITLE
WINC-739: Azure node manager added to services ConfigMap

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	config "github.com/openshift/api/config/v1"
+	openshiftClient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -100,8 +101,16 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 	if err != nil {
 		return nil, err
 	}
+	oc, err := openshiftClient.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create openshift client-go client")
+	}
+	ccmEnabled, err := cluster.IsCloudControllerOwnedByCCM(oc)
+	if err != nil {
+		return nil, errors.Wrap(err, "error determining if CCM owns cloud controller")
+	}
 	svcData, err := services.GenerateManifest(argsFromIgnition, clusterConfig.Network().VXLANPort(),
-		clusterConfig.Platform(), ctrl.Log.V(1).Enabled())
+		clusterConfig.Platform(), ccmEnabled, ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating expected Windows service state")
 	}

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -101,7 +101,7 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 		return nil, err
 	}
 	svcData, err := services.GenerateManifest(argsFromIgnition, clusterConfig.Network().VXLANPort(),
-		string(clusterConfig.Platform()), ctrl.Log.V(1).Enabled())
+		clusterConfig.Platform(), ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating expected Windows service state")
 	}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -63,8 +63,8 @@ const (
 	windowsExporterPath = K8sDir + "windows_exporter.exe"
 	// NetworkConfScriptPath is the location of the network configuration script
 	NetworkConfScriptPath = remoteDir + "network-conf.ps1"
-	// azureCloudNodeManagerPath is the location of the azure-cloud-node-manager.exe
-	azureCloudNodeManagerPath = K8sDir + payload.AzureCloudNodeManager
+	// AzureCloudNodeManagerPath is the location of the azure-cloud-node-manager.exe
+	AzureCloudNodeManagerPath = K8sDir + payload.AzureCloudNodeManager
 	// BootstrapKubeconfig is the location of the bootstrap kubeconfig
 	BootstrapKubeconfig = K8sDir + "bootstrap-kubeconfig"
 	// KubeletPath is the location of the kubelet exe
@@ -211,8 +211,6 @@ type Windows interface {
 	ConfigureWICD(string, []byte, []byte) error
 	// ConfigureKubeProxy ensures that the kube-proxy service is running
 	ConfigureKubeProxy() error
-	// ConfigureAzureCloudNodeManager ensures that the azure-cloud-node-manager service is running
-	ConfigureAzureCloudNodeManager(string) error
 	// EnsureRequiredServicesStopped ensures that all services that are needed to configure a VM are stopped
 	EnsureRequiredServicesStopped() error
 	// Deconfigure removes all files and services created as part of the configuration process
@@ -524,25 +522,6 @@ func (vm *windows) ConfigureWICD(apiServerURL string, serviceAccountCA, serviceA
 		return errors.Wrapf(err, "error ensuring %s Windows service has started running", wicdServiceName)
 	}
 	vm.log.Info("configured", "service", wicdServiceName, "args", wicdServiceArgs)
-	return nil
-}
-
-func (vm *windows) ConfigureAzureCloudNodeManager(nodeName string) error {
-	azureCloudNodeManagerServiceArgs := "--windows-service --node-name=" + nodeName + " --wait-routes=false --kubeconfig c:\\k\\kubeconfig"
-
-	azureCloudNodeManagerService, err := newService(
-		azureCloudNodeManagerPath,
-		AzureCloudNodeManagerServiceName,
-		azureCloudNodeManagerServiceArgs,
-		nil)
-	if err != nil {
-		return errors.Wrapf(err, "error creating %s service object", AzureCloudNodeManagerServiceName)
-	}
-
-	if err := vm.ensureServiceIsRunning(azureCloudNodeManagerService); err != nil {
-		return errors.Wrapf(err, "error ensuring %s Windows service has started running", AzureCloudNodeManagerServiceName)
-	}
-	vm.log.Info("configured", "service", AzureCloudNodeManagerServiceName, "args", azureCloudNodeManagerServiceArgs)
 	return nil
 }
 


### PR DESCRIPTION
Adds the azure cloud node manager into the windows-services ConfigMap
when an azure cluster is set to use CCM. This causes WICD to start and
manage the service. WMCO will no longer start the service.