### PR TITLE
[test] Add framework for storage testing

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -101,7 +101,8 @@ func testEastWestNetworking(t *testing.T) {
 			// So trying multiple times
 			var winServerDeployment *appsv1.Deployment
 			for i := 0; i < deploymentRetries; i++ {
-				winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver-"+strings.ToLower(node.Status.NodeInfo.MachineID), affinity)
+				winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver-"+strings.ToLower(
+					node.Status.NodeInfo.MachineID), affinity, nil)
 				if err == nil {
 					break
 				}
@@ -243,8 +244,15 @@ func testNorthSouthNetworking(t *testing.T) {
 	// Deploy a webserver pod on the new node. This is prone to timing out due to having to pull the Windows image
 	// So trying multiple times
 	var winServerDeployment *appsv1.Deployment
+	// If possible on this platform, add a PVC to the pod to ensure storage is working
+	var pvcVolumeSource *v1.PersistentVolumeClaimVolumeSource
+	if testCtx.CloudProvider.StorageSupport() {
+		pvc, err := testCtx.CloudProvider.CreatePVC(testCtx.client.K8s)
+		require.NoError(t, err)
+		pvcVolumeSource = &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
+	}
 	for i := 0; i < deploymentRetries; i++ {
-		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver", nil)
+		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver", nil, pvcVolumeSource)
 		if err == nil {
 			break
 		}
@@ -405,7 +413,8 @@ func (tc *testContext) deleteNamespace(name string) error {
 }
 
 // deployWindowsWebServer creates a deployment with a single Windows Server pod, listening on port 80
-func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity) (*appsv1.Deployment, error) {
+func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity,
+	pvcToMount *v1.PersistentVolumeClaimVolumeSource) (*appsv1.Deployment, error) {
 	// This will run a Server on the container, which can be reached with a GET request
 	winServerCommand := []string{powerShellExe, "-command",
 		"$listener = New-Object System.Net.HttpListener; $listener.Prefixes.Add('http://*:80/'); $listener.Start(); " +
@@ -414,7 +423,7 @@ func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity
 			"$content='<html><body><H1>Windows Container Web Server</H1></body></html>'; " +
 			"$buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; " +
 			"$response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };"}
-	winServerDeployment, err := tc.createWindowsServerDeployment(name, winServerCommand, affinity)
+	winServerDeployment, err := tc.createWindowsServerDeployment(name, winServerCommand, affinity, pvcToMount)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not create Windows deployment")
 	}
@@ -461,13 +470,29 @@ func (tc *testContext) getWindowsServerContainerImage() string {
 }
 
 // createWindowsServerDeployment creates a deployment with a Windows Server container. If affinity is nil then the
-// number of replicas will be set to 3 to allow for network testing across nodes.
-func (tc *testContext) createWindowsServerDeployment(name string, command []string, affinity *v1.Affinity) (*appsv1.Deployment, error) {
+// number of replicas will be set to 3 to allow for network testing across nodes. If pvcToMount is set, the pod will
+// mount the given pvc as a volume
+func (tc *testContext) createWindowsServerDeployment(name string, command []string, affinity *v1.Affinity,
+	pvcToMount *v1.PersistentVolumeClaimVolumeSource) (*appsv1.Deployment, error) {
 	deploymentsClient := tc.client.K8s.AppsV1().Deployments(tc.workloadNamespace)
 	replicaCount := int32(1)
 	// affinity being nil is a hint that the caller does not care which nodes the pods are deployed to
 	if affinity == nil {
 		replicaCount = int32(3)
+	}
+	var volumes []v1.Volume
+	var volumeMounts []v1.VolumeMount
+	if pvcToMount != nil {
+		volumes = append(volumes, v1.Volume{
+			Name: pvcToMount.ClaimName,
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: pvcToMount,
+			},
+		})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      pvcToMount.ClaimName,
+			MountPath: "C:\\mnt\\storage",
+		})
 	}
 	windowsServerImage := tc.getWindowsServerContainerImage()
 	containerUserName := "ContainerAdministrator"
@@ -522,9 +547,11 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 									ContainerPort: 80,
 								},
 							},
+							VolumeMounts: volumeMounts,
 						},
 					},
 					NodeSelector: map[string]string{"kubernetes.io/os": "windows"},
+					Volumes:      volumes,
 				},
 			},
 		},

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
@@ -142,4 +143,12 @@ func (a *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 
 func (a *Provider) GetType() config.PlatformType {
 	return config.AWSPlatformType
+}
+
+func (a *Provider) StorageSupport() bool {
+	return false
+}
+
+func (a *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on AWS")
 }

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -9,6 +9,7 @@ import (
 	mapi "github.com/openshift/api/machine/v1beta1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
@@ -114,4 +115,12 @@ func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 
 func (p *Provider) GetType() config.PlatformType {
 	return config.AzurePlatformType
+}
+
+func (p *Provider) StorageSupport() bool {
+	return false
+}
+
+func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on azure")
 }

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -6,6 +6,8 @@ import (
 	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	client "k8s.io/client-go/kubernetes"
 
 	oc "github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	awsProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/aws"
@@ -19,6 +21,10 @@ type CloudProvider interface {
 	GenerateMachineSet(bool, int32) (*mapi.MachineSet, error)
 	// GetType returns the cloud provider type ex: AWS, Azure etc
 	GetType() config.PlatformType
+	// StorageSupport indicates if we support Windows storage on this provider
+	StorageSupport() bool
+	// CreatePVC creates a new PersistentVolumeClaim that can be used by a workload
+	CreatePVC(p client.Interface) (*core.PersistentVolumeClaim, error)
 }
 
 // NewCloudProvider returns a CloudProvider interface or an error

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
@@ -93,4 +94,12 @@ func (p *Provider) newGCPProviderSpec() (*mapi.GCPMachineProviderSpec, error) {
 // GetType returns the GCP platform type
 func (p *Provider) GetType() config.PlatformType {
 	return config.GCPPlatformType
+}
+
+func (p *Provider) StorageSupport() bool {
+	return false
+}
+
+func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on gcp")
 }

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -1,10 +1,14 @@
 package none
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/pkg/errors"
+	core "k8s.io/api/core/v1"
+	client "k8s.io/client-go/kubernetes"
+
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 )
 
@@ -28,4 +32,12 @@ func (p *Provider) GenerateMachineSet(_ bool, replicas int32) (*mapi.MachineSet,
 // GetType returns the platform type for platform=none
 func (p *Provider) GetType() config.PlatformType {
 	return config.NonePlatformType
+}
+
+func (p *Provider) StorageSupport() bool {
+	return false
+}
+
+func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on platform none")
 }

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -3,15 +3,16 @@ package vsphere
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 
-	"github.com/pkg/errors"
-
 	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
@@ -130,4 +131,12 @@ func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*ma
 
 func (p *Provider) GetType() config.PlatformType {
 	return config.VSpherePlatformType
+}
+
+func (p *Provider) StorageSupport() bool {
+	return false
+}
+
+func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+	return nil, fmt.Errorf("storage not supported on vSphere")
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -179,7 +179,7 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 // returns a tearDown func that must be executed to cleanup resources
 func (tc *testContext) deployWindowsWorkloadAndTester() (func(), error) {
 	// create a Windows Webserver deployment
-	deployment, err := tc.deployWindowsWebServer("win-webserver", nil)
+	deployment, err := tc.deployWindowsWebServer("win-webserver", nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating Windows Webserver deployment for upgrade test")
 	}


### PR DESCRIPTION
Adds required methods to ClusterProvider, and calls them to add a persistent storage volume to the Windows webserver pods created during the north south tests.

Creating a PVC is currently disabled on all providers, but as functionality is added, it can be enabled for each provider individually.