### PR TITLE
OCPBUGS-5732: [wm_controller] Fix Machine node upgrades

### DIFF
--- a/pkg/nodeutil/nodeutil.go
+++ b/pkg/nodeutil/nodeutil.go
@@ -5,7 +5,7 @@ import (
 )
 
 // FindByAddress returns a pointer to the node within the given list with an address matching the given address, or
-// nil if the node was found.
+// nil if the node was not found.
 func FindByAddress(address string, nodes *core.NodeList) *core.Node {
 	for _, node := range nodes.Items {
 		for _, nodeAddress := range node.Status.Addresses {


### PR DESCRIPTION
This PR fixes an issue where Machine nodes were not being identified as
out-of-date. This made them skip the deconfigure process, preventing draining
nodes, which would have resulted in a user workload disruptions during upgrade.

Fixes [OCPBUGS-5732](https://issues.redhat.com/browse/OCPBUGS-5732)