### PR TITLE
OCPBUGS-5065: Add namespace parameter to WICD commands

### DIFF
--- a/cmd/daemon/bootstrap.go
+++ b/cmd/daemon/bootstrap.go
@@ -54,7 +54,7 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		klog.Exitf("error using service account to build config: %s", err.Error())
 	}
-	sc, err := controller.NewServiceController(context.TODO(), "", controller.Options{Config: cfg})
+	sc, err := controller.NewServiceController(context.TODO(), "", namespace, controller.Options{Config: cfg})
 	if err != nil {
 		klog.Exitf("error creating Service Controller: %s", err.Error())
 	}

--- a/cmd/daemon/cleanup.go
+++ b/cmd/daemon/cleanup.go
@@ -52,7 +52,7 @@ func runCleanupCmd(cmd *cobra.Command, args []string) {
 		klog.Exitf("error using service account to build config: %s", err.Error())
 	}
 	ctx := ctrl.SetupSignalHandler()
-	if err := cleanup.Deconfigure(cfg, ctx, preserveNode); err != nil {
+	if err := cleanup.Deconfigure(cfg, ctx, preserveNode, namespace); err != nil {
 		klog.Exitf(err.Error())
 	}
 }

--- a/cmd/daemon/controller.go
+++ b/cmd/daemon/controller.go
@@ -65,7 +65,7 @@ func runControllerCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 	klog.Info("service controller running")
-	if err := controller.RunController(ctx, apiServerURL, saCA, saToken); err != nil {
+	if err := controller.RunController(ctx, apiServerURL, saCA, saToken, namespace); err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -35,6 +35,7 @@ var (
 	saToken      string
 	saCA         string
 	apiServerURL string
+	namespace    string
 )
 
 func init() {
@@ -44,6 +45,10 @@ func init() {
 	rootCmd.MarkPersistentFlagRequired("sa-ca")
 	rootCmd.PersistentFlags().StringVar(&apiServerURL, "api-server", "", "URL of API server")
 	rootCmd.MarkPersistentFlagRequired("api-server")
+	bootstrapCmd.PersistentFlags().StringVar(&namespace, "namespace", "",
+		"The namespace that required cluster resources, such as the ConfigMap, will be located in. This is the "+
+			"namespace that WMCO is deployed in")
+	rootCmd.MarkPersistentFlagRequired("namespace")
 }
 
 func main() {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -71,8 +71,8 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 		return nil
 	}
 
-	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instanceInfo,
-		r.signer, labelsToApply, annotationsToApply, r.platform)
+	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, r.watchNamespace,
+		instanceInfo, r.signer, labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}
@@ -124,7 +124,7 @@ func (r *instanceReconciler) updateKubeletCA(node core.Node, contents []byte) er
 		return errors.Wrapf(err, "error creating instance for node %s", node.Name)
 	}
 	nodeConfig, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort,
-		winInstance, r.signer, nil, nil, r.platform)
+		r.watchNamespace, winInstance, r.signer, nil, nil, r.platform)
 	if err != nil {
 		return errors.Wrapf(err, "error creating nodeConfig for instance %s", winInstance.Address)
 	}
@@ -183,8 +183,8 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 		return errors.Wrap(err, "unable to create instance object from node")
 	}
 
-	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, instance, r.signer,
-		nil, nil, r.platform)
+	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.vxlanPort, r.watchNamespace,
+		instance, r.signer, nil, nil, r.platform)
 	if err != nil {
 		return errors.Wrap(err, "failed to create new nodeconfig")
 	}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -10,7 +10,7 @@ if [ "$COMMUNITY" = "true" ]; then
 fi
 
 # define namespace
-declare -r WMCO_DEPLOY_NAMESPACE=openshift-windows-machine-config-operator
+WMCO_DEPLOY_NAMESPACE=${WMCO_DEPLOY_NAMESPACE:="openshift-windows-machine-config-operator"}
 
 error-exit() {
     echo "Error: $*" >&2

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -142,26 +142,26 @@ fi
 
 # Test that the operator is running when the private key secret is not present
 printf "\n####### Testing operator deployed without private key secret #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 
 # Run the creation tests of the Windows VMs
 printf "\n####### Testing creation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 # Get logs for the creation tests
 printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
 get_WMCO_logs
 
 if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
   printf "\n####### Testing service reconciliation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+  go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 fi
 
 if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   # Run the upgrade tests and skip deletion of the Windows VMs
   printf "\n####### Testing upgrade #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+  go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 
   # Run the reconfiguration test
   # The reconfiguration suite must be run directly before the deletion suite. This is because we do not
@@ -169,13 +169,13 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   # added/moved in between these two suites may fail.
   # This limitation will be removed with https://issues.redhat.com/browse/WINC-655
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION
+  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 fi
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then
-  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args --private-key-path=$KUBE_SSH_KEY_PATH
+  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
   # Get logs on success before cleanup
   PRINT_UPGRADE=""
   if [[ "$TEST" = "upgrade" ]]; then

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -36,7 +36,7 @@ import (
 // Deconfigure removes an instance from the cluster. If preserveNode is true, the node object is not deleted.
 // If we are able to get the services ConfigMap tied to the desired version, all services defined in it are cleaned up.
 // TODO: Otherwise, perform cleanup based on a combination of the OpenShift managed tag and latest services ConfigMap.
-func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool) error {
+func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool, configMapNamespace string) error {
 	// Cannot use a cached client as no manager will be started to populate cache
 	directClient, err := controller.NewDirectClient(cfg)
 	if err != nil {
@@ -60,7 +60,7 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, preserveNode bool) error
 		// Fetch the CM of the desired version
 		cm := &core.ConfigMap{}
 		err = directClient.Get(ctx,
-			client.ObjectKey{Namespace: controller.WMCONamespace, Name: servicescm.NamePrefix + desiredVersion}, cm)
+			client.ObjectKey{Namespace: configMapNamespace, Name: servicescm.NamePrefix + desiredVersion}, cm)
 		if err != nil {
 			return err
 		}

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
+var wmcoNamespace = "openshift-windows-machine-config-operator"
+
 type fakePSCmdRunner struct {
 	results map[string]string
 }
@@ -106,7 +108,7 @@ func TestResolveNodeVariables(t *testing.T) {
 	}
 	for _, test := range testIO {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := NewServiceController(context.TODO(), test.nodeName, Options{
+			c, err := NewServiceController(context.TODO(), test.nodeName, wmcoNamespace, Options{
 				Client: clientfake.NewClientBuilder().WithObjects(&core.Node{
 					ObjectMeta: meta.ObjectMeta{
 						Name:        "node",
@@ -194,7 +196,7 @@ func TestResolvePowershellVariables(t *testing.T) {
 	}
 	for _, test := range testIO {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := NewServiceController(context.TODO(), "", Options{
+			c, err := NewServiceController(context.TODO(), "", wmcoNamespace, Options{
 				Client: clientfake.NewClientBuilder().Build(),
 				Mgr:    fake.NewTestMgr(nil),
 				cmdRunner: &fakePSCmdRunner{
@@ -363,7 +365,7 @@ func TestReconcileService(t *testing.T) {
 	}
 	for _, test := range testIO {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := NewServiceController(context.TODO(), "node", Options{
+			c, err := NewServiceController(context.TODO(), "node", wmcoNamespace, Options{
 				Client: clientfake.NewClientBuilder().WithObjects(&core.Node{
 					ObjectMeta: meta.ObjectMeta{
 						Name: "node",
@@ -468,13 +470,13 @@ func TestBootstrap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			desiredVersion := "testversion"
 			cm, err := servicescm.Generate(servicescm.NamePrefix+desiredVersion,
-				"openshift-windows-machine-config-operator", &servicescm.Data{test.configMapServices,
+				wmcoNamespace, &servicescm.Data{test.configMapServices,
 					[]servicescm.FileInfo{}})
 			require.NoError(t, err)
 			clusterObjs := []client.Object{cm}
 
 			winSvcMgr := fake.NewTestMgr(make(map[string]*fake.FakeService))
-			sc, err := NewServiceController(context.TODO(), "", Options{
+			sc, err := NewServiceController(context.TODO(), "", wmcoNamespace, Options{
 				Client:    clientfake.NewClientBuilder().WithObjects(clusterObjs...).Build(),
 				Mgr:       winSvcMgr,
 				cmdRunner: &fakePSCmdRunner{},
@@ -634,7 +636,7 @@ func TestReconcile(t *testing.T) {
 			desiredVersion := "testversion"
 			// This ConfigMap's name must match with the given Node object's desired-version annotation
 			cm, err := servicescm.Generate(servicescm.NamePrefix+desiredVersion,
-				"openshift-windows-machine-config-operator", &servicescm.Data{test.configMapServices,
+				wmcoNamespace, &servicescm.Data{test.configMapServices,
 					[]servicescm.FileInfo{}})
 			require.NoError(t, err)
 			clusterObjs := []client.Object{
@@ -651,7 +653,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			winSvcMgr := fake.NewTestMgr(test.existingServices)
-			c, err := NewServiceController(context.TODO(), "node", Options{
+			c, err := NewServiceController(context.TODO(), "node", wmcoNamespace, Options{
 				Client:    clientfake.NewClientBuilder().WithObjects(clusterObjs...).Build(),
 				Mgr:       winSvcMgr,
 				cmdRunner: &fakePSCmdRunner{},

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -82,6 +82,8 @@ type nodeConfig struct {
 	additionalLabels map[string]string
 	// platformType holds the name of the platform where cluster is deployed
 	platformType configv1.PlatformType
+	// wmcoNamespace is the namespace WMCO is deployed to
+	wmcoNamespace string
 }
 
 // ErrWriter is a wrapper to enable error-level logging inside kubectl drainer implementation
@@ -108,7 +110,7 @@ func (ow OutWriter) Write(p []byte) (n int, err error) {
 
 // NewNodeConfig creates a new instance of nodeConfig to be used by the caller.
 // hostName having a value will result in the VM's hostname being changed to the given value.
-func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPort string,
+func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServiceCIDR, vxlanPort, wmcoNamespace string,
 	instanceInfo *instance.Info, signer ssh.Signer, additionalLabels,
 	additionalAnnotations map[string]string, platformType configv1.PlatformType) (*nodeConfig, error) {
 	var err error
@@ -130,8 +132,9 @@ func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServ
 	}
 
 	return &nodeConfig{client: c, k8sclientset: clientset, Windows: win, platformType: platformType,
-		clusterServiceCIDR: clusterServiceCIDR, publicKeyHash: CreatePubKeyHashAnnotation(signer.PublicKey()),
-		log: log, additionalLabels: additionalLabels, additionalAnnotations: additionalAnnotations}, nil
+		wmcoNamespace: wmcoNamespace, clusterServiceCIDR: clusterServiceCIDR,
+		publicKeyHash: CreatePubKeyHashAnnotation(signer.PublicKey()), log: log, additionalLabels: additionalLabels,
+		additionalAnnotations: additionalAnnotations}, nil
 }
 
 // Configure configures the Windows VM to make it a Windows worker node
@@ -150,7 +153,8 @@ func (nc *nodeConfig) Configure() error {
 	}
 
 	// Start all required services to bootstrap a node object using WICD
-	if err := nc.Windows.Bootstrap(version.Get(), nodeConfigCache.apiServerEndpoint, nodeConfigCache.credentials); err != nil {
+	if err := nc.Windows.Bootstrap(version.Get(), nodeConfigCache.apiServerEndpoint, nc.wmcoNamespace,
+		nodeConfigCache.credentials); err != nil {
 		return errors.Wrap(err, "bootstrapping the Windows instance failed")
 	}
 
@@ -182,7 +186,8 @@ func (nc *nodeConfig) Configure() error {
 			return errors.Wrap(err, "unable to check if cloud controller owned by cloud controller manager")
 		}
 
-		if err := nc.Windows.ConfigureWICD(nodeConfigCache.apiServerEndpoint, nodeConfigCache.credentials); err != nil {
+		if err := nc.Windows.ConfigureWICD(nodeConfigCache.apiServerEndpoint, nc.wmcoNamespace,
+			nodeConfigCache.credentials); err != nil {
 			return errors.Wrap(err, "configuring WICD failed")
 		}
 		// Set the desired version annotation, communicating to WICD which Windows services configmap to use

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -230,9 +230,9 @@ type Windows interface {
 	// Reinitialize re-initializes the Windows VM's SSH client
 	Reinitialize() error
 	// Bootstrap prepares the Windows instance and runs the WICD bootstrap command
-	Bootstrap(string, string, *Authentication) error
+	Bootstrap(string, string, string, *Authentication) error
 	// ConfigureWICD ensures that the Windows Instance Config Daemon is running on the node
-	ConfigureWICD(string, *Authentication) error
+	ConfigureWICD(string, string, *Authentication) error
 	// ConfigureKubeProxy ensures that the kube-proxy service is running
 	ConfigureKubeProxy() error
 	// EnsureRequiredServicesStopped ensures that all services that are needed to configure a VM are stopped
@@ -464,7 +464,7 @@ func (vm *windows) Deconfigure() error {
 	return nil
 }
 
-func (vm *windows) Bootstrap(desiredVer, apiServerURL string, credentials *Authentication) error {
+func (vm *windows) Bootstrap(desiredVer, apiServerURL, watchNamespace string, credentials *Authentication) error {
 	vm.log.Info("configuring")
 	if err := vm.EnsureRequiredServicesStopped(); err != nil {
 		return errors.Wrap(err, "unable to stop all services")
@@ -482,8 +482,8 @@ func (vm *windows) Bootstrap(desiredVer, apiServerURL string, credentials *Authe
 	if err := vm.ensureWICDSecretContent(credentials); err != nil {
 		return err
 	}
-	wicdBootstrapCmd := fmt.Sprintf("%s bootstrap --desired-version %s --api-server %s --sa-ca %s --sa-token %s",
-		wicdPath, desiredVer, apiServerURL, wicdCAFile, wicdTokenFile)
+	wicdBootstrapCmd := fmt.Sprintf("%s bootstrap --desired-version %s --api-server %s --sa-ca %s --sa-token %s --namespace %s",
+		wicdPath, desiredVer, apiServerURL, wicdCAFile, wicdTokenFile, watchNamespace)
 	if out, err := vm.Run(wicdBootstrapCmd, true); err != nil {
 		vm.log.Info("failed to bootstrap node", "command", wicdBootstrapCmd, "output", out)
 		return err
@@ -492,12 +492,12 @@ func (vm *windows) Bootstrap(desiredVer, apiServerURL string, credentials *Authe
 }
 
 // ConfigureWICD starts the Windows Instance Config Daemon service
-func (vm *windows) ConfigureWICD(apiServerURL string, credentials *Authentication) error {
+func (vm *windows) ConfigureWICD(apiServerURL, watchNamespace string, credentials *Authentication) error {
 	if err := vm.ensureWICDSecretContent(credentials); err != nil {
 		return err
 	}
-	wicdServiceArgs := fmt.Sprintf("controller --windows-service --log-dir %s --api-server %s --sa-ca %s --sa-token %s",
-		wicdLogDir, apiServerURL, wicdCAFile, wicdTokenFile)
+	wicdServiceArgs := fmt.Sprintf("controller --windows-service --log-dir %s --api-server %s --sa-ca %s --sa-token %s --namespace %s",
+		wicdLogDir, apiServerURL, wicdCAFile, wicdTokenFile, watchNamespace)
 	wicdService, err := newService(wicdPath, wicdServiceName, wicdServiceArgs, nil)
 	if err != nil {
 		return errors.Wrapf(err, "error creating %s service object", wicdServiceName)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -88,7 +88,7 @@ func (tc *testContext) nodelessLogCollection(name, address string) error {
 
 // deleteWindowsInstanceConfigMap deletes the windows-instances configmap if it exists
 func (tc *testContext) deleteWindowsInstanceConfigMap() error {
-	err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Delete(context.TODO(), wiparser.InstanceConfigMap,
+	err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Delete(context.TODO(), wiparser.InstanceConfigMap,
 		metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
@@ -112,7 +112,7 @@ func (tc *testContext) createWindowsInstanceConfigMap(machines *mapi.MachineList
 		}
 		cm.Data[addr] = "username=" + tc.vmUsername()
 	}
-	_, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
+	_, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Create(context.TODO(), cm, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "unable to create configmap")
 	}
@@ -121,7 +121,7 @@ func (tc *testContext) createWindowsInstanceConfigMap(machines *mapi.MachineList
 
 // validateWindowsInstanceConfigMap validates the windows-instance ConfigMap
 func (tc *testContext) validateWindowsInstanceConfigMap(expectedCount int) error {
-	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(),
+	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(context.TODO(),
 		wiparser.InstanceConfigMap, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving ConfigMap: %s", wiparser.InstanceConfigMap)
@@ -208,7 +208,7 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 
 // byohLogCollection kicks off the collection of logs for instances listed in the windows-instances configmap
 func (tc *testContext) byohLogCollection() {
-	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(),
+	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(context.TODO(),
 		wiparser.InstanceConfigMap, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("unable to collect logs, error retrieving instances ConfigMap: %v", err)

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -30,13 +30,13 @@ func deletionTestSuite(t *testing.T) {
 
 // clearWindowsInstanceConfigMap removes all entries in the windows-instances ConfigMap
 func (tc *testContext) clearWindowsInstanceConfigMap() error {
-	cm, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), wiparser.InstanceConfigMap,
+	cm, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(context.TODO(), wiparser.InstanceConfigMap,
 		meta.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error retrieving windows-instances ConfigMap")
 	}
 	cm.Data = map[string]string{}
-	_, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Update(context.TODO(), cm, meta.UpdateOptions{})
+	_, err = tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Update(context.TODO(), cm, meta.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error clearing windows-instances ConfigMap data")
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -28,6 +28,8 @@ var (
 	privateKeyPath string
 	// wmcoPath is the path to the WMCO binary that was used within the operator image
 	wmcoPath string
+	// wmcoPath is the namespace WMCO is deployed to
+	wmcoNamespace string
 	// gc is the global context across the test suites.
 	gc = globalContext{}
 )
@@ -62,8 +64,6 @@ func (gc *globalContext) allNodes() []core.Node {
 // information should be easily accessible by other methods within the same test suite.
 // Some of the fields we have here can be exposed by via flags to the test suite.
 type testContext struct {
-	// namespace is the namespace the operator is deployed in
-	namespace string
 	// client is the OpenShift client
 	client *clusterinfo.OpenShift
 	// retryInterval to check for existence of resource in kube api server
@@ -105,8 +105,8 @@ func NewTestContext() (*testContext, error) {
 
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{client: oc, timeout: retry.Timeout, retryInterval: retry.Interval,
-		namespace: "openshift-windows-machine-config-operator", CloudProvider: cloudProvider,
-		workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels, toolsImage: toolsImage}, nil
+		CloudProvider: cloudProvider, workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels,
+		toolsImage: toolsImage}, nil
 }
 
 // vmUsername returns the name of the user which can be used to log into each Windows instance
@@ -141,6 +141,8 @@ func TestMain(m *testing.M) {
 			"Setting this to 0 will result in some tests being skipped")
 	flag.StringVar(&wmcoPath, "wmco-path", "./../../build/_output/bin/windows-machine-config-operator",
 		"Path to the WMCO binary, used for version validation")
+	flag.StringVar(&wmcoNamespace, "wmco-namespace", "openshift-windows-machine-config-operator",
+		"Namespace that WMCO is deployed to")
 	flag.StringVar(&privateKeyPath, "private-key-path", "",
 		"path of the private key file used to configure the Windows node")
 	flag.Parse()

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -79,7 +79,7 @@ func testPrometheus(t *testing.T) {
 	require.NoError(t, err)
 
 	// check that SM existS
-	_, err = testCtx.client.Monitoring.ServiceMonitors(testCtx.namespace).Get(context.TODO(),
+	_, err = testCtx.client.Monitoring.ServiceMonitors(wmcoNamespace).Get(context.TODO(),
 		metrics.WindowsMetricsResource, metav1.GetOptions{})
 	require.NoError(t, err, "error getting service monitor")
 
@@ -155,7 +155,7 @@ func testWindowsPrometheusRules(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 	// test if PrometheusRule object exists in WMCO repo
-	promRule, err := tc.client.Monitoring.PrometheusRules(tc.namespace).Get(context.TODO(), prometheusRule, metav1.GetOptions{})
+	promRule, err := tc.client.Monitoring.PrometheusRules(wmcoNamespace).Get(context.TODO(), prometheusRule, metav1.GetOptions{})
 	require.NoError(t, err)
 	// test if rules specific to windows exist
 	require.Equal(t, windowsRuleName, promRule.Spec.Groups[0].Name)
@@ -263,7 +263,7 @@ func (tc *testContext) getPrometheusToken() (string, error) {
 // openshift-windows-machine-config-operator namespace if it is not present. If the label is applied, it restarts the
 // WMCO deployment so that WMCO is aware that monitoring is enabled.
 func (tc *testContext) ensureMonitoringIsEnabled() error {
-	namespace, err := tc.client.K8s.CoreV1().Namespaces().Get(context.TODO(), tc.namespace, metav1.GetOptions{})
+	namespace, err := tc.client.K8s.CoreV1().Namespaces().Get(context.TODO(), wmcoNamespace, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func (tc *testContext) ensureMonitoringIsEnabled() error {
 	monitoringLabel := "openshift.io/cluster-monitoring"
 	value, ok := namespace.GetLabels()[monitoringLabel]
 	if !ok || value != "true" {
-		if _, err = tc.client.K8s.CoreV1().Namespaces().Patch(context.TODO(), tc.namespace, types.MergePatchType,
+		if _, err = tc.client.K8s.CoreV1().Namespaces().Patch(context.TODO(), wmcoNamespace, types.MergePatchType,
 			[]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, monitoringLabel, "true")),
 			metav1.PatchOptions{}); err != nil {
 			return err

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -77,7 +77,7 @@ func testReAddInstance(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 
-	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Get(context.TODO(), wiparser.InstanceConfigMap,
+	windowsInstances, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(context.TODO(), wiparser.InstanceConfigMap,
 		metav1.GetOptions{})
 	require.NoError(t, err, "error retrieving windows-instances ConfigMap")
 	require.NotEmpty(t, windowsInstances.Data, "no instances to remove")
@@ -96,7 +96,7 @@ func testReAddInstance(t *testing.T) {
 	patchDataBytes, err := json.Marshal(patchData)
 	require.NoError(t, err, "error getting patch data in bytes")
 
-	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Patch(context.TODO(),
+	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Patch(context.TODO(),
 		wiparser.InstanceConfigMap, types.JSONPatchType, patchDataBytes, metav1.PatchOptions{})
 	require.NoError(t, err, "error patching windows-instances ConfigMap data with remove operation")
 	// Ensure operator communicates to OLM that upgrade is not safe when processing BYOH nodes
@@ -118,7 +118,7 @@ func testReAddInstance(t *testing.T) {
 	patchDataBytes, err = json.Marshal(patchData)
 	require.NoError(t, err, "error getting patch data in bytes")
 
-	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Patch(context.TODO(),
+	windowsInstances, err = tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Patch(context.TODO(),
 		wiparser.InstanceConfigMap, types.JSONPatchType, patchDataBytes, metav1.PatchOptions{})
 	require.NoError(t, err, "error patching windows-instances ConfigMap data with add operation")
 

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -228,7 +228,7 @@ func (tc *testContext) createPrivateKeySecret(useKnownKey bool) error {
 
 	// Create the private key secret in both the operator's namespace, and the test namespace. This is needed to make it
 	// possible to SSH into the Windows nodes from pods spun up in the test namespace.
-	for _, ns := range []string{tc.namespace, tc.workloadNamespace} {
+	for _, ns := range []string{wmcoNamespace, tc.workloadNamespace} {
 		_, err := tc.client.K8s.CoreV1().Secrets(ns).Create(context.TODO(), &privateKeySecret, meta.CreateOptions{})
 		if err != nil {
 			return errors.Wrapf(err, "could not create private key secret in namespace %s", ns)
@@ -239,7 +239,7 @@ func (tc *testContext) createPrivateKeySecret(useKnownKey bool) error {
 
 // ensurePrivateKeyDeleted ensures that the privateKeySecret is deleted in both the operator and test namespaces
 func (tc *testContext) ensurePrivateKeyDeleted() error {
-	for _, ns := range []string{tc.namespace, tc.workloadNamespace} {
+	for _, ns := range []string{wmcoNamespace, tc.workloadNamespace} {
 		err := tc.client.K8s.CoreV1().Secrets(ns).Delete(context.TODO(), secrets.PrivateKeySecret, meta.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "could not delete private key secret in namespace %s", ns)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -26,8 +26,6 @@ const (
 	deploymentTimeout = time.Minute * 1
 	// resourceName is the name of a resource in the watched namespace (e.g pod name, deployment name)
 	resourceName = "windows-machine-config-operator"
-	// resourceNamespace is the namespace the resources are deployed in
-	resourceNamespace = "openshift-windows-machine-config-operator"
 	// windowsWorkloadTesterJob is the name of the job created to test Windows workloads
 	windowsWorkloadTesterJob = "windows-workload-tester"
 	// outdatedVersion is the 'previous' version in the simulated upgrade that the operator is being upgraded from
@@ -141,11 +139,11 @@ func (tc *testContext) configureUpgradeTest() error {
 	outdatedServicesCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      servicescm.NamePrefix + outdatedVersion,
-			Namespace: tc.namespace,
+			Namespace: wmcoNamespace,
 		},
 		Data: map[string]string{"services": "[]", "files": "[]"},
 	}
-	if _, err := tc.client.K8s.CoreV1().ConfigMaps(tc.namespace).Create(context.TODO(), outdatedServicesCM,
+	if _, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Create(context.TODO(), outdatedServicesCM,
 		metav1.CreateOptions{}); err != nil {
 		return err
 	}
@@ -166,7 +164,7 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 
 		patchData := fmt.Sprintf(`{"spec":{"replicas":%v}}`, desiredReplicas)
 
-		_, err = tc.client.K8s.AppsV1().Deployments(resourceNamespace).Patch(context.TODO(), resourceName,
+		_, err = tc.client.K8s.AppsV1().Deployments(wmcoNamespace).Patch(context.TODO(), resourceName,
 			types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 		if err != nil {
 			log.Printf("error patching operator deployment : %v", err)
@@ -181,7 +179,7 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 
 	// wait for the windows-machine-config-operator to scale up/down
 	err = wait.Poll(deploymentRetryInterval, deploymentTimeout, func() (done bool, err error) {
-		deployment, err := tc.client.K8s.AppsV1().Deployments(resourceNamespace).Get(context.TODO(), resourceName,
+		deployment, err := tc.client.K8s.AppsV1().Deployments(wmcoNamespace).Get(context.TODO(), resourceName,
 			metav1.GetOptions{})
 		if err != nil {
 			log.Printf("error getting operator deployment: %v", err)

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -60,7 +60,7 @@ func TestWMCO(t *testing.T) {
 func testOperatorDeployed(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
-	deployment, err := testCtx.client.K8s.AppsV1().Deployments(testCtx.namespace).Get(context.TODO(),
+	deployment, err := testCtx.client.K8s.AppsV1().Deployments(wmcoNamespace).Get(context.TODO(),
 		"windows-machine-config-operator", meta.GetOptions{})
 	require.NoError(t, err, "could not get WMCO deployment")
 	require.NotZerof(t, deployment.Status.AvailableReplicas, "WMCO deployment has no available replicas: %v", deployment)


### PR DESCRIPTION
This commit fixes an issue preventing WMCO from being deployed to non-default namespaces. If WMCO was deployed to a namespace other than openshift-windows-machine-config-operator, WICD would be unable to retrieve the services ConfigMap. This is fixed by WMCO informing WICD of the namespace to look in, by passing it in as a parameter in WICD commands.

Fixes OCPBUGS-5065