### PR TITLE
Revert "[test] Pin Azure 2022 image to 20348.1129.221007"

### DIFF
--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -19,7 +19,7 @@ const (
 	defaultImageOffer            = "WindowsServer"
 	defaultImagePublisher        = "MicrosoftWindowsServer"
 	defaultImageSKU              = "2022-datacenter-smalldisk"
-	defaultImageVersion          = "20348.1129.221007"
+	defaultImageVersion          = "latest"
 	defaultOSDiskSizeGB          = 128
 	defaultStorageAccountType    = "Premium_LRS"
 	// The default vm size set by machine-api-operator yields


### PR DESCRIPTION
This reverts commit bf31913c now that microsoft/Windows-Containers/issues/285 has been fixed.