### PR TITLE
WINC-920: Use Windows Server 2019 for Azure e2e tests

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -440,16 +440,13 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 	return podList.Items[0].Status.PodIP, nil
 }
 
-// getWindowsServerContainerImage gets the appropriate WindowsServer image based on VXLAN port
+// getWindowsServerContainerImage gets the appropriate WindowsServer image based on cloud provider
 func (tc *testContext) getWindowsServerContainerImage() string {
 	var windowsServerImage string
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType ||
 		tc.CloudProvider.GetType() == config.NonePlatformType {
 		// If we're on vSphere or platform:none we will use 2022
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
-	} else if tc.CloudProvider.GetType() == config.AzurePlatformType {
-		// On Azure we are testing 20H2
-		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-20h2"
 	} else {
 		// For other providers we use 1809
 		windowsServerImage = "mcr.microsoft.com/powershell:lts-nanoserver-1809"

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -18,7 +18,7 @@ const (
 	defaultCredentialsSecretName = "azure-cloud-credentials"
 	defaultImageOffer            = "WindowsServer"
 	defaultImagePublisher        = "MicrosoftWindowsServer"
-	defaultImageSKU              = "datacenter-core-20h2-with-containers-smalldisk"
+	defaultImageSKU              = "2019-Datacenter-with-Containers"
 	defaultImageVersion          = "latest"
 	defaultOSDiskSizeGB          = 128
 	defaultStorageAccountType    = "Premium_LRS"


### PR DESCRIPTION
this PR enables using Windows Server 2019 instead of Windows Server 20H2 for e2e tests 