### PR TITLE
WIP: WINC-886: Make WICD Bootstrap command not a method of ServiceController

### DIFF
--- a/cmd/daemon/bootstrap.go
+++ b/cmd/daemon/bootstrap.go
@@ -19,13 +19,9 @@ limitations under the License.
 package main
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-
-	"github.com/openshift/windows-machine-config-operator/pkg/daemon/controller"
 )
 
 var (
@@ -52,10 +48,6 @@ func runBootstrapCmd(cmd *cobra.Command, args []string) {
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		klog.Exitf("error building config: %s", err.Error())
-	}
-	sc, err := controller.NewServiceController(context.TODO(), "", namespace, controller.Options{Config: cfg})
-	if err != nil {
-		klog.Exitf("error creating Service Controller: %s", err.Error())
 	}
 	klog.Info("bootstrapping Windows instance")
 	if err := sc.Bootstrap(desiredVersion); err != nil {

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/controller"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/powershell"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/winsvc"
@@ -105,8 +106,12 @@ type ServiceController struct {
 }
 
 // Bootstrap starts all Windows services marked as necessary for node bootstrapping as defined in the given data
-func (sc *ServiceController) Bootstrap(desiredVersion string) error {
+func Bootstrap(desiredVersion string) error {
 	var cm core.ConfigMap
+	sc, err := controller.NewServiceController(context.TODO(), "", namespace, controller.Options{Config: cfg})
+	if err != nil {
+		klog.Exitf("error creating Service Controller: %s", err.Error())
+	}
 	err := sc.client.Get(sc.ctx,
 		client.ObjectKey{Namespace: sc.watchNamespace, Name: servicescm.NamePrefix + desiredVersion}, &cm)
 	if err != nil {


### PR DESCRIPTION
Changes the Bootstrap command so that it is not a method of ServiceController since the service controller object only needs to be instantiated once.