### PR TITLE
Use ClusterFirstWithHostNet DNS policy

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -399,6 +399,7 @@ spec:
                 imagePullPolicy: IfNotPresent
                 name: manager
                 resources: {}
+              dnsPolicy: ClusterFirstWithHostNet
               hostNetwork: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         name: windows-machine-config-operator
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       priorityClassName: system-cluster-critical
       containers:


### PR DESCRIPTION
As WMCO is ran with host network privileges, its DNS policy is currently
using the DNS servers of the Node it is running on.

Instead, the policy should be set to `ClusterFirstWithHostNet`. Without
this it will not be able to resolve any addresses defined within the
cluster's DNS, such as internal services. With this policy, cluster
defined services can be resolved, while also using the cluster
configured upstream name server for any names that are not within the
cluster.