### PR TITLE
WINC-561: Set kubelet priority flag

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -203,6 +203,7 @@ func generateKubeletArgs(argsFromIgnition map[string]string, debug bool) ([]stri
 	containerdEndpointValue := "npipe://./pipe/containerd-containerd"
 	certDirectory := "c:\\var\\lib\\kubelet\\pki\\"
 	windowsTaints := "os=Windows:NoSchedule"
+	windowsPriorityClass := "ABOVE_NORMAL_PRIORITY_CLASS"
 	// TODO: Removal of deprecated flags to be done in https://issues.redhat.com/browse/WINC-924
 	kubeletArgs := []string{
 		"--config=" + windows.KubeletConfigPath,
@@ -217,6 +218,10 @@ func generateKubeletArgs(argsFromIgnition map[string]string, debug bool) ([]stri
 		"--container-runtime=remote",
 		"--container-runtime-endpoint=" + containerdEndpointValue,
 		"--resolv-conf=",
+		// Allows the kubelet process to get more CPU time slices when compared to other processes running on the
+		// Windows host.
+		// See: https://kubernetes.io/docs/concepts/configuration/windows-resource-management/#resource-management-cpu
+		"--windows-priorityclass=" + windowsPriorityClass,
 	}
 
 	kubeletArgs = append(kubeletArgs, klogVerbosityArg(debug))

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -59,6 +59,7 @@ func creationTestSuite(t *testing.T) {
 	t.Run("Node Logs", testNodeLogs)
 	t.Run("Metrics validation", testMetrics)
 	t.Run("UserData validation", testUserData)
+	t.Run("Kubelet priority class validation", testKubeletPriorityClass)
 }
 
 // testWindowsNodeCreation tests the Windows node creation in the cluster


### PR DESCRIPTION
Uses the kubelet priority flag introduced in https://github.com/kubernetes/kubernetes/pull/96051 to set the kubelet priority class to ABOVE_NORMAL_PRIORITY_CLASS to ensure that running Pods do not starve the kubelet of CPU cycles.