### PR TITLE
[build] Remove dos2unix install step

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,6 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as build
 LABEL stage=build
 
-# dos2unix is needed to build CNI plugins
-RUN yum install -y dos2unix
-
 WORKDIR /build/windows-machine-config-operator/
 COPY .git .git
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,9 +1,6 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as build
 LABEL stage=build
 
-# dos2unix is needed to build CNI plugins
-RUN yum install -y dos2unix
-
 WORKDIR /build/windows-machine-config-operator/
 COPY .git .git
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,9 +7,6 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-open
 LABEL stage=build
 WORKDIR /build/
 
-# dos2unix is needed to build CNI plugins
-RUN yum install -y dos2unix
-
 # The source here corresponds to the code in the PR and is placed here by the CI infrastructure.
 WORKDIR /build/windows-machine-config-operator/
 # Copy .git metadata so that we can generate the version for the WMCO binary


### PR DESCRIPTION
This PR removes the step that downloads the dos2Unix command from the Dockerfile
as it is already installed as part of the base image registry.ci.openshift.org/openshift/release:rhel8-release-golang-1.19-openshift-4.12 It was added as part of the work done for:
https://issues.redhat.com/browse/ART-4902