### PR TITLE
WINC-677: [e2e] Modularize linux curler job creation

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -53,11 +53,8 @@ func testWindowsExporter(t *testing.T) {
 			require.Greaterf(t, len(winNodeInternalIP), 0, "test requires Windows node %s to have internal IP",
 				winNode.Name)
 
-			// This will curl the windows server. curl must be present in the container image.
-			linuxCurlerCommand := []string{"bash", "-c", "curl http://" + winNodeInternalIP + ":" +
-				strconv.Itoa(int(metrics.Port)) + "/" + metrics.PortName}
-			linuxCurlerJob, err := testCtx.createLinuxJob("linux-curler-"+strings.ToLower(winNode.Status.NodeInfo.MachineID),
-				linuxCurlerCommand)
+			linuxCurlerJob, err := testCtx.createLinuxCurlerJob(strings.ToLower(winNode.Status.NodeInfo.MachineID),
+				fmt.Sprintf("http://%s:%d/%s", winNodeInternalIP, int(metrics.Port), metrics.PortName), false)
 			require.NoError(t, err, "could not create Linux job")
 			// delete the job created
 			defer testCtx.deleteJob(linuxCurlerJob.Name)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -131,8 +131,8 @@ func testEastWestNetworking(t *testing.T) {
 
 					// create the curler job based on the specified curlerOS
 					if tt.curlerOS == linux {
-						curlerCommand := []string{"bash", "-c", "curl " + endpointIP}
-						curlerJob, err = testCtx.createLinuxJob("linux-curler-"+strings.ToLower(node.Status.NodeInfo.MachineID), curlerCommand)
+						curlerJob, err = testCtx.createLinuxCurlerJob(strings.ToLower(node.Status.NodeInfo.MachineID),
+							endpointIP, false)
 						require.NoError(t, err, "could not create Linux job")
 					} else if tt.curlerOS == windowsOS {
 						// Always deploy the Windows curler pod on the first node. Because we test scaling multiple
@@ -572,6 +572,28 @@ func (tc *testContext) getPodEvents(name string) ([]v1.Event, error) {
 		}
 	}
 	return podEvents, nil
+}
+
+// createLinuxCurlerJob creates a linux job to curl a specific endpoint. curl must be present in the container image.
+func (testCtx *testContext) createLinuxCurlerJob(jobSuffix, endpoint string, continuous bool) (*batchv1.Job, error) {
+	// Retries a failed curl attempt once to avoid flakes
+	curlCommand := fmt.Sprintf(
+		"curl %s;"+
+			" if [ $? != 0 ]; then"+
+			" sleep 60;"+
+			" curl %s || exit 1;"+
+			" fi",
+		endpoint, endpoint)
+	if continuous {
+		// curl every 5 seconds indefinitely. If the endpoint is inaccessible for a few minutes, pod exits with an error
+		curlCommand = fmt.Sprintf(
+			"while true; do "+
+				"%s;"+
+				" sleep 5;"+
+				" done",
+			curlCommand)
+	}
+	return testCtx.createLinuxJob("linux-curler-"+jobSuffix, []string{"bash", "-c", curlCommand})
 }
 
 // createLinuxJob creates a job which will run the provided command with a ubi8 image

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -34,23 +34,6 @@ const (
 	outdatedVersion = "old-version"
 )
 
-// generateLinuxWorkloadTesterCommand creates a Job to curl Windows webserver every 5 seconds.
-// If the webserver is not accessible for few minutes Curl Windows webserver
-// exit the pod with an error.
-func generateLinuxWorkloadTesterCommand(clusterIP string) []string {
-	return []string{
-		"bash",
-		"-c",
-		" while true;" +
-			" do curl " + clusterIP + ";" +
-			" if [ $? != 0 ]; then" +
-			" sleep 60;" +
-			" curl " + clusterIP + " || exit 1;" +
-			" fi; " +
-			"sleep 5; " +
-			"done"}
-}
-
 // upgradeTestSuite tests behaviour of the operator when an upgrade takes place.
 func upgradeTestSuite(t *testing.T) {
 	testCtx, err := NewTestContext()
@@ -209,8 +192,7 @@ func (tc *testContext) deployWindowsWorkloadAndTester() (func(), error) {
 		return nil, errors.Wrapf(err, "error creating service for deployment %s", deployment.Name)
 	}
 	// create a Job object that continuously curls the webserver every 5 seconds.
-	testerJob, err := tc.createLinuxJob(windowsWorkloadTesterJob,
-		generateLinuxWorkloadTesterCommand(intermediarySVC.Spec.ClusterIP))
+	testerJob, err := tc.createLinuxCurlerJob(windowsWorkloadTesterJob, intermediarySVC.Spec.ClusterIP, true)
 	if err != nil {
 		_ = tc.deleteDeployment(deployment.Name)
 		_ = tc.deleteService(intermediarySVC.Name)


### PR DESCRIPTION
This PR consolidates the creation of the linux curl commands in the e2e tests so that there is a standard way of calling the curler jobs.