### PR TITLE
OCPBUGS-7287: Fix Kublet logs are not written to kubelet.log

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -178,7 +178,7 @@ func getKubeletServiceConfiguration(argsFromIginition map[string]string, debug b
 		preScripts = append(preScripts, hostnameOverridePowershellVar)
 	}
 
-	kubeletServiceCmd := fmt.Sprintf("%s -log-file=%s -redirect-stderr=false %s",
+	kubeletServiceCmd := fmt.Sprintf("%s -log-file=%s %s",
 		windows.KubeLogRunnerPath, windows.KubeletLog, windows.KubeletPath)
 
 	for _, arg := range kubeletArgs {


### PR DESCRIPTION
This PR fixes an issue where the kubelet logs were not being written to the kubelet.log file.
The kubelet.exe invocation was not ordered correctly with the arguments being passed before it. 
Moreover, we do not want to set the `-redirect-stderr` flag to false and want to default to true which means we want our error logs to be logged to the same kubelet log file instead of stderr.

Fixes: OCPBUGS-7287