### PR TITLE
WINC-838: Add OS field to pod spec in Windows Server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ It is recommended to use images from public registries or pre-pull the images in
 ### Trunk port
 WMCO does not support adding Windows nodes to a cluster through a trunk port. The only supported networking setup for adding Windows nodes is through an access port carrying the VLAN traffic.
 
+## Running Windows workloads
+Be sure to set the [OS field in the Pod spec](https://kubernetes.io/docs/concepts/workloads/pods/#pod-os) to Windows
+when deploying Windows workloads. This field is used to authoritatively identify the pod OS for validation. 
+In OpenShift, it is used when enforcing OS-specific pod security standards.
+
 ## Development
 
 See [HACKING.md](docs/HACKING.md).

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -202,6 +202,7 @@ func (tc *testContext) deployNOOPDaemonSet() (*apps.DaemonSet, error) {
 					Labels: map[string]string{"name": "noop-ds"},
 				},
 				Spec: core.PodSpec{
+					OS:          &core.PodOS{Name: core.Windows},
 					Tolerations: []core.Toleration{{Key: "os", Value: "Windows", Effect: "NoSchedule"}},
 					Containers: []core.Container{{
 						Name:    "sleep",

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -491,6 +491,9 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 				},
 				Spec: v1.PodSpec{
 					Affinity: affinity,
+					OS: &v1.PodOS{
+						Name: v1.Windows,
+					},
 					Tolerations: []v1.Toleration{
 						{
 							Key:    "os",

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -333,6 +333,7 @@ func (tc *testContext) runJob(name string, command []string) (string, error) {
 		Spec: batch.JobSpec{
 			Template: core.PodTemplateSpec{
 				Spec: core.PodSpec{
+					OS:                 &core.PodOS{Name: core.Linux},
 					HostNetwork:        true,
 					RestartPolicy:      core.RestartPolicyNever,
 					ServiceAccountName: tc.workloadNamespace,


### PR DESCRIPTION
This PR adds the OS field in the pod specification for the
Windows Server deployment used in the network test. This ensures that
Windows pods can be identified authoritatively at admission time. As of
now, the SCC Admission Plugin does not perform any validation for Windows
pods, it ignores them. See to https://github.com/openshift/apiserver-library-go/pull/82

Fixes a CI issue introduced by https://github.com/openshift/kubernetes/pull/1290
where SCC Admission Plugin defaults the `runAsNonRoot` with value `true`.