### PR TITLE
[release-4.12] OCPBUGS-7843:  [build] Fix containerd version reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ WMCO_VERSION ?= 7.1.0
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.25.4+18eadca
 KUBE-PROXY_GIT_VERSION=v1.25.1+72939b9
+CONTAINERD_GIT_VERSION=v1.6.16-3+feedbee
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -224,3 +225,7 @@ kubelet:
 .PHONY: kube-proxy
 kube-proxy:
 	KUBE_GIT_VERSION=$(KUBE-PROXY_GIT_VERSION) KUBE_BUILD_PLATFORMS=windows/amd64 make -C kube-proxy WHAT=cmd/kube-proxy
+
+.PHONY : containerd
+containerd:
+	GOOS=windows VERSION=$(CONTAINERD_GIT_VERSION) make -C containerd bin/containerd.exe

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ WMCO_VERSION ?= 7.1.0
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.25.4+18eadca
 KUBE-PROXY_GIT_VERSION=v1.25.1+72939b9
-CONTAINERD_GIT_VERSION=v1.6.16-3+feedbee
+CONTAINERD_GIT_VERSION=v1.6.16-3-g2d3127cbb
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,9 +25,10 @@ COPY windows_exporter/ .
 RUN GOOS=windows ./promu build -v
 
 # Build containerd
-WORKDIR /build/windows-machine-config-operator/containerd/
-COPY containerd/ .
-RUN GOOS=windows make
+WORKDIR /build/windows-machine-config-operator/
+COPY containerd/ containerd/
+COPY Makefile Makefile
+RUN make containerd
 
 # Build containerd shim
 WORKDIR /build/windows-machine-config-operator/hcsshim/
@@ -37,7 +38,6 @@ RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 # Build kubelet
 WORKDIR /build/windows-machine-config-operator/
 COPY kubelet/ kubelet/
-COPY Makefile Makefile
 RUN make kubelet
 
 # Build kube-proxy

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -25,9 +25,10 @@ COPY windows_exporter/ .
 RUN GOOS=windows ./promu build -v
 
 # Build containerd
-WORKDIR /build/windows-machine-config-operator/containerd/
-COPY containerd/ .
-RUN GOOS=windows make
+WORKDIR /build/windows-machine-config-operator/
+COPY containerd/ containerd/
+COPY Makefile Makefile
+RUN make containerd
 
 # Build containerd shim
 WORKDIR /build/windows-machine-config-operator/hcsshim/
@@ -37,7 +38,6 @@ RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 # Build kubelet
 WORKDIR /build/windows-machine-config-operator/
 COPY kubelet/ kubelet/
-COPY Makefile Makefile
 RUN make kubelet
 
 # Build kube-proxy

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -33,9 +33,10 @@ COPY windows_exporter/ .
 RUN GOOS=windows ./promu build -v
 
 # Build containerd
-WORKDIR /build/windows-machine-config-operator/containerd/
-COPY containerd/ .
-RUN GOOS=windows make
+WORKDIR /build/windows-machine-config-operator/
+COPY containerd/ containerd/
+COPY Makefile Makefile
+RUN make containerd
 
 # Build containerd shim
 WORKDIR /build/windows-machine-config-operator/hcsshim/
@@ -45,7 +46,6 @@ RUN GOOS=windows go build ./cmd/containerd-shim-runhcs-v1
 # Build kubelet
 WORKDIR /build/windows-machine-config-operator/
 COPY kubelet/ kubelet/
-COPY Makefile Makefile
 RUN make kubelet
 
 # Build kube-proxy


### PR DESCRIPTION


Containerd Makefile uses VERSION env var to set the containerd version if it is not already set. When we run the make command in WMCO Dockerfile, the VERSION var is already set to the golang image version of the base image eg: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12.
This is the root cause of containerd Makefile not setting the version and we see containerd 1.19 as the misreported version in 4.12 and 1.18 in 4.11 cluster.
One way to solve this issue is unsetting the env var in Dockerfile however it may have other unknown implications with versions. Adding a containerd Makefile target instead that will set the value of the ENV var within context.

(manually cherry-pick from #1423)
