### PR TITLE
OCPBUGS-11306: [test] Use IPv6 disabled template for Windows 2022

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -234,7 +234,7 @@ get_vsphere_ms() {
 
   # set golden image template name
   # TODO: read from parameter
-  template="windows-golden-images/windows-server-2022-template"
+  template="windows-golden-images/windows-server-2022-template-ipv6-disabled"
 
   # TODO: Reduce the number of API calls, make just one call
   #       to `oc get machines` and pass the data around. This is the

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -45,7 +45,7 @@ func (p *Provider) newVSphereMachineProviderSpec() (*mapi.VSphereMachineProvider
 	// defined in the job spec.
 	vmTemplate := os.Getenv("VM_TEMPLATE")
 	if vmTemplate == "" {
-		vmTemplate = "windows-golden-images/windows-server-2022-template"
+		vmTemplate = "windows-golden-images/windows-server-2022-template-ipv6-disabled"
 	}
 
 	log.Printf("creating machineset based on template %s\n", vmTemplate)


### PR DESCRIPTION
Switch to using the IPv6 disabled template for Windows Server 2022 to mitigate issues seen in CI when the job lands in IBM vCenter where the DHCP server hands out IPv6 addresses causing `oc adm node-logs` test to fail. To be consistent update the machineset.sh script to also use the same template.

Fixes OCPBUGS-11306