### PR TITLE
Revert "[test] Capture stderr on oc adm node-logs failures"

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -63,12 +63,7 @@ func retrieveLog(nodeName, srcPath, destDir string) error {
 	cmd := exec.Command("oc", "adm", "node-logs", "--path="+srcPath, nodeName)
 	out, err := cmd.Output()
 	if err != nil {
-		var exitError *exec.ExitError
-		stderr := ""
-		if errors.As(err, exitError) {
-			stderr = string(exitError.Stderr)
-		}
-		return fmt.Errorf("oc adm node-logs failed with exit code %s and output: %s: %s", err, string(out), stderr)
+		return errors.Wrapf(err, "oc adm node-logs failed with output: %s", string(out))
 	}
 	// Save log files to the artifact directory
 	splitPath := strings.Split(srcPath, "/")


### PR DESCRIPTION
This reverts commit 0a5bad55ae625df7e3995e893c9e63348ff87c63.

This is causing a panic due to not initializing a pointer.