### PR TITLE
[test] Add namespace for PVC creation

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -247,8 +247,10 @@ func testNorthSouthNetworking(t *testing.T) {
 	// If possible on this platform, add a PVC to the pod to ensure storage is working
 	var pvcVolumeSource *v1.PersistentVolumeClaimVolumeSource
 	if testCtx.CloudProvider.StorageSupport() {
-		pvc, err := testCtx.CloudProvider.CreatePVC(testCtx.client.K8s)
+		pvc, err := testCtx.CloudProvider.CreatePVC(testCtx.client.K8s, testCtx.workloadNamespace)
 		require.NoError(t, err)
+		defer testCtx.client.K8s.CoreV1().PersistentVolumeClaims(testCtx.workloadNamespace).Delete(context.TODO(),
+			pvc.GetName(), metav1.DeleteOptions{})
 		pvcVolumeSource = &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
 	}
 	for i := 0; i < deploymentRetries; i++ {

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -149,6 +149,6 @@ func (a *Provider) StorageSupport() bool {
 	return false
 }
 
-func (a *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+func (a *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on AWS")
 }

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -121,6 +121,6 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on azure")
 }

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -23,8 +23,9 @@ type CloudProvider interface {
 	GetType() config.PlatformType
 	// StorageSupport indicates if we support Windows storage on this provider
 	StorageSupport() bool
-	// CreatePVC creates a new PersistentVolumeClaim that can be used by a workload
-	CreatePVC(p client.Interface) (*core.PersistentVolumeClaim, error)
+	// CreatePVC creates a new PersistentVolumeClaim that can be used by a workload. The PVC will be created with
+	// the given client, in the given namespace.
+	CreatePVC(client.Interface, string) (*core.PersistentVolumeClaim, error)
 }
 
 // NewCloudProvider returns a CloudProvider interface or an error

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -100,6 +100,6 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on gcp")
 }

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -38,6 +38,6 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on platform none")
 }

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -137,6 +137,6 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on vSphere")
 }


### PR DESCRIPTION
Adjusts the CreatePVC method to allow the namespace to be specified. Additionally cleans up PVCs when done with them.