### PR TITLE
OCPBUGS-2028: Set kubelet hostname for GCP platform

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -93,6 +93,7 @@ RUN make build-daemon
 #│   ├── kubelet.exe
 #│   └── kube-proxy.exe
 #├── powershell/
+#│   ├── gcp-get-hostname.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
@@ -136,6 +137,7 @@ RUN chmod 0777 /payload/generated
 
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
+COPY pkg/internal/gcp-get-hostname.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -103,6 +103,7 @@ RUN make build-daemon
 #│   ├── kubelet.exe
 #│   └── kube-proxy.exe
 #├── powershell/
+#│   ├── gcp-get-hostname.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
@@ -146,6 +147,7 @@ RUN chmod 0777 /payload/generated
 
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/gcp-get-hostname.ps1 .
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -35,6 +35,7 @@ RUN chmod 0777 generated
 
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
+COPY pkg/internal/gcp-get-hostname.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -115,6 +115,7 @@ func main() {
 		payload.HybridOverlayPath,
 		payload.KubeletPath,
 		payload.KubeProxyPath,
+		payload.GcpGetValidHostnameScriptPath,
 		payload.WICDPath,
 		payload.HNSPSModule,
 		payload.WindowsExporterPath,

--- a/pkg/internal/gcp-get-hostname.ps1
+++ b/pkg/internal/gcp-get-hostname.ps1
@@ -1,0 +1,32 @@
+# This script returns a mutated hostname if the length is longer than 63 characters for GCP. The hostname will be
+# the lesser of 63 characters after the first dot in the FQDN.
+#
+# To get the original hostname for a GCP compute instance, the instance metadata service is invoked using its
+# DNS address (metadata.google.internal) as the prefered method over the IPv4 address or other alternatives like
+# the GoogleCloud Tools for PowerShell library (https://cloud.google.com/tools/powershell/docs/quickstart) since
+# they may not be available, specially in the BYOH use case.
+#
+# See instance metadata documentaion for GCP https://cloud.google.com/compute/docs/metadata/default-metadata-values
+
+# MAX_LENGTH is the maximum number of character allowed for the instance's hostname in GCP
+$MAX_LENGTH = 63
+
+# get hostname from the instance metadata service
+$hostname=(Invoke-RestMethod -Headers @{'Metadata-Flavor'='Google'} `
+            -Uri "http://metadata.google.internal/computeMetadata/v1/instance/hostname")
+
+# check hostname length
+if ($hostname.Length -le $MAX_LENGTH) {
+    # up to 63 characters is good, nothing to do!
+    return $hostname
+}
+
+# find the index of first dot in the FQDN
+$firstDotIndex=$hostname.IndexOf(".")
+if (($firstDotIndex -gt 0) -and ($firstDotIndex -le $MAX_LENGTH) ) {
+    # and return first part of the FQDN
+    return $hostname.Substring(0, $firstDotIndex)
+}
+
+# otherwise, return the first 63 characters of the hostname
+return $hostname.Substring(0, $MAX_LENGTH)

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -28,6 +28,10 @@ const (
 	HcsshimPath = payloadDirectory + "/containerd/containerd-shim-runhcs-v1.exe"
 	// ContainerdConfPath contains the path of the containerd config file.
 	ContainerdConfPath = payloadDirectory + "/containerd/containerd_conf.toml"
+	// GcpGetHostnameScriptName is the name of the PowerShell script that resolves the hostname for GCP instances
+	GcpGetHostnameScriptName = "gcp-get-hostname.ps1"
+	// GcpGetValidHostnameScriptPath is the path of the PowerShell script that resolves the hostname for GCP instances
+	GcpGetValidHostnameScriptPath = payloadDirectory + "/powershell/" + GcpGetHostnameScriptName
 	// HNSPSModule is the path to the powershell module which defines various functions for dealing with Windows HNS
 	// networks
 	HNSPSModule = payloadDirectory + "/powershell/hns.psm1"

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -19,10 +19,9 @@ const (
 	// https://docs.openshift.com/container-platform/latest/rest_api/editing-kubelet-log-level-verbosity.html#log-verbosity-descriptions_editing-kubelet-log-level-verbosity
 	debugLogLevel    = "4"
 	standardLogLevel = "2"
-	// ec2HostnameVar is a variable that should be replaced with the value of `local-hostname` in the ec2 instance
-	// metadata
-	ec2HostnameVar = "EC2_HOSTNAME"
-	NodeIPVar      = "NODE_IP"
+	// hostnameOverrideVar is the variable that should be replaced with the value of the desired instance hostname
+	hostnameOverrideVar = "HOSTNAME_OVERRIDE"
+	NodeIPVar           = "NODE_IP"
 )
 
 // GenerateManifest returns the expected state of the Windows service configmap. If debug is true, debug logging
@@ -144,13 +143,16 @@ func getKubeletServiceConfiguration(argsFromIginition map[string]string, debug b
 		return servicescm.Service{}, err
 	}
 	var powershellVars []servicescm.PowershellCmdArg
-	hostnameArg := getKubeletHostnameOverride(platform)
-	if hostnameArg != "" {
-		kubeletArgs = append(kubeletArgs, hostnameArg)
-		powershellVars = append(powershellVars, servicescm.PowershellCmdArg{
-			Name: ec2HostnameVar,
-			Path: "Get-EC2InstanceMetadata -Category LocalHostname",
-		})
+
+	hostnameOverrideCmd := getHostnameCmd(platform)
+	if hostnameOverrideCmd != "" {
+		hostnameOverrideArg := "--hostname-override=" + hostnameOverrideVar
+		hostnameOverridePowershellVar := servicescm.PowershellCmdArg{
+			Name: hostnameOverrideVar,
+			Path: hostnameOverrideCmd,
+		}
+		kubeletArgs = append(kubeletArgs, hostnameOverrideArg)
+		powershellVars = append(powershellVars, hostnameOverridePowershellVar)
 	}
 
 	kubeletServiceCmd := windows.KubeletPath
@@ -217,12 +219,15 @@ func klogVerbosityArg(debug bool) string {
 	}
 }
 
-// getKubeletHostnameOverride returns the hostname override arg that should be used
-func getKubeletHostnameOverride(platformType config.PlatformType) string {
+// getHostnameCmd returns the hostname override command for the given platform as needed
+func getHostnameCmd(platformType config.PlatformType) string {
 	switch platformType {
 	case config.AWSPlatformType:
-		return "--hostname-override=" + ec2HostnameVar
+		return "Get-EC2InstanceMetadata -Category LocalHostname"
+	case config.GCPPlatformType:
+		return windows.GcpGetHostnameScriptRemotePath
 	default:
+		// by default use the original hostname
 		return ""
 	}
 }

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	"testing"
+
+	config "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostnameCmd(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformType config.PlatformType
+		expected     string
+	}{
+		{
+			name:         "any platform",
+			platformType: "",
+			expected:     "",
+		},
+		{
+			name:         "AWS platform",
+			platformType: config.AWSPlatformType,
+			expected:     "Get-EC2InstanceMetadata -Category LocalHostname",
+		},
+		{
+			name:         "GCP platform",
+			platformType: config.GCPPlatformType,
+			expected:     "C:\\Temp\\gcp-get-hostname.ps1",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := getHostnameCmd(test.platformType)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -23,6 +23,9 @@ import (
 const (
 	// remoteDir is the remote temporary directory created on the Windows VM
 	remoteDir = "C:\\Temp\\"
+	// GcpGetHostnameScriptRemotePath is the remote location of the PowerShell script that resolves the hostname
+	// for GCP instances
+	GcpGetHostnameScriptRemotePath = remoteDir + payload.GcpGetHostnameScriptName
 	// HNSPSModule is the remote location of the hns.psm1 module
 	HNSPSModule = remoteDir + "hns.psm1"
 	// K8sDir is the remote kubernetes executable directory
@@ -157,20 +160,21 @@ func getFilesToTransfer() (map[*payload.FileInfo]string, error) {
 		return filesToTransfer, nil
 	}
 	srcDestPairs := map[string]string{
-		payload.WICDPath:                   K8sDir,
-		payload.HybridOverlayPath:          K8sDir,
-		payload.HNSPSModule:                remoteDir,
-		payload.WindowsExporterPath:        K8sDir,
-		payload.WinBridgeCNIPlugin:         cniDir,
-		payload.HostLocalCNIPlugin:         cniDir,
-		payload.WinOverlayCNIPlugin:        cniDir,
-		payload.KubeProxyPath:              K8sDir,
-		payload.KubeletPath:                K8sDir,
-		payload.AzureCloudNodeManagerPath:  K8sDir,
-		payload.ContainerdPath:             ContainerdDir,
-		payload.HcsshimPath:                ContainerdDir,
-		payload.ContainerdConfPath:         ContainerdDir,
-		payload.NetworkConfigurationScript: remoteDir,
+		payload.GcpGetValidHostnameScriptPath: remoteDir,
+		payload.WICDPath:                      K8sDir,
+		payload.HybridOverlayPath:             K8sDir,
+		payload.HNSPSModule:                   remoteDir,
+		payload.WindowsExporterPath:           K8sDir,
+		payload.WinBridgeCNIPlugin:            cniDir,
+		payload.HostLocalCNIPlugin:            cniDir,
+		payload.WinOverlayCNIPlugin:           cniDir,
+		payload.KubeProxyPath:                 K8sDir,
+		payload.KubeletPath:                   K8sDir,
+		payload.AzureCloudNodeManagerPath:     K8sDir,
+		payload.ContainerdPath:                ContainerdDir,
+		payload.HcsshimPath:                   ContainerdDir,
+		payload.ContainerdConfPath:            ContainerdDir,
+		payload.NetworkConfigurationScript:    remoteDir,
 	}
 	files := make(map[*payload.FileInfo]string)
 	for src, dest := range srcDestPairs {


### PR DESCRIPTION
This change fetches the hostname from the GCE instance metadata service
and overrides the kubelet hostname so that the name of the Windows node
matches the hostname. The hostname is truncated if the length is longer
than 63 characters.

Should go after:
- https://github.com/openshift/windows-machine-config-operator/pull/1279