### PR TITLE
Adjust annotation wait debug log message

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -437,7 +437,7 @@ func (nc *nodeConfig) setNode(quickCheck bool) error {
 		nodes, err := nc.k8sclientset.CoreV1().Nodes().List(context.TODO(),
 			meta.ListOptions{LabelSelector: WindowsOSLabel})
 		if err != nil {
-			nc.log.V(1).Error(err, "node listing failed")
+			nc.log.V(1).Info("node listing failed", "err", err)
 			return false, nil
 		}
 		if len(nodes.Items) == 0 {
@@ -461,7 +461,7 @@ func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
 	err := wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
 		node, err := nc.k8sclientset.CoreV1().Nodes().Get(context.TODO(), nodeName, meta.GetOptions{})
 		if err != nil {
-			nc.log.V(1).Error(err, "unable to get associated node object")
+			nc.log.V(1).Info("unable to get associated node object", "err", err)
 			return false, nil
 		}
 		_, found := node.Annotations[annotation]

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -768,7 +768,7 @@ func (vm *windows) deleteService(svc *service) error {
 	err = wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
 		exists, err := vm.serviceExists(svc.name)
 		if err != nil {
-			vm.log.V(1).Error(err, "unable to check if Windows service exists", "service", svc.name)
+			vm.log.V(1).Info("unable to check if Windows service exists", "service", svc.name, "err", err)
 			return false, nil
 		}
 		return !exists, nil


### PR DESCRIPTION
Change from error level to info level, to stop stack traces from being logged. This is a debug log and will not effect logging in production.