### PR TITLE
[release-4.9] submodule update 03/16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WMCO_VERSION ?= 4.0.2
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
-KUBELET_GIT_VERSION=v1.22.15+c763d11
+KUBELET_GIT_VERSION=v1.22.15+39688a2
 KUBE-PROXY_GIT_VERSION=v1.22.0+0032072
 
 # CHANNELS define the bundle channels used in the bundle.


### PR DESCRIPTION
- [[submodule][kubelet] Update to 39688a260ac](https://github.com/openshift/windows-machine-config-operator/commit/0348a3b5baece216a3a2d77efcbd80c4d853c803)
- [[build] Update kubelet version to v1.22.15+39688a2](https://github.com/openshift/windows-machine-config-operator/commit/a93d95d08b2c83b5c7cb6de9ce355671c568a53b)