### PR TITLE
OCPBUGS-10437: Fix CNI conf

### DIFF
--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -80,49 +80,49 @@ Import-Module -DisableNameChecking HNS_MODULE_PATH
 
 $cni_template=@'
 {
-    "CniVersion":"0.2.0",
-    "Name":"HNS_NETWORK",
-    "Type":"win-overlay",
+    "cniVersion":"0.2.0",
+    "name":"HNS_NETWORK",
+    "type":"win-overlay",
     "apiVersion": 2,
-    "Capabilities":{
+    "capabilities":{
         "portMappings": true,
-        "Dns":true
+        "dns":true
     },
-    "Ipam":{
-        "Type":"host-local",
-        "Subnet":"ovn_host_subnet"
+    "ipam":{
+        "type":"host-local",
+        "subnet":"ovn_host_subnet"
     },
-    "Policies":[
+    "policies":[
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "OutBoundNAT",
-            "Settings": {
-                "ExceptionList": [
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "OutBoundNAT",
+            "settings": {
+                "exceptionList": [
                 "SERVICE_NETWORK_CIDR"
                 ],
-                "DestinationPrefix": "",
-                "NeedEncap": false
+                "destinationPrefix": "",
+                "needEncap": false
             }
         }
     },
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "SDNROUTE",
-            "Settings": {
-                "ExceptionList": [],
-                "DestinationPrefix": "SERVICE_NETWORK_CIDR",
-                "NeedEncap": true
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "SDNRoute",
+            "settings": {
+                "exceptionList": [],
+                "destinationPrefix": "SERVICE_NETWORK_CIDR",
+                "needEncap": true
             }
         }
     },
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "ProviderAddress",
-            "Settings": {
-                "ProviderAddress": "provider_address"
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "ProviderAddress",
+            "settings": {
+                "providerAddress": "provider_address"
             }
         }
     }

--- a/pkg/nodeconfig/payload/payload_test.go
+++ b/pkg/nodeconfig/payload/payload_test.go
@@ -14,49 +14,49 @@ Import-Module -DisableNameChecking c:\k\hns.psm1
 
 $cni_template=@'
 {
-    "CniVersion":"0.2.0",
-    "Name":"OVNKubernetesHNSNetwork",
-    "Type":"win-overlay",
+    "cniVersion":"0.2.0",
+    "name":"OVNKubernetesHNSNetwork",
+    "type":"win-overlay",
     "apiVersion": 2,
-    "Capabilities":{
+    "capabilities":{
         "portMappings": true,
-        "Dns":true
+        "dns":true
     },
-    "Ipam":{
-        "Type":"host-local",
-        "Subnet":"ovn_host_subnet"
+    "ipam":{
+        "type":"host-local",
+        "subnet":"ovn_host_subnet"
     },
-    "Policies":[
+    "policies":[
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "OutBoundNAT",
-            "Settings": {
-                "ExceptionList": [
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "OutBoundNAT",
+            "settings": {
+                "exceptionList": [
                 "10.0.0.1/32"
                 ],
-                "DestinationPrefix": "",
-                "NeedEncap": false
+                "destinationPrefix": "",
+                "needEncap": false
             }
         }
     },
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "SDNROUTE",
-            "Settings": {
-                "ExceptionList": [],
-                "DestinationPrefix": "10.0.0.1/32",
-                "NeedEncap": true
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "SDNRoute",
+            "settings": {
+                "exceptionList": [],
+                "destinationPrefix": "10.0.0.1/32",
+                "needEncap": true
             }
         }
     },
     {
-        "Name": "EndpointPolicy",
-        "Value": {
-            "Type": "ProviderAddress",
-            "Settings": {
-                "ProviderAddress": "provider_address"
+        "name": "EndpointPolicy",
+        "value": {
+            "type": "ProviderAddress",
+            "settings": {
+                "providerAddress": "provider_address"
             }
         }
     }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -150,6 +150,17 @@ func testEastWestNetworking(t *testing.T) {
 					assert.NoError(t, err, "could not curl the Windows server")
 				})
 			}
+			t.Run("service DNS resolution", func(t *testing.T) {
+				serviceDNS := fmt.Sprintf("%s.%s.svc.cluster.local", intermediarySVC.GetName(),
+					intermediarySVC.GetNamespace())
+				nodeAffinity, err := getAffinityForNode(&node)
+				require.NoError(t, err)
+				curler, err := testCtx.createWinCurlerJob(strings.ToLower(node.Status.NodeInfo.MachineID)+"-dns-test",
+					serviceDNS, nodeAffinity)
+				require.NoError(t, err)
+				defer testCtx.deleteJob(curler.GetName())
+				assert.NoError(t, testCtx.waitUntilJobSucceeds(curler.GetName()))
+			})
 		})
 	}
 }


### PR DESCRIPTION
https://github.com/openshift/windows-machine-config-operator/commit/62dc2c3e8db93de37a3b557c52de7bb18d3bfd85 introduced creating a CNI config with PascalCase moving away from the camelCase that was used previously generated. Generated is the key word here as the old template used PascalCase but the generated config was camelCase. This commit fixes the issue by adhering to the CNI config [definition](https://www.cni.dev/plugins/current/main/win-overlay/) for the win-overlay plugin.