### PR TITLE
Revert "[release-4.12] WINC-949: Rename powershellVariablesInCommand"

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -335,7 +335,7 @@ func (sc *ServiceController) expectedServiceCommand(expected servicescm.Service)
 			return "", err
 		}
 	}
-	if len(expected.PowershellPreScripts) > 0 {
+	if len(expected.PowershellVariablesInCommand) > 0 {
 		psVars, err = sc.resolvePowershellVariables(expected)
 		if err != nil {
 			return "", err
@@ -417,14 +417,12 @@ func (sc *ServiceController) resolveNodeVariables(svc servicescm.Service) (map[s
 // replace the variable with
 func (sc *ServiceController) resolvePowershellVariables(svc servicescm.Service) (map[string]string, error) {
 	vars := make(map[string]string)
-	for _, script := range svc.PowershellPreScripts {
-		out, err := sc.psCmdRunner.Run(script.Path)
+	for _, psVar := range svc.PowershellVariablesInCommand {
+		out, err := sc.psCmdRunner.Run(psVar.Path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not resolve PowerShell variable %s", script.VariableName)
+			return nil, errors.Wrapf(err, "could not resolve PowerShell variable %s", psVar.Name)
 		}
-		if script.VariableName != "" {
-			vars[script.VariableName] = strings.TrimSpace(out)
-		}
+		vars[psVar.Name] = strings.TrimSpace(out)
 	}
 	return vars, nil
 }

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -150,11 +150,11 @@ func TestReconcileService(t *testing.T) {
 					State: svc.Running,
 				}),
 			expectedService: servicescm.Service{
-				Name:                   "fakeservice",
-				Command:                "fakeservice",
-				NodeVariablesInCommand: nil,
-				PowershellPreScripts:   nil,
-				Dependencies:           nil,
+				Name:                         "fakeservice",
+				Command:                      "fakeservice",
+				NodeVariablesInCommand:       nil,
+				PowershellVariablesInCommand: nil,
+				Dependencies:                 nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice",
@@ -175,11 +175,11 @@ func TestReconcileService(t *testing.T) {
 					State: svc.Running,
 				}),
 			expectedService: servicescm.Service{
-				Name:                   "fakeservice",
-				Command:                "fakeservice",
-				NodeVariablesInCommand: nil,
-				PowershellPreScripts:   nil,
-				Dependencies:           nil,
+				Name:                         "fakeservice",
+				Command:                      "fakeservice",
+				NodeVariablesInCommand:       nil,
+				PowershellVariablesInCommand: nil,
+				Dependencies:                 nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice",
@@ -206,8 +206,8 @@ func TestReconcileService(t *testing.T) {
 					Name:               "NAME_REPLACE",
 					NodeObjectJsonPath: "{.metadata.name}",
 				}},
-				PowershellPreScripts: nil,
-				Dependencies:         nil,
+				PowershellVariablesInCommand: nil,
+				Dependencies:                 nil,
 			},
 			expectedServiceConfig: mgr.Config{
 				BinaryPathName: "fakeservice --node-name=node -v",
@@ -231,9 +231,9 @@ func TestReconcileService(t *testing.T) {
 				Name:                   "fakeservice",
 				Command:                "fakeservice --ip_example=CMD_REPLACE -v",
 				NodeVariablesInCommand: nil,
-				PowershellPreScripts: []servicescm.PowershellPreScript{{
-					VariableName: "CMD_REPLACE",
-					Path:         "c:\\k\\script.ps1",
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+					Name: "CMD_REPLACE",
+					Path: "c:\\k\\script.ps1",
 				}},
 				Dependencies: nil,
 			},
@@ -262,9 +262,9 @@ func TestReconcileService(t *testing.T) {
 					Name:               "NAME_REPLACE",
 					NodeObjectJsonPath: "{.metadata.name}",
 				}},
-				PowershellPreScripts: []servicescm.PowershellPreScript{{
-					VariableName: "CMD_REPLACE",
-					Path:         "c:\\k\\script.ps1",
+				PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+					Name: "CMD_REPLACE",
+					Path: "c:\\k\\script.ps1",
 				}},
 				Dependencies: nil,
 			},

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -33,13 +33,13 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 		return nil, errors.Wrap(err, "could not determine kubelet service configuration spec")
 	}
 	services := &[]servicescm.Service{{
-		Name:                   windows.WindowsExporterServiceName,
-		Command:                windows.WindowsExporterServiceCommand,
-		NodeVariablesInCommand: nil,
-		PowershellPreScripts:   nil,
-		Dependencies:           nil,
-		Bootstrap:              false,
-		Priority:               1,
+		Name:                         windows.WindowsExporterServiceName,
+		Command:                      windows.WindowsExporterServiceCommand,
+		NodeVariablesInCommand:       nil,
+		PowershellVariablesInCommand: nil,
+		Dependencies:                 nil,
+		Bootstrap:                    false,
+		Priority:                     1,
 	},
 		kubeletConfiguration,
 		hybridOverlayConfiguration(vxlanPort, debug),
@@ -65,10 +65,10 @@ func azureCloudNodeManagerConfiguration() servicescm.Service {
 			Name:               "NODE_NAME",
 			NodeObjectJsonPath: "{.metadata.name}",
 		}},
-		PowershellPreScripts: nil,
-		Dependencies:         nil,
-		Bootstrap:            false,
-		Priority:             2,
+		PowershellVariablesInCommand: nil,
+		Dependencies:                 nil,
+		Bootstrap:                    false,
+		Priority:                     2,
 	}
 }
 
@@ -96,10 +96,10 @@ func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service
 				NodeObjectJsonPath: "{.metadata.name}",
 			},
 		},
-		PowershellPreScripts: nil,
-		Dependencies:         []string{windows.KubeletServiceName},
-		Bootstrap:            false,
-		Priority:             1,
+		PowershellVariablesInCommand: nil,
+		Dependencies:                 []string{windows.KubeletServiceName},
+		Bootstrap:                    false,
+		Priority:                     1,
 	}
 }
 
@@ -125,9 +125,9 @@ func kubeProxyConfiguration(debug bool) servicescm.Service {
 				NodeObjectJsonPath: fmt.Sprintf("{.metadata.annotations.%s}", sanitizedSubnetAnnotation),
 			},
 		},
-		PowershellPreScripts: []servicescm.PowershellPreScript{{
-			VariableName: "ENDPOINT_IP",
-			Path:         windows.NetworkConfScriptPath,
+		PowershellVariablesInCommand: []servicescm.PowershellCmdArg{{
+			Name: "ENDPOINT_IP",
+			Path: windows.NetworkConfScriptPath,
 		}},
 		Dependencies: []string{windows.HybridOverlayServiceName},
 		Bootstrap:    false,
@@ -142,17 +142,17 @@ func getKubeletServiceConfiguration(argsFromIginition map[string]string, debug b
 	if err != nil {
 		return servicescm.Service{}, err
 	}
-	var preScripts []servicescm.PowershellPreScript
+	var powershellVars []servicescm.PowershellCmdArg
 
 	hostnameOverrideCmd := getHostnameCmd(platform)
 	if hostnameOverrideCmd != "" {
 		hostnameOverrideArg := "--hostname-override=" + hostnameOverrideVar
-		hostnameOverridePowershellVar := servicescm.PowershellPreScript{
-			VariableName: hostnameOverrideVar,
-			Path:         hostnameOverrideCmd,
+		hostnameOverridePowershellVar := servicescm.PowershellCmdArg{
+			Name: hostnameOverrideVar,
+			Path: hostnameOverrideCmd,
 		}
 		kubeletArgs = append(kubeletArgs, hostnameOverrideArg)
-		preScripts = append(preScripts, hostnameOverridePowershellVar)
+		powershellVars = append(powershellVars, hostnameOverridePowershellVar)
 	}
 
 	kubeletServiceCmd := windows.KubeletPath
@@ -164,13 +164,13 @@ func getKubeletServiceConfiguration(argsFromIginition map[string]string, debug b
 		kubeletServiceCmd = fmt.Sprintf("%s --node-ip=%s", kubeletServiceCmd, NodeIPVar)
 	}
 	return servicescm.Service{
-		Name:                   windows.KubeletServiceName,
-		Command:                kubeletServiceCmd,
-		Priority:               0,
-		Bootstrap:              true,
-		Dependencies:           []string{windows.ContainerdServiceName},
-		PowershellPreScripts:   preScripts,
-		NodeVariablesInCommand: nil,
+		Name:                         windows.KubeletServiceName,
+		Command:                      kubeletServiceCmd,
+		Priority:                     0,
+		Bootstrap:                    true,
+		Dependencies:                 []string{windows.ContainerdServiceName},
+		PowershellVariablesInCommand: powershellVars,
+		NodeVariablesInCommand:       nil,
 	}, nil
 }
 

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -47,12 +47,11 @@ type NodeCmdArg struct {
 	NodeObjectJsonPath string `json:"nodeObjectJsonPath"`
 }
 
-// PowershellPreScript describes a PowerShell script to be ran and an optional variable to be populated
-type PowershellPreScript struct {
-	// VariableName is the name of a variable which should be replaced by the output of the script. An empty value will
-	// cause no variable replacement to occur, but the script will still be ran.
-	VariableName string `json:"variableName,omitempty"`
-	// Path is the location of a PowerShell script to be ran
+// PowershellCmdArg describes a PowerShell variable and how its value can be populated
+type PowershellCmdArg struct {
+	// Name is the variable name as it appears in commands
+	Name string `json:"name"`
+	// Path is the location of a PowerShell script whose output is the value of the variable
 	Path string `json:"path"`
 }
 
@@ -61,13 +60,13 @@ type Service struct {
 	// Name is the name of the Windows service
 	Name string `json:"name"`
 	// Command is the command that will launch the Windows service. This could potentially include strings whose values
-	// will be derived from NodeVariablesInCommand and PowershellPreScripts.
+	// will be derived from NodeVariablesInCommand and PowershellVariablesInCommand.
 	// Before the command is run on an instance, all node and PowerShell variables will be replaced by their values
 	Command string `json:"path"`
 	// NodeVariablesInCommand holds all variables in the service command whose values are sourced from a node object
 	NodeVariablesInCommand []NodeCmdArg `json:"nodeVariablesInCommand,omitempty"`
-	// PowershellPreScripts is a list of PowerShell scripts which must run successfully before the service is started
-	PowershellPreScripts []PowershellPreScript `json:"powershellPreScripts,omitempty"`
+	// PowershellVariablesInCommand holds all variables in the command whose values are sourced from a PowerShell script
+	PowershellVariablesInCommand []PowershellCmdArg `json:"powershellVariablesInCommand,omitempty"`
 	// Dependencies is a list of service names that this service is dependent on
 	Dependencies []string `json:"dependencies,omitempty"`
 	// Bootstrap is a boolean flag indicating whether this service should be handled as part of node bootstrapping

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -77,9 +77,9 @@ func TestGenerate(t *testing.T) {
 				Name:               "NAME_VAR",
 				NodeObjectJsonPath: "{.metadata.name}",
 			}},
-			PowershellPreScripts: []PowershellPreScript{{
-				VariableName: "PS_VAR",
-				Path:         "C:\\k\\test-path.ps1",
+			PowershellVariablesInCommand: []PowershellCmdArg{{
+				Name: "PS_VAR",
+				Path: "C:\\k\\test-path.ps1",
 			}},
 			Dependencies: []string{"kubelet"},
 			Bootstrap:    false,
@@ -196,10 +196,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -228,10 +228,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -287,10 +287,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{"test-controller-service", "test-controller-service-2"},
@@ -320,10 +320,10 @@ func TestValidateDependencies(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{"test-controller-service"},
@@ -458,10 +458,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -491,10 +491,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -524,10 +524,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -557,10 +557,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},
@@ -590,10 +590,10 @@ func TestValidatePriorities(t *testing.T) {
 				{
 					Name:    "new-bootstrap-service",
 					Command: "C:\\new-service --variable-arg2=NETWORK_IP",
-					PowershellPreScripts: []PowershellPreScript{
+					PowershellVariablesInCommand: []PowershellCmdArg{
 						{
-							VariableName: "NETWORK_IP",
-							Path:         "C:\\k\\scripts\\get_net_ip.ps",
+							Name: "NETWORK_IP",
+							Path: "C:\\k\\scripts\\get_net_ip.ps",
 						},
 					},
 					Dependencies: []string{},


### PR DESCRIPTION
Reverts openshift/windows-machine-config-operator#1356

Reverting as part of the effort to get WICD work into 4.12: https://issues.redhat.com/browse/WINC-978