### PR TITLE
[test] Use Windows Server 2022 for custom VXLAN

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -422,7 +422,7 @@ func (tc *testContext) getWindowsServerContainerImage() string {
 	var windowsServerImage string
 	if tc.hasCustomVXLAN {
 		// If we're using a custom VXLANPort we need to use 2004
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-2004"
+		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-2022"
 	} else if tc.CloudProvider.GetType() == config.AzurePlatformType {
 		// On Azure we are testing 20H2
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-20h2"

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -48,7 +48,7 @@ func (p *Provider) newVSphereMachineProviderSpec(clusterID string) (*vsphere.VSp
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2004-template"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-with-docker"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)


### PR DESCRIPTION
- Use the windows-golden-images/windows-server-2022-template-with-docker VM template
- Use the lts-nanoserver-ltsc2022 image for deployments