### PR TITLE
WINC-1025: Enable CSI plugins on Windows nodes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,7 @@
 	path = cloud-provider-azure
 	url = https://github.com/openshift/cloud-provider-azure
 	branch = release-4.14
+[submodule "csi-proxy"]
+	path = csi-proxy
+	url = https://github.com/openshift/csi-proxy
+	branch = release-4.14

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -60,6 +60,11 @@ COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
+# Build csi-proxy
+WORKDIR /build/windows-machine-config-operator/csi-proxy
+COPY csi-proxy/ .
+RUN GOOS=windows make build
+
 WORKDIR /build/windows-machine-config-operator/
 # Copy files and directories needed to build the WMCO binary
 # Any new file added here should be reflected in `build/build.sh` if it dirties the git working tree.
@@ -135,6 +140,9 @@ WORKDIR /payload/cni/
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/host-local.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-bridge.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-overlay.exe .
+
+WORKDIR /payload/csi-proxy/
+COPY --from=build /build/windows-machine-config-operator/csi-proxy/bin/csi-proxy.exe .
 
 # Create directory for generated files with open permissions, this allows WMCO to write to this directory
 RUN mkdir /payload/generated

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -60,6 +60,11 @@ COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
+# Build csi-proxy
+WORKDIR /build/windows-machine-config-operator/csi-proxy
+COPY csi-proxy/ .
+RUN GOOS=windows make build
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL stage=base
 
@@ -90,3 +95,6 @@ WORKDIR /payload/cni/
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/host-local.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-bridge.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-overlay.exe .
+
+WORKDIR /payload/csi-proxy/
+COPY --from=build /build/windows-machine-config-operator/csi-proxy/bin/csi-proxy.exe .

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -68,6 +68,11 @@ COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
+# Build csi-proxy
+WORKDIR /build/windows-machine-config-operator/csi-proxy
+COPY csi-proxy/ .
+RUN GOOS=windows make build
+
 # Build WMCO
 WORKDIR /build/windows-machine-config-operator
 # Copy files and directories needed to build the WMCO binary
@@ -145,6 +150,9 @@ WORKDIR /payload/cni/
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/host-local.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-bridge.exe .
 COPY --from=build /build/windows-machine-config-operator/containernetworking-plugins/bin/win-overlay.exe .
+
+WORKDIR /payload/csi-proxy/
+COPY --from=build /build/windows-machine-config-operator/csi-proxy/bin/csi-proxy.exe .
 
 # Create directory for generated files with open permissions, this allows WMCO to write to this directory
 RUN mkdir /payload/generated

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -328,15 +328,16 @@ Find more information [here](custom-workload.md)
 
 This project contains git submodules for the following components:
 
+- cloud-provider-azure
+- containerd
+- containernetworking-plugins
+- csi-proxy
+- hcsshim
+- kube-proxy
 - kubernetes
 - ovn-kubernetes
-- containernetworking-plugins
 - promu
 - windows_exporter
-- containerd 
-- hcsshim 
-- kube-proxy 
-- cloud-provider-azure 
 
 To update the git submodules you can use the script hack/update_submodules.sh
 Use the help command for up to date instructions:

--- a/goio.yaml
+++ b/goio.yaml
@@ -10,6 +10,8 @@ excludes:
   - matchtype: path
     regexp: container*
   - matchtype: path
+    regexp: csi-proxy
+  - matchtype: path
     regexp: kube*
   - matchtype: path
     regexp: hcsshim

--- a/hack/update_submodules.sh
+++ b/hack/update_submodules.sh
@@ -92,7 +92,7 @@ function update_submodules_for_branch() {
     # Update the submodule to the latest remote commit
     git submodule update --remote $submodule
     generate_submodule_commit $submodule
-    if [ "$submodule" = "kubelet" ] || [ "$submodule" = "kube-proxy" ] || [ "$submodule" = "containerd" ]; then
+    if [ "$submodule" = "kubelet" ] || [ "$submodule" = "kube-proxy" ] || [ "$submodule" = "containerd" ] || [ "$submodule" = "csi-proxy" ]; then
       generate_version_commit "$submodule"
     fi
   done

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -59,6 +59,8 @@ const (
 	// HybridOverlayPath contains the path of the hybrid overlay binary. The container image should already have this
 	// binary mounted
 	HybridOverlayPath = payloadDirectory + HybridOverlayName
+	// CSIProxyPath contains the path of the csi-proxy executable. This should be mounted in the container image.
+	CSIProxyPath = payloadDirectory + "csi-proxy/csi-proxy.exe"
 	// WindowsExporterName is the name of the Windows metrics exporter executable
 	WindowsExporterName = "windows_exporter.exe"
 	// WindowsExporterPath contains the path of the windows_exporter binary. The container image should already have

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -44,6 +44,7 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 		kubeletConfiguration,
 		hybridOverlayConfiguration(vxlanPort, debug),
 		kubeProxyConfiguration(debug),
+		csiProxyConfiguration(),
 	}
 	if platform == config.AzurePlatformType && ccmEnabled {
 		*services = append(*services, azureCloudNodeManagerConfiguration())
@@ -154,6 +155,21 @@ func kubeProxyConfiguration(debug bool) servicescm.Service {
 		Dependencies: []string{windows.HybridOverlayServiceName},
 		Bootstrap:    false,
 		Priority:     3,
+	}
+}
+
+// csiProxyConfiguration returns the Service definition for csi-proxy
+func csiProxyConfiguration() servicescm.Service {
+	serviceCmd := fmt.Sprintf("%s -log_file=%s -logtostderr=false -windows-service", windows.CSIProxyPath,
+		windows.CSIProxyLog)
+	return servicescm.Service{
+		Name:                   "csi-proxy",
+		Command:                serviceCmd,
+		NodeVariablesInCommand: nil,
+		PowershellPreScripts:   nil,
+		Dependencies:           nil,
+		Bootstrap:              false,
+		Priority:               2,
 	}
 }
 

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -86,6 +86,12 @@ const (
 	KubeProxyLog = KubeProxyLogDir + "\\kube-proxy.log"
 	// KubeProxyPath is the location of the kube-proxy exe
 	KubeProxyPath = K8sDir + "\\kube-proxy.exe"
+	// CSIProxyPath is the location of the csi-proxy exe
+	CSIProxyPath = K8sDir + "\\csi-proxy.exe"
+	// csiProxyLogDir is the location of the csi-proxy log file
+	csiProxyLogDir = logDir + "\\csi-proxy"
+	// CSIProxyLog is the location of the csi-proxy log file
+	CSIProxyLog = csiProxyLogDir + "\\csi-proxy.log"
 	// HybridOverlayPath is the location of the hybrid-overlay-node exe
 	HybridOverlayPath = K8sDir + "\\hybrid-overlay-node.exe"
 	// HybridOverlayServiceName is the name of the hybrid-overlay-node Windows service
@@ -146,6 +152,7 @@ var (
 		CniConfDir,
 		logDir,
 		KubeletLogDir,
+		csiProxyLogDir,
 		KubeProxyLogDir,
 		wicdLogDir,
 		HybridOverlayLogDir,
@@ -174,6 +181,7 @@ func getFilesToTransfer() (map[*payload.FileInfo]string, error) {
 		payload.KubeletPath:                    K8sDir,
 		payload.AzureCloudNodeManagerPath:      K8sDir,
 		payload.KubeLogRunnerPath:              K8sDir,
+		payload.CSIProxyPath:                   K8sDir,
 		payload.ContainerdPath:                 ContainerdDir,
 		payload.HcsshimPath:                    ContainerdDir,
 		payload.ContainerdConfPath:             ContainerdDir,

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 
 	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	client "k8s.io/client-go/kubernetes"
 
@@ -17,7 +22,12 @@ import (
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
 )
 
-const defaultCredentialsSecretName = "vsphere-cloud-credentials"
+const (
+	defaultCredentialsSecretName = "vsphere-cloud-credentials"
+	storageClassName             = "ntfs"
+	windowsFSSName               = "win-internal-feature-states.csi.vsphere.vmware.com"
+	csiNamespace                 = "openshift-cluster-csi-drivers"
+)
 
 // Provider is a provider struct for testing vSphere
 type Provider struct {
@@ -133,9 +143,321 @@ func (p *Provider) GetType() config.PlatformType {
 }
 
 func (p *Provider) StorageSupport() bool {
-	return false
+	return true
 }
 
-func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
-	return nil, fmt.Errorf("storage not supported on vSphere")
+// CreatePVC creates a PVC for a dynamically provisioned volume
+func (p *Provider) CreatePVC(client client.Interface, namespace string) (*core.PersistentVolumeClaim, error) {
+	if err := p.ensureWindowsCSIDrivers(client); err != nil {
+		return nil, err
+	}
+	// Use a StorageClass to allow for dynamic volume provisioning
+	// https://docs.openshift.com/container-platform/4.12/storage/dynamic-provisioning.html#about_dynamic-provisioning
+	sc, err := p.ensureStorageClass(client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to ensure a usable StorageClass is created: %w", err)
+	}
+	pvcSpec := core.PersistentVolumeClaim{
+		ObjectMeta: meta.ObjectMeta{
+			GenerateName: storageClassName + "-",
+		},
+		Spec: core.PersistentVolumeClaimSpec{
+			AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+			Resources: core.ResourceRequirements{
+				Requests: core.ResourceList{core.ResourceStorage: resource.MustParse("2Gi")},
+			},
+			StorageClassName: &sc.Name,
+		},
+	}
+	return client.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), &pvcSpec, meta.CreateOptions{})
+}
+
+// ensureStorageClass ensures a usable vSphere NTFS storage class exists
+func (p *Provider) ensureStorageClass(client client.Interface) (*storage.StorageClass, error) {
+	sc, err := client.StorageV1().StorageClasses().Get(context.TODO(), storageClassName, meta.GetOptions{})
+	if err == nil {
+		return sc, nil
+	} else if !k8sapierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("error getting storage class '%s': %w", storageClassName, err)
+	}
+	volumeBinding := storage.VolumeBindingImmediate
+	reclaimPolicy := core.PersistentVolumeReclaimDelete
+	sc = &storage.StorageClass{
+		ObjectMeta: meta.ObjectMeta{
+			Name: storageClassName,
+		},
+		Provisioner:       "csi.vsphere.vmware.com",
+		Parameters:        map[string]string{"fstype": "ntfs"},
+		ReclaimPolicy:     &reclaimPolicy,
+		VolumeBindingMode: &volumeBinding,
+	}
+	return client.StorageV1().StorageClasses().Create(context.TODO(), sc, meta.CreateOptions{})
+}
+
+// ensureWindowsCSIDrivers ensures that the vSphere CSI drivers are deployed across Windows nodes
+func (p *Provider) ensureWindowsCSIDrivers(client client.Interface) error {
+	if err := p.ensureFSSConfigMap(client); err != nil {
+		return err
+	}
+	return p.ensureWindowsCSIDaemonSet(client)
+}
+
+// ensureFSSConfigMap creates a feature state switch ConfigMap for Windows Nodes. The FSS used by Linux nodes is
+// unusable as it does not set csi-windows-support to true
+func (p *Provider) ensureFSSConfigMap(client client.Interface) error {
+	fssCM := core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name: windowsFSSName,
+		},
+		Data: map[string]string{
+			"block-volume-snapshot":            "true",
+			"cnsmgr-suspend-create-volume":     "true",
+			"csi-auth-check":                   "true",
+			"csi-migration":                    "true",
+			"improved-csi-idempotency":         "true",
+			"improved-volume-topology":         "false",
+			"online-volume-extend":             "true",
+			"topology-preferential-datastores": "true",
+			"csi-windows-support":              "true",
+		},
+		BinaryData: nil,
+	}
+
+	// See if the ConfigMap already exists in the state we expect it to be in.
+	existingCM, err := client.CoreV1().ConfigMaps(csiNamespace).Get(context.TODO(), windowsFSSName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing FSS ConfigMap: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingCM.Data, fssCM.Data) {
+			// ConfigMap is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the ConfigMap as it has the wrong data.
+		err = client.CoreV1().ConfigMaps(csiNamespace).Delete(context.TODO(), windowsFSSName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing FSS ConfigMap: %w", err)
+		}
+	}
+	_, err = client.CoreV1().ConfigMaps(csiNamespace).Create(context.TODO(), &fssCM, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("could not create FSS ConfigMap: %w", err)
+	}
+	return nil
+}
+
+// ensureWindowsCSIDaemonSet deploys the Windows CSI driver DaemonSet if it doesn't already exist
+func (p *Provider) ensureWindowsCSIDaemonSet(client client.Interface) error {
+	dsName := "vmware-vsphere-csi-driver-node-windows"
+	directoryType := core.HostPathDirectory
+	directoryOrCreate := core.HostPathDirectoryOrCreate
+	ds := apps.DaemonSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name: dsName,
+		},
+		Spec: apps.DaemonSetSpec{
+			Selector: &meta.LabelSelector{MatchLabels: map[string]string{"app": dsName}},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{"app": dsName},
+				},
+				Spec: core.PodSpec{
+					PriorityClassName:  "system-node-critical",
+					NodeSelector:       map[string]string{core.LabelOSStable: "windows"},
+					ServiceAccountName: "vmware-vsphere-csi-driver-node-sa",
+					OS:                 &core.PodOS{Name: core.Windows},
+					Tolerations: []core.Toleration{
+						{
+							Key:    "os",
+							Value:  "Windows",
+							Effect: core.TaintEffectNoSchedule,
+						},
+					},
+					Containers: []core.Container{
+						{
+							Name:  "node-driver-registrar",
+							Image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0",
+							Args:  []string{"--v=5", "--csi-address=$(ADDRESS)", "-kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
+							Env: []core.EnvVar{
+								{
+									Name:  "ADDRESS",
+									Value: `unix://C:\\csi\\csi.sock`,
+								},
+								{
+									Name:  "DRIVER_REG_SOCK_PATH",
+									Value: `C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock`,
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									Name:      "plugin-dir",
+									MountPath: "/csi",
+								},
+								{
+									Name:      "registration-dir",
+									MountPath: "/registration",
+								},
+							},
+						},
+						{
+							Name:  "vsphere-csi-node",
+							Image: "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0",
+							Args:  []string{"--fss-name=" + windowsFSSName, "--fss-namespace=$(CSI_NAMESPACE)"},
+							Env: []core.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name:  "CSI_ENDPOINT",
+									Value: `unix://C:\\csi\\csi.sock`,
+								},
+								{
+									Name:  "MAX_VOLUMES_PER_NODE",
+									Value: "59",
+								},
+								{
+									Name:  "X_CSI_MODE",
+									Value: "node",
+								},
+								{
+									Name:  "X_CSI_SPEC_REQ_VALIDATION",
+									Value: "false",
+								},
+								{
+									Name:  "X_CSI_SPEC_DISABLE_LEN_CHECK",
+									Value: "true",
+								},
+								{
+									Name: "CSI_NAMESPACE",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.namespace",
+										},
+									},
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									Name:      "plugin-dir",
+									MountPath: "/csi",
+								},
+								{
+									Name:      "pod-mount-dir",
+									MountPath: "/var/lib/kubelet",
+								},
+								{
+									Name:      "csi-proxy-volume-v1",
+									MountPath: `\\.\pipe\csi-proxy-volume-v1`,
+								},
+								{
+									Name:      "csi-proxy-filesystem-v1",
+									MountPath: `\\.\pipe\csi-proxy-filesystem-v1`,
+								},
+								{
+									Name:      "csi-proxy-disk-v1",
+									MountPath: `\\.\pipe\csi-proxy-disk-v1`,
+								},
+								{
+									Name:      "csi-proxy-system-v1alpha1",
+									MountPath: `\\.\pipe\csi-proxy-system-v1alpha1`,
+								},
+							},
+						},
+					},
+					Volumes: []core.Volume{
+						{
+							Name: "registration-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet\plugins_registry\`,
+									Type: &directoryType,
+								},
+							},
+						},
+						{
+							Name: "plugin-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\`,
+									Type: &directoryOrCreate,
+								},
+							},
+						},
+						{
+							Name: "pod-mount-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet`,
+									Type: &directoryType,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-disk-v1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-disk-v1`,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-volume-v1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-volume-v1`,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-filesystem-v1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-filesystem-v1`,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-system-v1alpha1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-system-v1alpha1`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// See if the DaemonSet already exists in the state we expect it to be in.
+	existingDS, err := client.AppsV1().DaemonSets(csiNamespace).Get(context.TODO(), dsName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing Windows CSI DaemonSet: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingDS.Spec, ds.Spec) {
+			// DaemonSet is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the DaemonSet as it has the wrong spec.
+		err = client.AppsV1().DaemonSets(csiNamespace).Delete(context.TODO(), dsName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing Windows CSI DaemonSet: %w", err)
+
+		}
+	}
+	_, err = client.AppsV1().DaemonSets(csiNamespace).Create(context.TODO(), &ds, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating Windows CSI DaemonSet: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR allows the use of persistent storage on Windows nodes with CSI drivers.
It includes:
* Shipping csi-proxy in the payload
* Running csi-proxy as a Windows service
* Tests storage functionality using vSphere csi drivers