### PR TITLE
OCPBUGS-5354: Enable draining DaemonSet workloads

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -244,6 +244,12 @@ spec:
           - delete
           - get
         - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - get
+        - apiGroups:
           - certificates.k8s.io
           resources:
           - certificatesigningrequests

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -97,6 +97,12 @@ rules:
   - delete
   - get
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -175,7 +175,7 @@ fi
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then
-  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
   # Get logs on success before cleanup
   PRINT_UPGRADE=""
   if [[ "$TEST" = "upgrade" ]]; then

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -39,6 +39,8 @@ import (
 	"github.com/openshift/windows-machine-config-operator/version"
 )
 
+//+kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get
+
 const (
 	// HybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
 	HybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"
@@ -490,7 +492,11 @@ func (nc *nodeConfig) newDrainHelper() *drain.Helper {
 		Ctx:    context.TODO(),
 		Client: nc.k8sclientset,
 		ErrOut: &ErrWriter{nc.log},
-		Out:    &OutWriter{nc.log},
+		// Evict all pods regardless of their controller and orphan status
+		Force: true,
+		// Prevents erroring out in case a DaemonSet's pod is on the node
+		IgnoreAllDaemonSets: true,
+		Out:                 &OutWriter{nc.log},
 	}
 }
 


### PR DESCRIPTION
Draining a workload created with a DaemonSet was causing an error due
to lacking DaemonSet `get` permissions. This change adds the RBAC
permissions to resolve said error.

Additionally, the drain flags had to be adjusted by adding the `force`
and `IgnoreAllDaemonSets` flags.

Because draining ignores Daemonset pods, the pod's containers would be
leaked, continuing to run in the background even with kubelet and
containerd stopped. Stopping containerd does not stop containerd
containers running on the instance.

This behavior is preventing WMCO from removing the containerd shim.
To address this, WICD cleanup was made to kill all processes using
the shim, which will stop the leaked containers.

An issue with how the deletion tests were being invoked needed to be
corrected in order to properly test this issue. The tests were
incorrectly using the default expected Node count of 1 machine node
and 1 byoh node, instead of being passed the actual correct value.

Fixes OCPBUGS-5354