### PR TITLE
[release-4.12] OCPBUGS-7336: [build] Fix k8s version reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
 WMCO_VERSION ?= 7.0.1
 
+# *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
+# command in generate_k8s_version_commit() in hack/update_submodules.sh
+KUBELET_GIT_VERSION=v1.26.0+feedbee
+KUBE-PROXY_GIT_VERSION=v1.26.0+feedbee
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -211,3 +216,11 @@ base-img:
 wmco-img:
 	podman build . -t $(IMG) -f build/Dockerfile.wmco
 	podman push $(IMG)
+
+.PHONY: kubelet
+kubelet:
+	KUBE_GIT_VERSION=$(KUBELET_GIT_VERSION) KUBE_BUILD_PLATFORMS=windows/amd64 make -C kubelet WHAT=cmd/kubelet
+
+.PHONY: kube-proxy
+kube-proxy:
+	KUBE_GIT_VERSION=$(KUBE-PROXY_GIT_VERSION) KUBE_BUILD_PLATFORMS=windows/amd64 make -C kube-proxy WHAT=cmd/kube-proxy

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,16 +35,14 @@ COPY hcsshim/ .
 RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 
 # Build kubelet
-WORKDIR /build/windows-machine-config-operator/kubelet/
-COPY kubelet/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kubelet
+WORKDIR /build/windows-machine-config-operator/
+COPY kubelet/ kubelet/
+COPY Makefile Makefile
+RUN make kubelet
 
 # Build kube-proxy
-WORKDIR /build/windows-machine-config-operator/kube-proxy/
-COPY kube-proxy/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kube-proxy
+COPY kube-proxy/ kube-proxy/
+RUN make kube-proxy
 
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/
@@ -66,7 +64,6 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY vendor vendor
 COPY .gitignore .gitignore
-COPY Makefile Makefile
 COPY build build
 COPY cmd cmd
 COPY controllers controllers

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -35,16 +35,14 @@ COPY hcsshim/ .
 RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 
 # Build kubelet
-WORKDIR /build/windows-machine-config-operator/kubelet/
-COPY kubelet/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kubelet
+WORKDIR /build/windows-machine-config-operator/
+COPY kubelet/ kubelet/
+COPY Makefile Makefile
+RUN make kubelet
 
 # Build kube-proxy
-WORKDIR /build/windows-machine-config-operator/kube-proxy/
-COPY kube-proxy/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kube-proxy
+COPY kube-proxy/ kube-proxy/
+RUN make kube-proxy
 
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -43,16 +43,14 @@ COPY hcsshim/ .
 RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 
 # Build kubelet
-WORKDIR /build/windows-machine-config-operator/kubelet/
-COPY kubelet/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kubelet
+WORKDIR /build/windows-machine-config-operator/
+COPY kubelet/ kubelet/
+COPY Makefile Makefile
+RUN make kubelet
 
 # Build kube-proxy
-WORKDIR /build/windows-machine-config-operator/kube-proxy/
-COPY kube-proxy/ .
-ENV KUBE_BUILD_PLATFORMS windows/amd64
-RUN make WHAT=cmd/kube-proxy
+COPY kube-proxy/ kube-proxy/
+RUN make kube-proxy
 
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/
@@ -79,7 +77,6 @@ COPY vendor vendor
 COPY version version
 COPY go.mod go.mod
 COPY go.sum go.sum
-COPY Makefile Makefile
 COPY tools.go tools.go
 COPY .gitignore .gitignore
 RUN make build


### PR DESCRIPTION
The openshift/kubernetes repo does not propagate all tags from upstream. Only the X.Y.0 tag is propagated. This causes the Windows kubelet and kube-proxy Z version to lag behind its Linux counterparts. The Linux [build](https://github.com/openshift/doozer/blob/a34e303682ca180e4f071f85cc4c34e6d333787e/doozerlib/metadata.py#L788) of kubelet and kube-proxy figures out the Z version at build time. To do something similar for Windows, we can leverage the hack/update_submodules.sh script which is always used to update the kubelet and kube-proxy submodules. To achieve this, the following changes are made:
- Add kubelet and kube-proxy version variables to the Makefile along with make endpoints
- Call these make endpoints in the Dockerfile
- Update hack/update_submodules.sh to pull upstream tags and generate a commit that updates the Makefile version variables

Now the built binaries will have the correct version encoded in them.

(manually cherry picked from https://github.com/openshift/windows-machine-config-operator/pull/1401)