### PR TITLE
[release-4.11] [build] Update containerd version to v1.6.19-4-g37febd202

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ WMCO_VERSION ?= 6.0.1
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.24.6+deccab3
 KUBE-PROXY_GIT_VERSION=v1.24.0+041f707
-CONTAINERD_GIT_VERSION=v1.6.16-3-g2d3127cbb
+CONTAINERD_GIT_VERSION=v1.6.19-4-g37febd202
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")


### PR DESCRIPTION
This commit was generated using hack/update_submodules.sh

The submodule already points to version 1.6.19. The version update was missing from the Makefile.