### PR TITLE
WINC-898: Containerd is added to windows-services configmap

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -94,6 +94,7 @@ RUN make build-daemon
 #│   └── kube-proxy.exe
 #├── powershell/
 #│   ├── gcp-get-hostname.ps1
+#│   ├── windows-defender-exclusion.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
@@ -138,6 +139,7 @@ RUN chmod 0777 /payload/generated
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
 COPY pkg/internal/gcp-get-hostname.ps1 .
+COPY pkg/internal/windows-defender-exclusion.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -104,6 +104,7 @@ RUN make build-daemon
 #│   └── kube-proxy.exe
 #├── powershell/
 #│   ├── gcp-get-hostname.ps1
+#│   ├── windows-defender-exclusion.ps1
 #│   └── hns.psm1
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
@@ -148,6 +149,7 @@ RUN chmod 0777 /payload/generated
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/gcp-get-hostname.ps1 .
+COPY --from=build /build/windows-machine-config-operator/pkg/internal/windows-defender-exclusion.ps1 .
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -36,6 +36,7 @@ RUN chmod 0777 generated
 # Copy required powershell scripts
 WORKDIR /payload/powershell/
 COPY pkg/internal/gcp-get-hostname.ps1 .
+COPY pkg/internal/windows-defender-exclusion.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -419,7 +419,7 @@ func (sc *ServiceController) resolveNodeVariables(svc servicescm.Service) (map[s
 }
 
 // resolvePowershellVariables returns a map, with the keys being each variable, and the value being the string to
-// replace the variable with
+// replace the variable with. Variables with blank names will not result in a map entry, but their script will be run.
 func (sc *ServiceController) resolvePowershellVariables(svc servicescm.Service) (map[string]string, error) {
 	vars := make(map[string]string)
 	for _, psVar := range svc.PowershellVariablesInCommand {
@@ -427,7 +427,9 @@ func (sc *ServiceController) resolvePowershellVariables(svc servicescm.Service) 
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not resolve PowerShell variable %s", psVar.Name)
 		}
-		vars[psVar.Name] = strings.TrimSpace(out)
+		if psVar.Name != "" {
+			vars[psVar.Name] = strings.TrimSpace(out)
+		}
 	}
 	return vars, nil
 }

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -129,6 +129,93 @@ func TestResolveNodeVariables(t *testing.T) {
 	}
 }
 
+func TestResolvePowershellVariables(t *testing.T) {
+	testIO := []struct {
+		name      string
+		service   servicescm.Service
+		expected  map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "No Powershell variables to replace",
+			service:   servicescm.Service{},
+			expected:  map[string]string{},
+			expectErr: false,
+		},
+		{
+			name: "Resolve variable with unknown path",
+			service: servicescm.Service{
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+					Name: "CMD_REPLACE",
+					Path: "invalid-script.ps1",
+				}},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Resolve variable with known path",
+			service: servicescm.Service{
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+					Name: "CMD_REPLACE",
+					Path: "c:\\k\\script.ps1",
+				}},
+			},
+			expected:  map[string]string{"CMD_REPLACE": "127.0.0.1"},
+			expectErr: false,
+		},
+		{
+			name: "Empty variable name",
+			service: servicescm.Service{
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+					Name: "",
+					Path: "c:\\k\\script.ps1",
+				}},
+			},
+			expected:  map[string]string{},
+			expectErr: false,
+		},
+		{
+			name: "Multiple variable to resolve",
+			service: servicescm.Service{
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{
+					{
+						Name: "CMD_REPLACE1",
+						Path: "c:\\k\\script.ps1",
+					},
+					{
+						Name: "CMD_REPLACE2",
+						Path: "c:\\k\\test.ps1",
+					},
+				},
+			},
+			expected:  map[string]string{"CMD_REPLACE1": "127.0.0.1", "CMD_REPLACE2": "test-output"},
+			expectErr: false,
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := NewServiceController(context.TODO(), "", Options{
+				Client: clientfake.NewClientBuilder().Build(),
+				Mgr:    fake.NewTestMgr(nil),
+				cmdRunner: &fakePSCmdRunner{
+					map[string]string{
+						"c:\\k\\script.ps1": "127.0.0.1",
+						"c:\\k\\test.ps1":   "test-output",
+					},
+				},
+			})
+			require.NoError(t, err)
+			actual, err := c.resolvePowershellVariables(test.service)
+			if test.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.EqualValues(t, test.expected, actual)
+		})
+	}
+}
+
 func TestReconcileService(t *testing.T) {
 	testIO := []struct {
 		name                  string

--- a/pkg/internal/windows-defender-exclusion.ps1
+++ b/pkg/internal/windows-defender-exclusion.ps1
@@ -1,0 +1,29 @@
+# This script creates an exclusion for the given file if the Windows Defender antivirus is running on the instance.
+# No action taken otherwise. 
+# If getting the antivirus process or creating the exclusion fails unexpectedly, return the error.
+# Returns nothing otherwise.
+
+# USAGE
+#    windows-defender-exclusion.ps1 [OPTIONS] <file_path>
+# OPTIONS
+#    -BinPath                 path to the file that should be excluded
+# EXAMPLES
+#    windows-defender-exclusion.ps1 -BinPath "C:\k\containerd\containerd.exe"
+
+
+param(
+    [Parameter(Mandatory=$true)] [String] $BinPath
+)
+
+# Check if the process associated with Windows Defender exists. Reference:
+# https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility?view=o365-worldwide#use-windows-powershell-to-confirm-that-microsoft-defender-antivirus-is-running
+try {
+    # The winDefenderProcess variable is used to suppress the command's stdout as the value is not relevant; only the
+    # error is relevant, and errors are not suppressed.
+    $winDefenderProcess = Get-Process -Name MsMpEng -ErrorAction Stop
+    # No error means the process exists, so create exclusion
+    Add-MpPreference -ExclusionProcess $BinPath 
+}
+catch [Microsoft.PowerShell.Commands.ProcessCommandException] {
+    # Process does not exist, do nothing
+}

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -32,6 +32,12 @@ const (
 	GcpGetHostnameScriptName = "gcp-get-hostname.ps1"
 	// GcpGetValidHostnameScriptPath is the path of the PowerShell script that resolves the hostname for GCP instances
 	GcpGetValidHostnameScriptPath = payloadDirectory + "/powershell/" + GcpGetHostnameScriptName
+	// WinDefenderExclusionScriptName is the name of the PowerShell script that creates an exclusion for containerd if
+	// the Windows Defender Antivirus is active
+	WinDefenderExclusionScriptName = "windows-defender-exclusion.ps1"
+	// WinDefenderExclusionScriptPath is the path of the PowerShell script that creates an exclusion for containerd if
+	// the Windows Defender Antivirus is active
+	WinDefenderExclusionScriptPath = payloadDirectory + "/powershell/" + WinDefenderExclusionScriptName
 	// HNSPSModule is the path to the powershell module which defines various functions for dealing with Windows HNS
 	// networks
 	HNSPSModule = payloadDirectory + "/powershell/hns.psm1"


### PR DESCRIPTION
This PR moves the containerd service definition to `windows-services` 
ConfigMap. The priorities of other services were adjusted since containerd
is a bootstrap service that also must be first to start.
Starting containerd (including the pre-config work of creating a Windows
Defender exclusion if needed) is now done by WICD bootstrap instead of WMCO.