### PR TITLE
WINC-977: Update kube-proxy submodule to sdn-4.13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 [submodule "kube-proxy"]
 	path = kube-proxy
 	url = https://github.com/openshift/kubernetes
-	branch = sdn-4.12-kubernetes-1.25.1
+	branch = sdn-4.13-kubernetes-1.26.0
 [submodule "containerd"]
 	path = containerd
 	url = https://github.com/openshift/containerd

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WMCO_VERSION ?= 8.0.0
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.26.0+149fe52
-KUBE-PROXY_GIT_VERSION=v1.25.1+72939b9
+KUBE-PROXY_GIT_VERSION=v1.26.0+9500d08
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -129,10 +129,10 @@ func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service
 // kubeProxyConfiguration returns the Service definition for kube-proxy
 func kubeProxyConfiguration(debug bool) servicescm.Service {
 	sanitizedSubnetAnnotation := strings.ReplaceAll(nodeconfig.HybridOverlaySubnet, ".", "\\.")
-	cmd := fmt.Sprintf("%s --windows-service --proxy-mode=kernelspace --feature-gates=WinOverlay=true "+
-		"--hostname-override=NODE_NAME --kubeconfig=%s --cluster-cidr=NODE_SUBNET --log-dir=%s --logtostderr=false "+
-		"--network-name=%s --source-vip=ENDPOINT_IP --enable-dsr=false", windows.KubeProxyPath, windows.KubeconfigPath,
-		windows.KubeProxyLogDir, windows.OVNKubeOverlayNetwork)
+	cmd := fmt.Sprintf("%s -log-file=%s %s --windows-service --proxy-mode=kernelspace --feature-gates=WinOverlay=true "+
+		"--hostname-override=NODE_NAME --kubeconfig=%s --cluster-cidr=NODE_SUBNET "+
+		"--network-name=%s --source-vip=ENDPOINT_IP --enable-dsr=false", windows.KubeLogRunnerPath, windows.KubeProxyLog,
+		windows.KubeProxyPath, windows.KubeconfigPath, windows.OVNKubeOverlayNetwork)
 	// Set log level
 	cmd = fmt.Sprintf("%s %s", cmd, klogVerbosityArg(debug))
 	return servicescm.Service{

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -83,6 +83,8 @@ const (
 	KubeletConfigPath = K8sDir + "\\kubelet.conf"
 	// KubeletLog is the location of the kubelet log file
 	KubeletLog = KubeletLogDir + "\\kubelet.log"
+	// KubeProxyLog is the location of the kube-proxy log file
+	KubeProxyLog = KubeProxyLogDir + "\\kube-proxy.log"
 	// KubeProxyPath is the location of the kube-proxy exe
 	KubeProxyPath = K8sDir + "\\kube-proxy.exe"
 	// HybridOverlayPath is the location of the hybrid-overlay-node exe

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -22,17 +22,12 @@ import (
 func testNodeLogs(t *testing.T) {
 	// All these paths are relative to /var/log/
 	mandatoryLogs := []string{
-		"kube-proxy/kube-proxy.exe.INFO",
+		"kube-proxy/kube-proxy.log",
 		"hybrid-overlay/hybrid-overlay.log",
 		"kubelet/kubelet.log",
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
 	}
-	optionalLogs := []string{
-		"kube-proxy/kube-proxy.exe.ERROR",
-		"kube-proxy/kube-proxy.exe.WARNING",
-	}
-
 	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
 	for _, node := range gc.allNodes() {
 		nodeDir := filepath.Join(nodeArtifacts, node.Name)
@@ -48,18 +43,6 @@ func testNodeLogs(t *testing.T) {
 					return true, nil
 				})
 				assert.NoError(t, err)
-			})
-		}
-		// Grab the optional logs for debugging purposes
-		for _, file := range optionalLogs {
-			// These logs aren't guaranteed to exist, so its better to ignore any error
-			_ = wait.PollImmediate(retry.Interval, retry.ResourceChangeTimeout, func() (bool, error) {
-				err := retrieveLog(node.GetName(), file, nodeDir)
-				if err != nil {
-					log.Printf("unable to retrieve log %s from node %s: %s", file, node.GetName(), err)
-					return false, nil
-				}
-				return true, nil
 			})
 		}
 	}


### PR DESCRIPTION
- Replace the usage of deprecated klog flags like --log-dir and --logstostderr with the kube-log-runner invocation to direct logs to a single log file.
- [submodule][kube-proxy] Update to 9500d080756 
- [build] Update kube-proxy version to v1.26.0+9500d08 