### PR TITLE
WINC-733: Instance cleanup is done by WICD cleanup command

### DIFF
--- a/cmd/daemon/cleanup.go
+++ b/cmd/daemon/cleanup.go
@@ -35,15 +35,10 @@ var (
 			"according to information given by Windows Service ConfigMaps present within the cluster",
 		Run: runCleanupCmd,
 	}
-	// preserveNode is an optional flag that instructs WICD to deconfigure an instance without deleting the Node object.
-	// This is useful in the node upgrade scenario.
-	preserveNode bool
 )
 
 func init() {
 	rootCmd.AddCommand(cleanupCmd)
-	cleanupCmd.PersistentFlags().BoolVar(&preserveNode, "preserveNode", false,
-		"If set to true, preserves the Node associated with this instance. Defaults to false.")
 }
 
 func runCleanupCmd(cmd *cobra.Command, args []string) {
@@ -52,7 +47,7 @@ func runCleanupCmd(cmd *cobra.Command, args []string) {
 		klog.Exitf("error using service account to build config: %s", err.Error())
 	}
 	ctx := ctrl.SetupSignalHandler()
-	if err := cleanup.Deconfigure(cfg, ctx, preserveNode, namespace); err != nil {
+	if err := cleanup.Deconfigure(cfg, ctx, namespace); err != nil {
 		klog.Exitf(err.Error())
 	}
 }

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -33,10 +33,10 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
-// Deconfigure removes an instance from the cluster. If preserveNode is true, the node object is not deleted.
+// Deconfigure removes an instance from the cluster.
 // If we are able to get the services ConfigMap tied to the desired version, all services defined in it are cleaned up.
 // TODO: Otherwise, perform cleanup based on a combination of the OpenShift managed tag and latest services ConfigMap.
-func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool, configMapNamespace string) error {
+func Deconfigure(cfg *rest.Config, ctx context.Context, configMapNamespace string) error {
 	// Cannot use a cached client as no manager will be started to populate cache
 	directClient, err := controller.NewDirectClient(cfg)
 	if err != nil {
@@ -81,13 +81,7 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool, confi
 	if err = removeServices(svcMgr, cmData.Services); err != nil {
 		return err
 	}
-
-	// Delete node if needed
-	if preserveNode || node == nil {
-		return nil
-	}
-	klog.Infof("deleting node %s", node.GetName())
-	return directClient.Delete(ctx, node)
+	return nil
 }
 
 // removeServices uses the given manager to remove all the given Windows services from this instance.

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -69,7 +69,7 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool, confi
 	}()
 	if err != nil {
 		// TODO: best effort cleanup of all OpenShift managed services and those in the latest services ConfigMap
-		// https://issues.redhat.com/browse/WINC-733
+		// https://issues.redhat.com/browse/WINC-853
 		return err
 	}
 

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -77,6 +77,7 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool, confi
 	if err != nil {
 		klog.Exitf("could not create service manager: %s", err.Error())
 	}
+	defer svcMgr.Disconnect()
 	if err = removeServices(svcMgr, cmData.Services); err != nil {
 		return err
 	}

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -265,6 +265,7 @@ func (sc *ServiceController) reconcileServices(services []servicescm.Service) er
 			if err != nil {
 				return err
 			}
+			defer winSvcObj.Close()
 			klog.Infof("created service %s", service.Name)
 		} else {
 			// open the service
@@ -272,6 +273,7 @@ func (sc *ServiceController) reconcileServices(services []servicescm.Service) er
 			if err != nil {
 				return err
 			}
+			defer winSvcObj.Close()
 			klog.Infof("reconciling existing service %s", service.Name)
 		}
 		if err := sc.reconcileService(winSvcObj, service); err != nil {

--- a/pkg/daemon/fake/manager.go
+++ b/pkg/daemon/fake/manager.go
@@ -68,6 +68,10 @@ type testMgr struct {
 	svcList *fakeServiceList
 }
 
+func (t *testMgr) Disconnect() error {
+	return nil
+}
+
 // CreateService installs new service name on the system.
 // The service will be executed by running exepath binary.
 // Use config c to specify service parameters.


### PR DESCRIPTION
With this PR, WMCO starts invoking WICD cleanup command to stop and delete services and delete the node object.
Responsibility of removing directories and HNS networks is mainatined by WMCO while excluding deletion of log directories for future reference.

