### PR TITLE
WINC-741: WICD takes more responsibility of Node configuration

### DIFF
--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -12,3 +12,4 @@ rules:
   - list
   - watch
   - get
+  - patch

--- a/config/wicd/windows-instance-config-daemon-cluster-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role.yaml
@@ -11,3 +11,4 @@ rules:
       - list
       - watch
       - get
+      - patch

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -27,11 +27,6 @@ import (
 	"github.com/openshift/windows-machine-config-operator/version"
 )
 
-const (
-	// machineAPINamespace is the name of the namespace in which machine objects and userData secret is created.
-	machineAPINamespace = "openshift-machine-api"
-)
-
 // instanceReconciler contains everything needed to perform actions on a Windows instance
 type instanceReconciler struct {
 	// Client is the cache client

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -232,7 +232,7 @@ func (r *SecretReconciler) updateUserData(ctx context.Context, keySigner ssh.Sig
 			annotationsToApply = map[string]string{nodeconfig.PubKeyHashAnnotation: ""}
 		}
 
-		if err := metadata.ApplyAnnotations(r.client, ctx, node, annotationsToApply); err != nil {
+		if err := metadata.ApplyLabelsAndAnnotations(ctx, r.client, node, nil, annotationsToApply); err != nil {
 			return errors.Wrapf(err, "error updating annotations on node %s", node.GetName())
 		}
 		r.log.V(1).Info("patched node object", "node", node.GetName(), "patch", annotationsToApply)

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/condition"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
@@ -38,7 +39,6 @@ import (
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch;update
 
 const (
-	userDataSecret = "windows-user-data"
 	// SecretController is the name of this controller in logs and other outputs.
 	SecretController = "secret"
 )
@@ -110,7 +110,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // isUserDataSecret returns true if the provided object is the userData Secret
 func isUserDataSecret(obj client.Object) bool {
-	return obj.GetName() == userDataSecret && obj.GetNamespace() == machineAPINamespace
+	return obj.GetName() == secrets.UserDataSecret && obj.GetNamespace() == cluster.MachineAPINamespace
 }
 
 // isPrivateKeySecret returns true if the provided object is the private key secret
@@ -164,15 +164,16 @@ func (r *SecretReconciler) Reconcile(ctx context.Context,
 	// Generate expected userData based on the existing private key
 	validUserData, err := secrets.GenerateUserData(r.platform, keySigner.PublicKey())
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "error generating %s secret", userDataSecret)
+		return reconcile.Result{}, errors.Wrapf(err, "error generating %s secret", secrets.UserDataSecret)
 	}
 
 	userData := &core.Secret{}
 	// Fetch UserData instance
-	err = r.client.Get(ctx, kubeTypes.NamespacedName{Name: userDataSecret, Namespace: machineAPINamespace}, userData)
+	err = r.client.Get(ctx,
+		kubeTypes.NamespacedName{Name: secrets.UserDataSecret, Namespace: cluster.MachineAPINamespace}, userData)
 	if err != nil && k8sapierrors.IsNotFound(err) {
 		// Secret is deleted
-		log.Info("secret not found, creating the secret", "name", userDataSecret)
+		log.Info("secret not found, creating the secret", "name", secrets.UserDataSecret)
 		err = r.client.Create(ctx, validUserData)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -180,7 +181,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context,
 		// Secret created successfully - don't requeue
 		return reconcile.Result{}, nil
 	} else if err != nil {
-		log.Error(err, "error retrieving the secret", "name", userDataSecret)
+		log.Error(err, "error retrieving the secret", "name", secrets.UserDataSecret)
 		return reconcile.Result{}, err
 	} else if string(userData.Data["userData"][:]) == string(validUserData.Data["userData"][:]) {
 		// valid userData secret already exists
@@ -238,7 +239,7 @@ func (r *SecretReconciler) updateUserData(ctx context.Context, keySigner ssh.Sig
 	}
 
 	// Set userdata to expected value
-	r.log.Info("updating secret", "name", userDataSecret)
+	r.log.Info("updating secret", "name", secrets.UserDataSecret)
 	err = r.client.Update(ctx, expected)
 	if err != nil {
 		return errors.Wrap(err, "error updating secret")

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -147,7 +147,7 @@ func (r *WindowsMachineReconciler) mapNodeToMachine(object client.Object) []reco
 	}
 
 	// Map the Node to the associated Machine through the Node's UID
-	machines, err := r.machineClient.Machines(machineAPINamespace).List(context.TODO(),
+	machines, err := r.machineClient.Machines(cluster.MachineAPINamespace).List(context.TODO(),
 		meta.ListOptions{LabelSelector: MachineOSLabel + "=Windows," + IgnoreLabel + "!=true"})
 	if err != nil {
 		r.log.Error(err, "could not get a list of machines")
@@ -244,8 +244,7 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context,
 	}
 
 	// Fetch the Machine instance
-	machine, err := r.machineClient.Machines(machineAPINamespace).Get(ctx,
-		request.Name, meta.GetOptions{})
+	machine, err := r.machineClient.Machines(cluster.MachineAPINamespace).Get(ctx, request.Name, meta.GetOptions{})
 	if err != nil {
 		if k8sapierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -447,7 +446,7 @@ func (r *WindowsMachineReconciler) validateUserData() error {
 
 	userDataSecret := &core.Secret{}
 	err := r.client.Get(context.TODO(), kubeTypes.NamespacedName{Name: secrets.UserDataSecret,
-		Namespace: secrets.UserDataNamespace}, userDataSecret)
+		Namespace: cluster.MachineAPINamespace}, userDataSecret)
 	if err != nil {
 		return errors.Wrap(err, "could not find Windows userData secret in required namespace")
 	}
@@ -471,14 +470,14 @@ func (r *WindowsMachineReconciler) isAllowedDeletion(machine *mapi.Machine) (boo
 	}
 	machinesetName := machine.OwnerReferences[0].Name
 
-	machines, err := r.machineClient.Machines(machineAPINamespace).List(context.TODO(),
+	machines, err := r.machineClient.Machines(cluster.MachineAPINamespace).List(context.TODO(),
 		meta.ListOptions{LabelSelector: MachineOSLabel + "=Windows"})
 	if err != nil {
 		return false, errors.Wrap(err, "cannot list Machines")
 	}
 
 	// get Windows MachineSet
-	windowsMachineSet, err := r.machineClient.MachineSets(machineAPINamespace).Get(context.TODO(),
+	windowsMachineSet, err := r.machineClient.MachineSets(cluster.MachineAPINamespace).Get(context.TODO(),
 		machinesetName, meta.GetOptions{})
 	if err != nil {
 		return false, errors.Wrap(err, "cannot get MachineSet")

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -29,6 +29,8 @@ const (
 	cloudControllerOwnershipConditionType = "CloudControllerOwner"
 	// clusterCloudControllerManagerOperatorName is the registered name of Cluster Cloud Controller Manager Operator
 	clusterCloudControllerManagerOperatorName = "cloud-controller-manager"
+	// MachineAPINamespace is the name of the namespace in which machine objects and userData secret is created.
+	MachineAPINamespace = "openshift-machine-api"
 )
 
 // Network interface contains methods to interact with cluster network objects

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -30,7 +30,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/controller"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/powershell"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
@@ -54,7 +54,7 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, configMapNamespace strin
 		if err != nil {
 			return err
 		}
-		desiredVersion, present := node.Annotations[nodeconfig.DesiredVersionAnnotation]
+		desiredVersion, present := node.Annotations[metadata.DesiredVersionAnnotation]
 		if !present {
 			return errors.Wrapf(err, "node missing desired version annotation")
 		}

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -34,7 +34,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
-// Deconfigure removes an instance from the cluster.
+// Deconfigure removes all managed services from the instance and the version annotation
 // If we are able to get the services ConfigMap tied to the desired version, all services defined in it are cleaned up.
 // TODO: Otherwise, perform cleanup based on a combination of the OpenShift managed tag and latest services ConfigMap.
 func Deconfigure(cfg *rest.Config, ctx context.Context, configMapNamespace string) error {
@@ -83,6 +83,10 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, configMapNamespace strin
 		return err
 	}
 	cleanupContainers()
+
+	if node != nil {
+		return metadata.RemoveVersionAnnotation(ctx, directClient, *node)
+	}
 	return nil
 }
 

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -205,7 +205,7 @@ func (sc *ServiceController) SetupWithManager(mgr ctrl.Manager) error {
 
 // mapToCurrentNode maps all events to the node associated with this Windows instance
 func (sc *ServiceController) mapToCurrentNode(_ client.Object) []reconcile.Request {
-	return []reconcile.Request{{types.NamespacedName{Name: sc.nodeName}}}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: sc.nodeName}}}
 }
 
 // Reconcile fulfills the Reconciler interface
@@ -435,8 +435,7 @@ func (sc *ServiceController) resolvePowershellVariables(svc servicescm.Service) 
 // It also returns the config and scheme used to created the client.
 func NewDirectClient(cfg *rest.Config) (client.Client, error) {
 	clientScheme := runtime.NewScheme()
-	err := clientgoscheme.AddToScheme(clientScheme)
-	if err = clientgoscheme.AddToScheme(clientScheme); err != nil {
+	if err := clientgoscheme.AddToScheme(clientScheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -247,6 +247,10 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 		klog.Error(err)
 		return ctrl.Result{}, err
 	}
+	// Version annotation is the indicator that the node was fully configured by this version of the services ConfigMap
+	if err = metadata.ApplyVersionAnnotation(sc.ctx, sc.client, node, desiredVersion); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "error updating version annotation on node %s", sc.nodeName)
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -49,7 +49,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/powershell"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/winsvc"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeutil"
 	"github.com/openshift/windows-machine-config-operator/pkg/services"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
@@ -179,15 +179,15 @@ func (sc *ServiceController) SetupWithManager(mgr ctrl.Manager) error {
 		// A node's name will never change, so it is fine to use the name for node identification
 		// The node must have a desired-version annotation for it to be reconcilable
 		CreateFunc: func(e event.CreateEvent) bool {
-			return sc.nodeName == e.Object.GetName() && e.Object.GetAnnotations()[nodeconfig.DesiredVersionAnnotation] != ""
+			return sc.nodeName == e.Object.GetName() && e.Object.GetAnnotations()[metadata.DesiredVersionAnnotation] != ""
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Only process update events if the desired version has changed
 			return sc.nodeName == e.ObjectNew.GetName() &&
-				e.ObjectOld.GetAnnotations()[nodeconfig.DesiredVersionAnnotation] != e.ObjectNew.GetAnnotations()[nodeconfig.DesiredVersionAnnotation]
+				e.ObjectOld.GetAnnotations()[metadata.DesiredVersionAnnotation] != e.ObjectNew.GetAnnotations()[metadata.DesiredVersionAnnotation]
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return sc.nodeName == e.Object.GetName() && e.Object.GetAnnotations()[nodeconfig.DesiredVersionAnnotation] != ""
+			return sc.nodeName == e.Object.GetName() && e.Object.GetAnnotations()[metadata.DesiredVersionAnnotation] != ""
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false
@@ -223,7 +223,7 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 		return ctrl.Result{}, err
 	}
 
-	desiredVersion, present := node.Annotations[nodeconfig.DesiredVersionAnnotation]
+	desiredVersion, present := node.Annotations[metadata.DesiredVersionAnnotation]
 	if !present {
 		// node missing desired version annotation, don't requeue
 		return ctrl.Result{}, nil

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/fake"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
@@ -645,7 +645,7 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: meta.ObjectMeta{
 						Name: "node",
 						Annotations: map[string]string{
-							nodeconfig.DesiredVersionAnnotation: desiredVersion,
+							metadata.DesiredVersionAnnotation: desiredVersion,
 						},
 					},
 				},

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -14,8 +14,12 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 )
 
-// VersionAnnotation indicates the version of WMCO that configured the node
-const VersionAnnotation = "windowsmachineconfig.openshift.io/version"
+const (
+	// VersionAnnotation indicates the version of WMCO that configured the node
+	VersionAnnotation = "windowsmachineconfig.openshift.io/version"
+	// DesiredVersionAnnotation is a Node annotation, indicating the Service ConfigMap that should be used to configure it
+	DesiredVersionAnnotation = "windowsmachineconfig.openshift.io/desired-version"
+)
 
 // generatePatch creates a patch applying the given operation onto each given annotation key and value
 func generatePatch(op string, labels, annotations map[string]string) ([]*patch.JSONPatch, error) {

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -55,8 +55,6 @@ const (
 	// KubeletClientCAFilename is the name of the CA certificate file required by kubelet to interact
 	// with the kube-apiserver client
 	KubeletClientCAFilename = "kubelet-ca.crt"
-	// DesiredVersionAnnotation is a Node annotation, indicating the Service ConfigMap that should be used to configure it
-	DesiredVersionAnnotation = "windowsmachineconfig.openshift.io/desired-version"
 	// mcoNamespace is the namespace the Machine Config Server is deployed in, which manages the node bootsrapper secret
 	mcoNamespace = "openshift-machine-config-operator"
 	// mcoBootstrapSecret is the resource name that holds the cert and token required to create the bootstrap kubeconfig
@@ -193,7 +191,7 @@ func (nc *nodeConfig) Configure() error {
 			return errors.Wrap(err, "configuring WICD failed")
 		}
 		// Set the desired version annotation, communicating to WICD which Windows services configmap to use
-		if err := nc.applyLabelsAndAnnotations(nil, map[string]string{DesiredVersionAnnotation: version.Get()}); err != nil {
+		if err := nc.applyLabelsAndAnnotations(nil, map[string]string{metadata.DesiredVersionAnnotation: version.Get()}); err != nil {
 			return errors.Wrapf(err, "error updating desired version annotation on node %s", nc.node.GetName())
 		}
 

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/crypto/ssh"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -152,8 +151,9 @@ func (nc *nodeConfig) Configure() error {
 		return err
 	}
 
+	wmcoVersion := version.Get()
 	// Start all required services to bootstrap a node object using WICD
-	if err := nc.Windows.Bootstrap(version.Get(), nodeConfigCache.apiServerEndpoint, nc.wmcoNamespace,
+	if err := nc.Windows.Bootstrap(wmcoVersion, nodeConfigCache.apiServerEndpoint, nc.wmcoNamespace,
 		nodeConfigCache.credentials); err != nil {
 		return errors.Wrap(err, "bootstrapping the Windows instance failed")
 	}
@@ -176,7 +176,8 @@ func (nc *nodeConfig) Configure() error {
 		for key, value := range nc.additionalAnnotations {
 			annotationsToApply[key] = value
 		}
-		if err := nc.applyLabelsAndAnnotations(nc.additionalLabels, annotationsToApply); err != nil {
+		if err := metadata.ApplyLabelsAndAnnotations(context.TODO(), nc.client, *nc.node, nc.additionalLabels,
+			annotationsToApply); err != nil {
 			return errors.Wrapf(err, "error updating public key hash and additional annotations on node %s",
 				nc.node.GetName())
 		}
@@ -191,18 +192,17 @@ func (nc *nodeConfig) Configure() error {
 			return errors.Wrap(err, "configuring WICD failed")
 		}
 		// Set the desired version annotation, communicating to WICD which Windows services configmap to use
-		if err := nc.applyLabelsAndAnnotations(nil, map[string]string{metadata.DesiredVersionAnnotation: version.Get()}); err != nil {
+		if err := metadata.ApplyDesiredVersionAnnotation(context.TODO(), nc.client, *nc.node, wmcoVersion); err != nil {
 			return errors.Wrapf(err, "error updating desired version annotation on node %s", nc.node.GetName())
 		}
 
-		// Now that basic kubelet configuration is complete, configure networking in the node
-		if err := nc.configureNetwork(); err != nil {
-			return errors.Wrap(err, "configuring node network failed")
+		// Wait for version annotation. This prevents uncordoning the node until all node services and networks are up
+		if err := metadata.WaitForVersionAnnotation(context.TODO(), nc.client, nc.node.Name); err != nil {
+			return errors.Wrapf(err, "error waiting for proper %s annotation for node %s", metadata.VersionAnnotation,
+				nc.node.GetName())
 		}
 
-		// Now that the node has been fully configured, add the version annotation to signify that the node
-		// was successfully configured by this version of WMCO
-		// populate node object in nodeConfig once more
+		// Now that the node has been fully configured, update the node object in nodeConfig once more
 		if err := nc.setNode(false); err != nil {
 			return errors.Wrap(err, "error getting node object")
 		}
@@ -213,8 +213,7 @@ func (nc *nodeConfig) Configure() error {
 		if ownedByCCM && nc.platformType == configv1.AzurePlatformType {
 			// TODO: The proper long term solution is to run this as a pod and give it the correct permissions
 			// via service account. This isn't currently possible as we are unable to build Windows container images
-			// due to shortcomings in our build system. Short term solution is to do this taint removal in WICD, when
-			// WICD removes the cordon. https://issues.redhat.com/browse/WINC-741
+			// due to shortcomings in our build system.
 			cloudTaint := &core.Taint{
 				Key:    cloudproviderapi.TaintExternalCloudProvider,
 				Effect: core.TaintEffectNoSchedule,
@@ -222,11 +221,6 @@ func (nc *nodeConfig) Configure() error {
 			if err := cloudnodeutil.RemoveTaintOffNode(nc.k8sclientset, nc.node.GetName(), nc.node, cloudTaint); err != nil {
 				return errors.Wrapf(err, "error excluding cloud taint on node %s", nc.node.GetName())
 			}
-		}
-		// Version annotation is the indicator that the node was fully configured by this version of WMCO, so it should
-		// be added at the end of the process.
-		if err := nc.applyLabelsAndAnnotations(nil, map[string]string{metadata.VersionAnnotation: version.Get()}); err != nil {
-			return errors.Wrapf(err, "error updating version annotation on node %s", nc.node.GetName())
 		}
 
 		// Uncordon the node now that it is fully configured
@@ -366,21 +360,6 @@ func createKubeletConf(clusterServiceCIDR string) (string, error) {
 	return string(kubeletConfigData), nil
 }
 
-// applyLabelsAndAnnotations applies all the given labels and annotations and updates the Node object in NodeConfig
-func (nc *nodeConfig) applyLabelsAndAnnotations(labels, annotations map[string]string) error {
-	patchData, err := metadata.GenerateAddPatch(labels, annotations)
-	if err != nil {
-		return err
-	}
-	node, err := nc.k8sclientset.CoreV1().Nodes().Patch(context.TODO(), nc.node.GetName(), kubeTypes.JSONPatchType,
-		patchData, meta.PatchOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "unable to apply patch data %s", patchData)
-	}
-	nc.node = node
-	return nil
-}
-
 // isCloudControllerOwnedByCCM checks if Cloud Controllers are managed by Cloud Controller Manager (CCM)
 // instead of Kube Controller Manager.
 func isCloudControllerOwnedByCCM() (bool, error) {
@@ -395,35 +374,6 @@ func isCloudControllerOwnedByCCM() (bool, error) {
 	}
 
 	return cluster.IsCloudControllerOwnedByCCM(client)
-}
-
-// configureNetwork configures k8s networking in the node
-// we are assuming that the WindowsVM and node objects are valid
-func (nc *nodeConfig) configureNetwork() error {
-	// Wait until the node object has the hybrid overlay subnet annotation. Otherwise the hybrid-overlay will fail to
-	// start
-	if err := nc.waitForNodeAnnotation(HybridOverlaySubnet); err != nil {
-		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlaySubnet,
-			nc.node.GetName())
-	}
-
-	// Wait until the node object has the hybrid overlay MAC annotation. This indicates that hybrid-overlay is running
-	// successfully, and is required for the CNI configuration to start.
-	if err := nc.waitForNodeAnnotation(HybridOverlayMac); err != nil {
-		return errors.Wrapf(err, "error waiting for %s node annotation for %s", HybridOverlayMac,
-			nc.node.GetName())
-	}
-	// Running the hybrid-overlay causes network reconfiguration in the Windows VM which results in the ssh connection
-	// being closed, and the client is not smart enough to reconnect.
-	if err := nc.Windows.Reinitialize(); err != nil {
-		return errors.Wrap(err, "error reinitializing VM after running hybrid-overlay")
-	}
-
-	// Start the kube-proxy service
-	if err := nc.Windows.ConfigureKubeProxy(); err != nil {
-		return errors.Wrapf(err, "error starting kube-proxy for %s", nc.node.GetName())
-	}
-	return nil
 }
 
 // setNode finds the Node associated with the VM that has been configured, and sets the node field of the
@@ -458,32 +408,6 @@ func (nc *nodeConfig) setNode(quickCheck bool) error {
 	return errors.Wrapf(err, "unable to find node with address %s", instanceAddress)
 }
 
-// waitForNodeAnnotation checks if the node object has the given annotation and waits for retry.Interval seconds and
-// returns an error if the annotation does not appear in that time frame.
-func (nc *nodeConfig) waitForNodeAnnotation(annotation string) error {
-	nodeName := nc.node.GetName()
-	var found bool
-	err := wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
-		node, err := nc.k8sclientset.CoreV1().Nodes().Get(context.TODO(), nodeName, meta.GetOptions{})
-		if err != nil {
-			nc.log.V(1).Error(err, "unable to get associated node object")
-			return false, nil
-		}
-		_, found := node.Annotations[annotation]
-		if found {
-			// update node to avoid staleness
-			nc.node = node
-			return true, nil
-		}
-		return false, nil
-	})
-
-	if !found {
-		return errors.Wrapf(err, "timeout waiting for %s node annotation", annotation)
-	}
-	return nil
-}
-
 // newDrainHelper returns new drain.Helper instance
 func (nc *nodeConfig) newDrainHelper() *drain.Helper {
 	return &drain.Helper{
@@ -514,19 +438,9 @@ func (nc *nodeConfig) Deconfigure() error {
 		return errors.Wrapf(err, "unable to drain node %s", nc.node.GetName())
 	}
 
-	// Revert the changes we've made to the instance by removing services and deleting all installed files
+	// Revert all changes we've made to the instance by removing installed services, files, and the version annotation
 	if err := nc.Windows.Deconfigure(nc.wmcoNamespace, nodeConfigCache.apiServerEndpoint); err != nil {
 		return errors.Wrap(err, "error deconfiguring instance")
-	}
-	// Clear the version annotation from the node object to indicate the node is not configured
-	patchData, err := metadata.GenerateRemovePatch([]string{}, []string{metadata.VersionAnnotation})
-	if err != nil {
-		return errors.Wrapf(err, "error creating version annotation remove request")
-	}
-	_, err = nc.k8sclientset.CoreV1().Nodes().Patch(context.TODO(), nc.node.GetName(), kubeTypes.JSONPatchType,
-		patchData, meta.PatchOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "error removing version annotation from node %s", nc.node.GetName())
 	}
 
 	nc.log.Info("instance has been deconfigured", "node", nc.node.GetName())

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -11,13 +11,13 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeTypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 )
 
 const (
 	// UserDataSecret is the name of the userData secret that WMCO creates
 	UserDataSecret = "windows-user-data"
-	// UserDataNamespace is the namespace of the userData secret that WMCO creates
-	UserDataNamespace = "openshift-machine-api"
 	// PrivateKeySecret is the name of the private key secret provided by the user
 	PrivateKeySecret = "cloud-private-key"
 	// PrivateKeySecretKey is the key within the private key secret which holds the private key
@@ -50,7 +50,7 @@ func GenerateUserData(platformType oconfig.PlatformType, publicKey ssh.PublicKey
 	userDataSecret := &core.Secret{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      UserDataSecret,
-			Namespace: UserDataNamespace,
+			Namespace: cluster.MachineAPINamespace,
 		},
 		Data: map[string][]byte{
 			"userData": []byte(userData),

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -230,8 +229,6 @@ type Windows interface {
 	Bootstrap(string, string, string, *Authentication) error
 	// ConfigureWICD ensures that the Windows Instance Config Daemon is running on the node
 	ConfigureWICD(string, string, *Authentication) error
-	// ConfigureKubeProxy ensures that the kube-proxy service is running
-	ConfigureKubeProxy() error
 	// Deconfigure removes all files and networks created by WMCO and runs the WICD cleanup command.
 	Deconfigure(string, string) error
 	// RunWICDCleanup runs the WICD cleanup command that ensures all services configured by WICD are stopped.
@@ -246,8 +243,6 @@ type windows struct {
 	signer ssh.Signer
 	// interact is used to connect to and interact with the VM
 	interact connectivity
-	// vxlanPort is the custom VXLAN port
-	vxlanPort string
 	// instance contains information about the Windows instance to interact with
 	// A valid instance is configured with a network address that either is an IPv4 address or resolves to one.
 	instance *instance.Info
@@ -268,7 +263,6 @@ func New(clusterDNS, vxlanPort string, instanceInfo *instance.Info, signer ssh.S
 	return &windows{
 			interact:               conn,
 			clusterDNS:             clusterDNS,
-			vxlanPort:              vxlanPort,
 			instance:               instanceInfo,
 			log:                    log,
 			defaultShellPowerShell: defaultShellPowershell(conn),
@@ -471,18 +465,6 @@ func (vm *windows) ConfigureWICD(apiServerURL, watchNamespace string, credential
 		return errors.Wrapf(err, "error ensuring %s Windows service has started running", WicdServiceName)
 	}
 	vm.log.Info("configured", "service", WicdServiceName, "args", wicdServiceArgs)
-	return nil
-}
-
-func (vm *windows) ConfigureKubeProxy() error {
-	// TODO: Currently this function, and waiting for kube-proxy to be running, is required. kube-proxy is the final
-	//       Windows Service. WMCO still has to perform post-configuration steps such as applying the version
-	//       annotation, which indicates the the Node has been full configured. This function should be removed as part
-	//       of https://issues.redhat.com/browse/WINC-741, where WICD will take care of those steps.
-	vm.log.V(1).Info("waiting for kube-proxy to start running")
-	if err := vm.waitForServiceToRun(KubeProxyServiceName); err != nil {
-		return errors.Wrapf(err, "error waiting for %s Windows service to start running", KubeProxyServiceName)
-	}
 	return nil
 }
 
@@ -790,48 +772,6 @@ func (vm *windows) startService(svc *service) error {
 		return errors.Wrapf(err, "failed to start %s service with output: %s", svc.name, out)
 	}
 	return nil
-}
-
-// waitForHNSNetworks waits for the OVN overlay HNS networks to be created until the timeout is reached
-func (vm *windows) waitForHNSNetworks() error {
-	var out string
-	var err error
-	for retries := 0; retries < retry.Count; retries++ {
-		out, err = vm.Run("Get-HnsNetwork", true)
-		if err != nil {
-			// retry
-			continue
-		}
-
-		if strings.Contains(out, BaseOVNKubeOverlayNetwork) &&
-			strings.Contains(out, OVNKubeOverlayNetwork) {
-			return nil
-		}
-		time.Sleep(retry.Interval)
-	}
-
-	// OVN overlay HNS networks were not found
-	vm.log.Info("Get-HnsNetwork", "output", out)
-	return errors.Wrap(err, "timeout waiting for OVN overlay HNS networks")
-}
-
-// waitForServiceToRun waits for the given service to be in RUNNING state
-// until the timeout is reached
-func (vm *windows) waitForServiceToRun(serviceName string) error {
-	var err error
-	for retries := 0; retries < retry.Count; retries++ {
-		serviceRunning, err := vm.isRunning(serviceName)
-		if err != nil {
-			return errors.Wrapf(err, "unable to check if %s Windows service is running", serviceName)
-		}
-		if serviceRunning {
-			return nil
-		}
-		time.Sleep(retry.Interval)
-	}
-
-	// service did not reach running state
-	return fmt.Errorf("timeout waiting for %s service to be in running state: %v", serviceName, err)
 }
 
 // newFileInfo returns a pointer to a FileInfo object created from the specified file on the Windows VM

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -175,7 +175,8 @@ func testWindowsNodeDeletion(t *testing.T) {
 	testCtx.deleteWindowsInstanceConfigMap()
 
 	// Cleanup secrets created by us.
-	err = testCtx.client.K8s.CoreV1().Secrets("openshift-machine-api").Delete(context.TODO(), "windows-user-data", meta.DeleteOptions{})
+	err = testCtx.client.K8s.CoreV1().Secrets(clusterinfo.MachineAPINamespace).Delete(context.TODO(),
+		clusterinfo.UserDataSecretName, meta.DeleteOptions{})
 	require.NoError(t, err, "could not delete userData secret")
 
 	err = testCtx.client.K8s.CoreV1().Secrets(wmcoNamespace).Delete(context.TODO(), secrets.PrivateKeySecret, meta.DeleteOptions{})

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -129,7 +129,7 @@ func (a *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 		SecurityGroups:     linuxWorkerSpec.SecurityGroups,
 		Subnet:             linuxWorkerSpec.Subnet,
 		Placement:          linuxWorkerSpec.Placement,
-		UserDataSecret:     &core.LocalObjectReference{Name: "windows-user-data"},
+		UserDataSecret:     &core.LocalObjectReference{Name: clusterinfo.UserDataSecretName},
 	}
 
 	rawBytes, err := json.Marshal(providerSpec)

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -87,7 +87,7 @@ func (p *Provider) newAzureMachineProviderSpec(location, zone string) (*mapi.Azu
 // GenerateMachineSet generates the machineset object which is aws provider specific
 func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
 	// Inspect master-0 to get Azure Location and Zone
-	machines, err := p.oc.Machine.Machines("openshift-machine-api").Get(context.TODO(),
+	machines, err := p.oc.Machine.Machines(clusterinfo.MachineAPINamespace).Get(context.TODO(),
 		p.InfrastructureName+"-master-0", meta.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get master-0 machine resource: %v", err)

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -74,7 +74,7 @@ func (p *Provider) newVSphereMachineProviderSpec() (*mapi.VSphereMachineProvider
 func (p *Provider) getWorkspaceFromExistingMachineSet() (*mapi.Workspace, error) {
 	listOptions := meta.ListOptions{LabelSelector: "machine.openshift.io/cluster-api-cluster=" +
 		p.InfrastructureName}
-	machineSets, err := p.oc.Machine.MachineSets("openshift-machine-api").List(context.TODO(), listOptions)
+	machineSets, err := p.oc.Machine.MachineSets(clusterinfo.MachineAPINamespace).List(context.TODO(), listOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get machinesets")
 	}

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -57,7 +57,8 @@ func (tc *testContext) getCloudPrivateKey() ([]byte, error) {
 
 // getUserDataContents returns the contents of the windows-user-data secret
 func (tc *testContext) getUserDataContents() (string, error) {
-	secret, err := tc.client.K8s.CoreV1().Secrets(clusterinfo.MachineAPINamespace).Get(context.TODO(), "windows-user-data", meta.GetOptions{})
+	secret, err := tc.client.K8s.CoreV1().Secrets(clusterinfo.MachineAPINamespace).Get(context.TODO(),
+		clusterinfo.UserDataSecretName, meta.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -770,15 +770,15 @@ func testDependentServiceChanges(t *testing.T) {
 // triggerWICDReconciliation kicks off WICD instance reconciliation by changing the desiredVersionAnnotation to an
 // incorrect version, and then back to the correct version.
 func (tc *testContext) triggerWICDReconciliation(node *core.Node) error {
-	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, nc.DesiredVersionAnnotation,
+	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, metadata.DesiredVersionAnnotation,
 		"test")
 	_, err := tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType,
 		[]byte(patchData), meta.PatchOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error patching node annotation")
 	}
-	patchData = fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, nc.DesiredVersionAnnotation,
-		node.Annotations[nc.DesiredVersionAnnotation])
+	patchData = fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, metadata.DesiredVersionAnnotation,
+		node.Annotations[metadata.DesiredVersionAnnotation])
 	_, err = tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType,
 		[]byte(patchData), meta.PatchOptions{})
 	if err != nil {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -480,13 +480,14 @@ func testServicesConfigMap(t *testing.T) {
 		cmData, err = servicescm.Parse(cm.Data)
 		require.NoError(t, err, "unable to parse ConfigMap data")
 
-		// Check that the expected services are defined within the CM data
-		expectedSvcs, err := tc.expectedWindowsServices(windows.RequiredServicesOwnedByWICD)
+		// Check that only the expected services are defined within the CM data. WICD itself should not be defined in it
+		expectedSvcs, err := tc.expectedWindowsServices(windows.RequiredServices)
+		expectedSvcs[windows.WicdServiceName] = false
 		require.NoError(t, err)
-		for svcName, shouldBeRunning := range expectedSvcs {
+		for svcName, shouldBeInConfigMap := range expectedSvcs {
 			t.Run(svcName, func(t *testing.T) {
-				assert.Equalf(t, shouldBeRunning, containsService(svcName, cmData.Services),
-					"service existence should be %t", shouldBeRunning)
+				assert.Equalf(t, shouldBeInConfigMap, containsService(svcName, cmData.Services),
+					"service existence should be %t", shouldBeInConfigMap)
 			})
 		}
 	})


### PR DESCRIPTION
This PR moves the version annotation application and removal to WICD,
instead of WMCO. This allows us to reduce WMCO's responsibility when reconciling
nodes -- it no longer watches or stops any WICD managed Windows services. It also
shifts the responsibility of stopping services before bootstrapping from WMCO to WICD.
To do this, the WICD cleanup command was with partial best effort cleanup, using 
most recently created services ConfigMap  if no associated node object exists.

The PR also includes miscellaneous changes:
Adds containerd to the services ConfigMap validation e2e test.
Removes hardcoded values and consolidates Machine API namespace & user data constants.
Rehomes the desired version annotation constant to the metadata pkg.