### PR TITLE
[release-4.10] Assert that Windows pods use cluster DNS

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -150,6 +150,17 @@ func testEastWestNetworking(t *testing.T) {
 					assert.NoError(t, err, "could not curl the Windows server")
 				})
 			}
+			t.Run("service DNS resolution", func(t *testing.T) {
+				serviceDNS := fmt.Sprintf("%s.%s.svc.cluster.local", intermediarySVC.GetName(),
+					intermediarySVC.GetNamespace())
+				nodeAffinity, err := getAffinityForNode(&node)
+				require.NoError(t, err)
+				curler, err := testCtx.createWinCurlerJob(strings.ToLower(node.Status.NodeInfo.MachineID)+"-dns-test",
+					serviceDNS, nodeAffinity)
+				require.NoError(t, err)
+				defer testCtx.deleteJob(curler.GetName())
+				assert.NoError(t, testCtx.waitUntilJobSucceeds(curler.GetName()))
+			})
 		})
 	}
 }


### PR DESCRIPTION
Removes defunct DNS test and replaces it with a test which ensures that pods can resolve cluster services through DNS.

(cherry picked from commit 38e374f6274b7a8c400eb3c816e3764b6c48e0e4)