### PR TITLE
OCPBUGS-1513: Fix check for Windows Defender

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -487,8 +487,8 @@ func (vm *windows) Bootstrap(desiredVer, apiServerURL string, credentials *Authe
 // configureContainerd configures the Windows defender exclusion and starts the
 // Windows containerd service
 func (vm *windows) configureContainerd() error {
-	// if Windows Defender is installed on the instance, create an exclusion for containerd
-	exclusionNeeded, err := vm.isWindowsDefenderEnabled()
+	// if Windows Defender is running on the instance, create an exclusion for containerd
+	exclusionNeeded, err := vm.isWindowsDefenderRunning()
 	if err != nil {
 		return err
 	}
@@ -930,9 +930,11 @@ func (vm *windows) isContainersFeatureEnabled() (bool, error) {
 	return strings.Contains(out, "Enabled"), nil
 }
 
-// isWindowsDefenderEnabled returns true if the Windows Defender antivirus/firewall is installed on the Windows instance
-func (vm *windows) isWindowsDefenderEnabled() (bool, error) {
-	command := "(Get-Service | where {$_.DisplayName -Like 'Windows Defender*'}).Count -gt 0"
+// isWindowsDefenderRunning returns true if the Windows Defender antivirus/firewall is running on the Windows instance
+func (vm *windows) isWindowsDefenderRunning() (bool, error) {
+	// Check if the process associated with Windows Defender exists. Reference:
+	// https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility?view=o365-worldwide#use-windows-powershell-to-confirm-that-microsoft-defender-antivirus-is-running
+	command := "(Get-Process -Name MsMpEng -ErrorAction SilentlyContinue) -ne $null"
 	out, err := vm.Run(command, true)
 	if err != nil {
 		return false, errors.Wrap(err, "error checking if Windows Defender is enabled")


### PR DESCRIPTION
Before, the check to see if Windows Defender antivirus was running was wrongly
checking for any services whose name starts with Windows Defender regardless of
state, leading to an error creating an exclusion for containerd on instances
without Defender installed. 

This PR fixes this by checking for the presence of the specific running process 
associated with the Defender antivirus service.
It also adds an e2e test to validate instances are able to be configured into
Nodes regardless of the Windows Defender antivirus status.

Fixes OCPBUGS-1513
Fixes #1240 