### PR TITLE
WINC-1035: Support Nutanix platform

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -304,9 +304,9 @@ func (r *ConfigMapReconciler) ensureInstancesAreUpToDate(instances []*instance.I
 	windowsInstances := &core.ConfigMap{ObjectMeta: meta.ObjectMeta{Name: wiparser.InstanceConfigMap,
 		Namespace: r.watchNamespace}}
 	for _, instanceInfo := range instances {
-		// When platform type is none, kubelet will pick a random interface to use for the Node's IP. In that case we
+		// When platform type is none or Nutanix, kubelet will pick a random interface to use for the Node's IP. In that case we
 		// should override that with the IP that the user is providing via the ConfigMap.
-		instanceInfo.SetNodeIP = r.platform == config.NonePlatformType
+		instanceInfo.SetNodeIP = r.platform == config.NonePlatformType || r.platform == config.NutanixPlatformType
 		encryptedUsername, err := crypto.EncryptToJSONString(instanceInfo.Username, privateKeyBytes)
 		if err != nil {
 			return fmt.Errorf("unable to encrypt username for instance %s: %w", instanceInfo.Address, err)

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -409,8 +409,9 @@ func (r *WindowsMachineReconciler) configureMachine(ipAddress, instanceID, machi
 	// equivalent of ignition in Windows, WMCO must correct this by changing the VM's hostname.
 	// TODO: Remove this once we figure out how to do this via guestInfo in vSphere
 	// 		https://bugzilla.redhat.com/show_bug.cgi?id=1876987
+	// Windows Hostname could be changed in initial customizing, however Nutanix is using the same workflow as with vSphere
 	hostname := ""
-	if r.platform == oconfig.VSpherePlatformType {
+	if r.platform == oconfig.VSpherePlatformType || r.platform == oconfig.NutanixPlatformType {
 		hostname = machineName
 	}
 	username := r.getDefaultUsername()

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -363,6 +363,7 @@ func (tc *testContext) waitForWindowsMachines(machineCount int, phase string, ig
 			machineStateTimeLimit = time.Minute * 20
 		}
 	}
+	log.Printf("waiting (timeout: %s) for %d Windows Machines to reach phase %q", machineStateTimeLimit.String(), machineCount, phase)
 
 	listOptions := metav1.ListOptions{LabelSelector: clusterinfo.MachineE2ELabel + "=true"}
 	if ignoreLabel {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -245,6 +245,7 @@ func testNorthSouthNetworking(t *testing.T) {
 	// Ignore the application ingress load balancer test for None and vSphere platforms as it has to be created manually
 	// https://docs.openshift.com/container-platform/4.9/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html
 	if testCtx.CloudProvider.GetType() == config.VSpherePlatformType ||
+		testCtx.CloudProvider.GetType() == config.NutanixPlatformType ||
 		testCtx.CloudProvider.GetType() == config.NonePlatformType {
 		t.Skipf("NorthSouthNetworking test is disabled for platform %s", testCtx.CloudProvider.GetType())
 	}

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -13,6 +13,7 @@ import (
 	azureProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/azure"
 	gcpProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/gcp"
 	noneProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/none"
+	nutanixProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/nutanix"
 	vSphereProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
 
@@ -46,6 +47,8 @@ func NewCloudProvider() (CloudProvider, error) {
 		return gcpProvider.New(openshift, &infra.Status), nil
 	case config.VSpherePlatformType:
 		return vSphereProvider.New(openshift, &infra.Status)
+	case config.NutanixPlatformType:
+		return nutanixProvider.New(openshift, &infra.Status)
 	case config.NonePlatformType:
 		return noneProvider.New(openshift)
 	default:

--- a/test/e2e/providers/nutanix/nutanix.go
+++ b/test/e2e/providers/nutanix/nutanix.go
@@ -1,0 +1,87 @@
+package nutanix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	config "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
+)
+
+type Provider struct {
+	oc *clusterinfo.OpenShift
+	*config.InfrastructureStatus
+}
+
+// New returns a new Provider
+func New(oc *clusterinfo.OpenShift, infraStatus *config.InfrastructureStatus) (*Provider, error) {
+	return &Provider{
+		oc:                   oc,
+		InfrastructureStatus: infraStatus,
+	}, nil
+}
+
+// GenerateMachineSet generates a Windows MachineSet which is Nutanix provider specific
+func (a *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*machinev1beta1.MachineSet, error) {
+	listOptions := meta.ListOptions{LabelSelector: "machine.openshift.io/cluster-api-machine-role=worker"}
+	machines, err := a.oc.Machine.Machines(clusterinfo.MachineAPINamespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, err
+	}
+	if len(machines.Items) == 0 {
+		return nil, fmt.Errorf("found 0 worker role machines")
+	}
+
+	workerSpec := &machinev1.NutanixMachineProviderConfig{}
+	err = json.Unmarshal(machines.Items[0].Spec.ProviderSpec.Value.Raw, workerSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal raw machine provider spec: %v", err)
+	}
+
+	// The Windows image named "nutanix-windows-server" was pre-uploaded to the Nutanix CI prism-central.
+	// This image has "Windows Server 2022" type.
+	winImageName := "nutanix-windows-server"
+	winImageIdentifier := machinev1.NutanixResourceIdentifier{
+		Type: machinev1.NutanixIdentifierName,
+		Name: &winImageName,
+	}
+
+	providerSpec := &machinev1.NutanixMachineProviderConfig{
+		Cluster:           workerSpec.Cluster,
+		Image:             winImageIdentifier,
+		Subnets:           workerSpec.Subnets,
+		VCPUsPerSocket:    workerSpec.VCPUsPerSocket,
+		VCPUSockets:       workerSpec.VCPUSockets,
+		MemorySize:        workerSpec.MemorySize,
+		SystemDiskSize:    workerSpec.SystemDiskSize,
+		CredentialsSecret: workerSpec.CredentialsSecret,
+		UserDataSecret:    &core.LocalObjectReference{Name: clusterinfo.UserDataSecretName},
+	}
+
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	return machineset.New(rawBytes, a.InfrastructureName, replicas, withIgnoreLabel, a.InfrastructureName+"-"), nil
+}
+
+func (a *Provider) GetType() config.PlatformType {
+	return config.NutanixPlatformType
+}
+
+func (a *Provider) StorageSupport() bool {
+	return false
+}
+
+func (a *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on Nutanix")
+}

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -324,7 +324,9 @@ func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, er
 	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
 	powershellDefaultCommand := command
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType ||
-		tc.CloudProvider.GetType() == config.GCPPlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
+		tc.CloudProvider.GetType() == config.GCPPlatformType ||
+		tc.CloudProvider.GetType() == config.AzurePlatformType ||
+		tc.CloudProvider.GetType() == config.NutanixPlatformType {
 		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
 	}
 


### PR DESCRIPTION
[controllers] Support Nutanix platform

Nutanix is similar to the vSphere platform, so add the Nutanix platform in
places where vSphere platform is special cased.
Do the same in the e2e tests except for testPrivateKeyChange() because of
cloudbase-init support in Nutanix.
