### PR TITLE
WIP: [release-4.12][e2e][vSphere] Use IPv6-disabled VM template

### DIFF
--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -45,7 +45,7 @@ func (p *Provider) newVSphereMachineProviderSpec() (*mapi.VSphereMachineProvider
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2022-template"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-ipv6-disabled"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)


### PR DESCRIPTION
This PR is just to test the new golden image until we can get access to the IBM vCenter environment. 
The goal is to ensure Windows worker nodes are never assigned IPv6 addresses.