### PR TITLE
WINC-1040: Use Version annotation for service removal in WICD cleanup

### DIFF
--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -62,16 +62,23 @@ func Deconfigure(cfg *rest.Config, ctx context.Context, configMapNamespace strin
 			cmData, err = servicescm.Parse(cm.Data)
 			return err
 		}
-		// Otherwise, fetch the ConfigMap tied to the node's desired version annotation
-		desiredVersion, present := node.Annotations[metadata.DesiredVersionAnnotation]
+		// Otherwise, fetch the ConfigMap tied to the node's version annotation.
+		// This ensures we cleanup using the same ConfigMap version that was used to configure the instance
+		version, present := node.Annotations[metadata.VersionAnnotation]
 		if !present {
-			return fmt.Errorf("node %s missing desired version annotation", node.Name)
+			// If no version annotation exists, try the desired version. This is useful if node configuration fails and
+			// the instance needs to be reconciled
+			version, present = node.Annotations[metadata.DesiredVersionAnnotation]
+			if !present {
+				return fmt.Errorf("node %s missing desired version annotation", node.Name)
+			}
 		}
 		err = directClient.Get(ctx,
-			client.ObjectKey{Namespace: configMapNamespace, Name: servicescm.NamePrefix + desiredVersion}, cm)
+			client.ObjectKey{Namespace: configMapNamespace, Name: servicescm.NamePrefix + version}, cm)
 		if err != nil {
 			return err
 		}
+		klog.Infof("removing services tied to version: %s", version)
 		cmData, err = servicescm.Parse(cm.Data)
 		return err
 	}()


### PR DESCRIPTION
This PR uses the version annotation instead of the desired version
as the source of truth when deconfiguring Windows services. This is 
important to ensure there are no services left behind when upgrading, 
if there is a change to the services CM spec between WMCO versions.

Using the desired version anno is kept as a backup operation if the node 
does not have a version annotation (i.e. was not fully configured). This is 
useful to recover when configuration fails and the instance needs to be reconciled.