### PR TITLE
[test] Fix naming of MachineSet

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -326,7 +326,7 @@ func (a *awsProvider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (
 		return nil, err
 	}
 
-	return machineset.New(rawBytes, a.InfrastructureName, replicas, withIgnoreLabel), nil
+	return machineset.New(rawBytes, a.InfrastructureName, replicas, withIgnoreLabel, a.InfrastructureName+"-"), nil
 }
 
 func (a *awsProvider) GetType() config.PlatformType {

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -109,7 +109,7 @@ func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 		return nil, fmt.Errorf("failed to marshal azure machine provider spec: %v", err)
 	}
 
-	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
+	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel, ""), nil
 }
 
 func (p *Provider) GetType() config.PlatformType {

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -39,7 +39,7 @@ func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 	if err != nil {
 		return nil, errors.Wrap(err, "error marshalling gcp provider spec")
 	}
-	return machineset.New(rawSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
+	return machineset.New(rawSpec, p.InfrastructureName, replicas, withIgnoreLabel, p.InfrastructureName+"-"), nil
 }
 
 // newGCPProviderSpec returns a GCPMachineProviderSpec which describes a Windows server 2022 VM

--- a/test/e2e/providers/machineset/machineset.go
+++ b/test/e2e/providers/machineset/machineset.go
@@ -10,8 +10,8 @@ import (
 )
 
 // New returns a new MachineSet for use with the e2e test suite
-func New(rawProvider []byte, infrastructureName string, replicas int32, withIgnoreLabel bool) *mapi.MachineSet {
-	machineSetName := machineSetName(withIgnoreLabel)
+func New(rawProvider []byte, infrastructureName string, replicas int32, withIgnoreLabel bool, withPrefix string) *mapi.MachineSet {
+	machineSetName := machineSetName(withIgnoreLabel, withPrefix)
 	matchLabels := map[string]string{
 		mapi.MachineClusterIDLabel:   infrastructureName,
 		clusterinfo.MachineE2ELabel:  "true",
@@ -63,12 +63,12 @@ func New(rawProvider []byte, infrastructureName string, replicas int32, withIgno
 	}
 }
 
-// machineSetName returns the name of the Windows MachineSet created in the e2e tests depending on if the
-// ignore label is set or not
-func machineSetName(isIgnoreLabelSet bool) string {
+// machineSetName returns the name of the Windows MachineSet with the specified prefix created in the e2e tests
+// depending on if the ignore label is set or not
+func machineSetName(isIgnoreLabelSet bool, prefix string) string {
 	if isIgnoreLabelSet {
-		return "e2e"
+		return prefix + "e2e"
 	}
 	// Designate MachineSets that will be configured by the Windows Machine controller "e2e-wm"
-	return "e2e-wm"
+	return prefix + "e2e-wm"
 }

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -125,7 +125,7 @@ func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 		return nil, errors.Wrap(err, "failed to marshal vSphere machine provider spec")
 	}
 
-	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel), nil
+	return machineset.New(rawProviderSpec, p.InfrastructureName, replicas, withIgnoreLabel, ""), nil
 }
 
 func (p *Provider) GetType() config.PlatformType {


### PR DESCRIPTION
The  infra name prefix is required for proper clean up when deprovisioning the cluster especially on GCP. Adding AWS to sync with what we are doing in the machineset hack script. Note that this cannot be done for all providers as Azure has naming restrictions when it comes to Windows VMs.