### PR TITLE
[bundle] Fix metadata version annotation

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v2.0.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  com.redhat.openshift.versions: "=v4.11"
+  com.redhat.openshift.versions: "=v4.13"
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1


### PR DESCRIPTION
This commit sets the proper OCP version in the bundle metadata so the
operator is only included in catalogs targeting the compatible OCP version.

Follow-up to https://github.com/openshift/windows-machine-config-operator/pull/1349/