### PR TITLE
[test] fix panic introduced by 0a5bad5

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -65,7 +65,7 @@ func retrieveLog(nodeName, srcPath, destDir string) error {
 	if err != nil {
 		var exitError *exec.ExitError
 		stderr := ""
-		if errors.As(err, exitError) {
+		if errors.As(err, &exitError) {
 			stderr = string(exitError.Stderr)
 		}
 		return fmt.Errorf("oc adm node-logs failed with exit code %s and output: %s: %s", err, string(out), stderr)


### PR DESCRIPTION
The purpose of this commit is to fix the panic introduced by https://github.com/openshift/windows-machine-config-operator/commit/0a5bad55ae625df7e3995e893c9e63348ff87c63.

(changed link to reference the openshift repo)