### PR TITLE
WINC-949: Rename powershellVariablesInCommand

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -340,7 +340,7 @@ func (sc *ServiceController) expectedServiceCommand(expected servicescm.Service)
 			return "", err
 		}
 	}
-	if len(expected.PowershellVariablesInCommand) > 0 {
+	if len(expected.PowershellPreScripts) > 0 {
 		psVars, err = sc.resolvePowershellVariables(expected)
 		if err != nil {
 			return "", err
@@ -422,13 +422,13 @@ func (sc *ServiceController) resolveNodeVariables(svc servicescm.Service) (map[s
 // replace the variable with. Variables with blank names will not result in a map entry, but their script will be run.
 func (sc *ServiceController) resolvePowershellVariables(svc servicescm.Service) (map[string]string, error) {
 	vars := make(map[string]string)
-	for _, psVar := range svc.PowershellVariablesInCommand {
-		out, err := sc.psCmdRunner.Run(psVar.Path)
+	for _, script := range svc.PowershellPreScripts {
+		out, err := sc.psCmdRunner.Run(script.Path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not resolve PowerShell variable %s", psVar.Name)
+			return nil, errors.Wrapf(err, "could not resolve PowerShell variable %s", script.VariableName)
 		}
-		if psVar.Name != "" {
-			vars[psVar.Name] = strings.TrimSpace(out)
+		if script.VariableName != "" {
+			vars[script.VariableName] = strings.TrimSpace(out)
 		}
 	}
 	return vars, nil

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -145,9 +145,9 @@ func TestResolvePowershellVariables(t *testing.T) {
 		{
 			name: "Resolve variable with unknown path",
 			service: servicescm.Service{
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
-					Name: "CMD_REPLACE",
-					Path: "invalid-script.ps1",
+				PowershellPreScripts: []servicescm.PowershellPreScript{{
+					VariableName: "CMD_REPLACE",
+					Path:         "invalid-script.ps1",
 				}},
 			},
 			expectErr: true,
@@ -155,9 +155,9 @@ func TestResolvePowershellVariables(t *testing.T) {
 		{
 			name: "Resolve variable with known path",
 			service: servicescm.Service{
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
-					Name: "CMD_REPLACE",
-					Path: "c:\\k\\script.ps1",
+				PowershellPreScripts: []servicescm.PowershellPreScript{{
+					VariableName: "CMD_REPLACE",
+					Path:         "c:\\k\\script.ps1",
 				}},
 			},
 			expected:  map[string]string{"CMD_REPLACE": "127.0.0.1"},
@@ -166,9 +166,9 @@ func TestResolvePowershellVariables(t *testing.T) {
 		{
 			name: "Empty variable name",
 			service: servicescm.Service{
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
-					Name: "",
-					Path: "c:\\k\\script.ps1",
+				PowershellPreScripts: []servicescm.PowershellPreScript{{
+					VariableName: "",
+					Path:         "c:\\k\\script.ps1",
 				}},
 			},
 			expected:  map[string]string{},
@@ -177,14 +177,14 @@ func TestResolvePowershellVariables(t *testing.T) {
 		{
 			name: "Multiple variable to resolve",
 			service: servicescm.Service{
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{
+				PowershellPreScripts: []servicescm.PowershellPreScript{
 					{
-						Name: "CMD_REPLACE1",
-						Path: "c:\\k\\script.ps1",
+						VariableName: "CMD_REPLACE1",
+						Path:         "c:\\k\\script.ps1",
 					},
 					{
-						Name: "CMD_REPLACE2",
-						Path: "c:\\k\\test.ps1",
+						VariableName: "CMD_REPLACE2",
+						Path:         "c:\\k\\test.ps1",
 					},
 				},
 			},
@@ -235,11 +235,11 @@ func TestReconcileService(t *testing.T) {
 					State: svc.Running,
 				}),
 			expectedService: servicescm.Service{
-				Name:                         "fakeservice",
-				Command:                      "fakeservice",
-				NodeVariablesInCommand:       nil,
-				PowershellVariablesInCommand: nil,
-				Dependencies:                 nil,
+				Name:                   "fakeservice",
+				Command:                "fakeservice",
+				NodeVariablesInCommand: nil,
+				PowershellPreScripts:   nil,
+				Dependencies:           nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice",
@@ -260,11 +260,11 @@ func TestReconcileService(t *testing.T) {
 					State: svc.Running,
 				}),
 			expectedService: servicescm.Service{
-				Name:                         "fakeservice",
-				Command:                      "fakeservice",
-				NodeVariablesInCommand:       nil,
-				PowershellVariablesInCommand: nil,
-				Dependencies:                 nil,
+				Name:                   "fakeservice",
+				Command:                "fakeservice",
+				NodeVariablesInCommand: nil,
+				PowershellPreScripts:   nil,
+				Dependencies:           nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice",
@@ -291,8 +291,8 @@ func TestReconcileService(t *testing.T) {
 					Name:               "NAME_REPLACE",
 					NodeObjectJsonPath: "{.metadata.name}",
 				}},
-				PowershellVariablesInCommand: nil,
-				Dependencies:                 nil,
+				PowershellPreScripts: nil,
+				Dependencies:         nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice --node-name=node -v",
@@ -316,9 +316,9 @@ func TestReconcileService(t *testing.T) {
 				Name:                   "fakeservice",
 				Command:                "fakeservice --ip_example=CMD_REPLACE -v",
 				NodeVariablesInCommand: nil,
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
-					Name: "CMD_REPLACE",
-					Path: "c:\\k\\script.ps1",
+				PowershellPreScripts: []servicescm.PowershellPreScript{{
+					VariableName: "CMD_REPLACE",
+					Path:         "c:\\k\\script.ps1",
 				}},
 				Dependencies: nil,
 			},
@@ -347,9 +347,9 @@ func TestReconcileService(t *testing.T) {
 					Name:               "NAME_REPLACE",
 					NodeObjectJsonPath: "{.metadata.name}",
 				}},
-				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
-					Name: "CMD_REPLACE",
-					Path: "c:\\k\\script.ps1",
+				PowershellPreScripts: []servicescm.PowershellPreScript{{
+					VariableName: "CMD_REPLACE",
+					Path:         "c:\\k\\script.ps1",
 				}},
 				Dependencies: nil,
 			},

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -47,11 +47,12 @@ type NodeCmdArg struct {
 	NodeObjectJsonPath string `json:"nodeObjectJsonPath"`
 }
 
-// PowershellCmdArg describes a PowerShell variable and how its value can be populated
-type PowershellCmdArg struct {
-	// Name is the variable name as it appears in commands
-	Name string `json:"name"`
-	// Path is the location of a PowerShell script whose output is the value of the variable
+// PowershellPreScript describes a PowerShell script to be ran and an optional variable to be populated
+type PowershellPreScript struct {
+	// VariableName is the name of a variable which should be replaced by the output of the script. An empty value will
+	// cause no variable replacement to occur, but the script will still be ran.
+	VariableName string `json:"variableName,omitempty"`
+	// Path is the location of a PowerShell script to be ran
 	Path string `json:"path"`
 }
 
@@ -60,13 +61,13 @@ type Service struct {
 	// Name is the name of the Windows service
 	Name string `json:"name"`
 	// Command is the command that will launch the Windows service. This could potentially include strings whose values
-	// will be derived from NodeVariablesInCommand and PowershellVariablesInCommand.
+	// will be derived from NodeVariablesInCommand and PowershellPreScripts.
 	// Before the command is run on an instance, all node and PowerShell variables will be replaced by their values
 	Command string `json:"path"`
 	// NodeVariablesInCommand holds all variables in the service command whose values are sourced from a node object
 	NodeVariablesInCommand []NodeCmdArg `json:"nodeVariablesInCommand,omitempty"`
-	// PowershellVariablesInCommand holds all variables in the command whose values are sourced from a PowerShell script
-	PowershellVariablesInCommand []PowershellCmdArg `json:"powershellVariablesInCommand,omitempty"`
+	// PowershellPreScripts is a list of PowerShell scripts which must run successfully before the service is started
+	PowershellPreScripts []PowershellPreScript `json:"powershellPreScripts,omitempty"`
 	// Dependencies is a list of service names that this service is dependent on
 	Dependencies []string `json:"dependencies,omitempty"`
 	// Bootstrap is a boolean flag indicating whether this service should be handled as part of node bootstrapping

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -77,9 +77,9 @@ func TestGenerate(t *testing.T) {
 				Name:               "NAME_VAR",
 				NodeObjectJsonPath: "{.metadata.name}",
 			}},
-			PowershellVariablesInCommand: []PowershellCmdArg{{
-				Name: "PS_VAR",
-				Path: "C:\\k\\test-path.ps1",
+			PowershellPreScripts: []PowershellPreScript{{
+				VariableName: "PS_VAR",
+				Path:         "C:\\k\\test-path.ps1",
 			}},
 			Dependencies: []string{"kubelet"},
 			Bootstrap:    false,
@@ -196,10 +196,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -228,10 +228,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -287,10 +287,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{"test-controller-service", "test-controller-service-2"},
@@ -320,10 +320,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{"test-controller-service"},
@@ -458,10 +458,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -491,10 +491,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -524,10 +524,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -557,10 +557,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -590,10 +590,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellVariablesInCommand: []PowershellCmdArg{
+					PowershellPreScripts: []PowershellPreScript{
 						{
-							Name: "NETWORK_IP",
-							Path: "C:\\k\\scripts\\get_net_ip.ps",
+							VariableName: "NETWORK_IP",
+							Path:         "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},


### PR DESCRIPTION
Renames powershellVariablesInCommand to powershellPreScripts to remove the implicit requirement of a variable to replace, which is not always necessary. Also renames powershellVaraiblesInCommand.Name, to VariableName, to be more clear about the purpose of the field with the new naming.