### PR TITLE
[test] Pin Azure 2022 image to 20348.1129.221007

### DIFF
--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -19,7 +19,7 @@ const (
 	defaultImageOffer            = "WindowsServer"
 	defaultImagePublisher        = "MicrosoftWindowsServer"
 	defaultImageSKU              = "2022-datacenter-smalldisk"
-	defaultImageVersion          = "latest"
+	defaultImageVersion          = "20348.1129.221007"
 	defaultOSDiskSizeGB          = 128
 	defaultStorageAccountType    = "Premium_LRS"
 	// The default vm size set by machine-api-operator yields


### PR DESCRIPTION
SSH server installs on Azure Windows Server 2022 images after 20348.1129.221007 are failing with:
```console
PS C:\ProgramData\ssh> Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
Add-WindowsCapability : Add-WindowsCapability failed. Error code = 0x800f0950
At line:1 char:1
+ Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Add-WindowsCapability], COMException
    + FullyQualifiedErrorId : Microsoft.Dism.Commands.AddWindowsCapabilityCommand
```
Pin the image to 20348.1129.221007 to avoid this until Microsoft fixes the issue.