### PR TITLE
OCPBUGS-11259: BYOH node upgrade failed with WICD RBAC permissions

### DIFF
--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -13,3 +13,4 @@ rules:
   - watch
   - get
   - patch
+  - delete

--- a/config/wicd/windows-instance-config-daemon-cluster-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role.yaml
@@ -12,3 +12,4 @@ rules:
       - watch
       - get
       - patch
+      - delete


### PR DESCRIPTION
This PR adds the WICD RBAC permissions to delete nodes. This is required to ensure a successful upgrade since WMCO version 7.0.1 has the WICD binary with the capability to delete nodes, this feature was removed in WMCO 8.0.0. This commit will ensure backward comaptibility during an upgrade from 7.0.1 to 8.0.0.

Ran:
`make bundle`

Fixes: OCPBUGS-11259