### PR TITLE
[test] Move storage testing to its own test

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -154,6 +154,8 @@ get_WMCO_logs
 if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  printf "\n####### Testing storage #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  go test ./test/e2e/... -run=TestWMCO/storage -v -timeout=10m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
   printf "\n####### Testing service reconciliation #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
 fi

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -255,17 +255,8 @@ func testNorthSouthNetworking(t *testing.T) {
 	// Deploy a webserver pod on the new node. This is prone to timing out due to having to pull the Windows image
 	// So trying multiple times
 	var winServerDeployment *appsv1.Deployment
-	// If possible on this platform, add a PVC to the pod to ensure storage is working
-	var pvcVolumeSource *v1.PersistentVolumeClaimVolumeSource
-	if testCtx.CloudProvider.StorageSupport() {
-		pvc, err := testCtx.CloudProvider.CreatePVC(testCtx.client.K8s, testCtx.workloadNamespace)
-		require.NoError(t, err)
-		defer testCtx.client.K8s.CoreV1().PersistentVolumeClaims(testCtx.workloadNamespace).Delete(context.TODO(),
-			pvc.GetName(), metav1.DeleteOptions{})
-		pvcVolumeSource = &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
-	}
 	for i := 0; i < deploymentRetries; i++ {
-		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver", nil, pvcVolumeSource)
+		winServerDeployment, err = testCtx.deployWindowsWebServer("win-webserver", nil, nil)
 		if err == nil {
 			break
 		}

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testStorage tests that persistent volumes can be accessed by Windows pods
+func testStorage(t *testing.T) {
+	tc, err := NewTestContext()
+	require.NoError(t, err)
+	if !tc.StorageSupport() {
+		t.Skip("storage is not supported on this platform")
+	}
+	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
+	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
+	require.Greater(t, len(gc.allNodes()), 0, "test requires at least one Windows node to run")
+
+	// Create the PVC and choose the node the deployment will be scheduled on. This is necessary as ReadWriteOnly
+	// volumes can only be bound to a single node.
+	// https://docs.openshift.com/container-platform/4.12/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage
+	var pvcVolumeSource *core.PersistentVolumeClaimVolumeSource
+	pvc, err := tc.CloudProvider.CreatePVC(tc.client.K8s, tc.workloadNamespace)
+	require.NoError(t, err)
+	defer tc.client.K8s.CoreV1().PersistentVolumeClaims(tc.workloadNamespace).Delete(context.TODO(),
+		pvc.GetName(), meta.DeleteOptions{})
+	pvcVolumeSource = &core.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
+	affinity, err := getAffinityForNode(&gc.allNodes()[0])
+	require.NoError(t, err)
+
+	// The deployment will not come to ready if the volume is not able to be attached to the pod. If the deployment is
+	// successful, storage is working as expected.
+	winServerDeployment, err := tc.deployWindowsWebServer("win-webserver-storage-test", affinity, pvcVolumeSource)
+	assert.NoError(t, err)
+	if err == nil {
+		defer tc.deleteDeployment(winServerDeployment.GetName())
+	}
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -46,6 +46,7 @@ func TestWMCO(t *testing.T) {
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
 	t.Run("network", testNetwork)
+	t.Run("storage", testStorage)
 	t.Run("service reconciliation", testDependentServiceChanges)
 	t.Run("upgrade", upgradeTestSuite)
 	// The reconfigurationTestSuite must be run directly before the deletionTestSuite. This is because we do not


### PR DESCRIPTION
Instead of using the network tests to indirectly test storage, move it to a separate test. This ensures that neither test is compromised by the requirements of the other. As storage testing uses the same container image, this should not add much to the testing time, since no images need to be pulled.