### PR TITLE
WINC-941: [services] Use IMDSv1 to get hostname in AWS

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -223,7 +223,9 @@ func klogVerbosityArg(debug bool) string {
 func getHostnameCmd(platformType config.PlatformType) string {
 	switch platformType {
 	case config.AWSPlatformType:
-		return "Get-EC2InstanceMetadata -Category LocalHostname"
+		// Use the Instance Metadata Service Version 1 (IMDSv1) to fetch the hostname. IMDSv1 will continue to be
+		// supported indefinitely as per AWS docs. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+		return "Invoke-RestMethod -UseBasicParsing -Uri http://169.254.169.254/latest/meta-data/local-hostname"
 	case config.GCPPlatformType:
 		return windows.GcpGetHostnameScriptRemotePath
 	default:

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -21,7 +21,7 @@ func TestGetHostnameCmd(t *testing.T) {
 		{
 			name:         "AWS platform",
 			platformType: config.AWSPlatformType,
-			expected:     "Get-EC2InstanceMetadata -Category LocalHostname",
+			expected:     "Invoke-RestMethod -UseBasicParsing -Uri http://169.254.169.254/latest/meta-data/local-hostname",
 		},
 		{
 			name:         "GCP platform",


### PR DESCRIPTION
Before, the AWS Tools for PowerShell library (https://github.com/aws/aws-tools-for-powershell)
was used to retrieve the local hostname of the Windows instances in AWS.

This change propose the instance metadata service version 1 (IMDSv1) endpoint
since the library may not be available, especially in the BYOH use case.