### PR TITLE
[release-4.13] WINC-1037: Allows selecting Windows Server version for testing

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -271,6 +271,7 @@ Additional flags that can be passed to `hack/run-ci-e2e-test.sh` are
   - `all` all the tests are run
   - `basic` creation, network and deletion tests are run
   - `upgrade` creation, upgrade, reconfiguration and deletion tests are run
+- `-w` specify the Windows Server version to test against. Defaults to 2022. Other option is 2019.
 
 Example command to run the full test suite with 2 instances configured by the Windows Machine controller, and 1
 configured by the ConfigMap controller, skipping the deletion of all the nodes.

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -43,7 +43,10 @@ get_WMCO_logs() {
 }
 
 TEST="all"
-while getopts ":m:c:b:st:" opt; do
+# WINDOWS_SERVER_VERSION will be set in the CI config. If it is not set, default to 2022.
+WIN_VER=${WINDOWS_SERVER_VERSION:-"2022"}
+
+while getopts ":m:c:b:st:w:" opt; do
   case ${opt} in
     m ) # number of instances to create and configure using the Machine controller
       MACHINE_NODE_COUNT_OPTION="--machine-node-count=$OPTARG"
@@ -64,8 +67,11 @@ while getopts ":m:c:b:st:" opt; do
         exit 1
       fi
       ;;
+    w ) # Windows Server version to test against. Defaults to 2022. Other option is 2019.
+      WIN_VER=$OPTARG
+      ;;
     \? )
-      echo "Usage: $0 [-m] [-c] [-s] [-b] [-t]"
+      echo "Usage: $0 [-m] [-c] [-s] [-b] [-t] [-w]"
       exit 0
       ;;
   esac
@@ -137,33 +143,35 @@ if [[ -n "$WINDOWS_INSTANCES_DATA" ]]; then
   echo "updated ${BYOH_NODE_COUNT_OPTION}"
 fi
 
+echo "Testing against Windows Server $WIN_VER"
+
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
 
+GO_TEST_ARGS="$BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE --windows-server-version=$WIN_VER"
 # Test that the operator is running when the private key secret is not present
 printf "\n####### Testing operator deployed without private key secret #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
-
+go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $GO_TEST_ARGS
 # Run the creation tests of the Windows VMs
 printf "\n####### Testing creation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $GO_TEST_ARGS
 # Get logs for the creation tests
 printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
 get_WMCO_logs
 
 if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $GO_TEST_ARGS
   printf "\n####### Testing storage #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/storage -v -timeout=10m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/storage -v -timeout=10m -args $GO_TEST_ARGS
   printf "\n####### Testing service reconciliation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $GO_TEST_ARGS
 fi
 
 if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   # Run the upgrade tests and skip deletion of the Windows VMs
   printf "\n####### Testing upgrade #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $GO_TEST_ARGS
 
   # Run the reconfiguration test
   # The reconfiguration suite must be run directly before the deletion suite. This is because we do not
@@ -171,13 +179,13 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   # added/moved in between these two suites may fail.
   # This limitation will be removed with https://issues.redhat.com/browse/WINC-655
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH $WMCO_PATH_OPTION --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
 fi
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then
-  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args $BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE
+  go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args $GO_TEST_ARGS
   # Get logs on success before cleanup
   PRINT_UPGRADE=""
   if [[ "$TEST" = "upgrade" ]]; then

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -328,7 +328,7 @@ func (tc *testContext) uninstallWindowsDefender(machine *mapi.Machine) error {
 
 // createWindowsMachineSet creates given number of Windows Machines.
 func (tc *testContext) createWindowsMachineSet(replicas int32, ignoreLabel bool) (*mapi.MachineSet, error) {
-	machineSet, err := tc.CloudProvider.GenerateMachineSet(ignoreLabel, replicas)
+	machineSet, err := tc.CloudProvider.GenerateMachineSet(ignoreLabel, replicas, tc.windowsServerVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -21,6 +21,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 // testNetwork runs all the cluster and node network tests
@@ -462,11 +464,13 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 	return podList.Items[0].Status.PodIP, nil
 }
 
-// getWindowsServerContainerImage gets the appropriate WindowsServer image based on the cloud provider
+// getWindowsServerContainerImage gets the appropriate WindowsServer image based on the OS version
 func (tc *testContext) getWindowsServerContainerImage() string {
-	if tc.CloudProvider.GetType() == config.AWSPlatformType {
-		// On AWS we are currently testing 2019
+	switch tc.windowsServerVersion {
+	case windows.Server2019:
 		return "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+	case windows.Server2022:
+	default:
 	}
 	// the default container image must be compatible with Windows Server 2022
 	return "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -14,10 +14,13 @@ import (
 	gcpProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/gcp"
 	noneProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/none"
 	vSphereProvider "github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 type CloudProvider interface {
-	GenerateMachineSet(bool, int32) (*mapi.MachineSet, error)
+	// GenerateMachineSet generates provider specific Windows Server version MachineSet with the given replicas and
+	// the ignore label if the boolean is set
+	GenerateMachineSet(bool, int32, windows.ServerVersion) (*mapi.MachineSet, error)
 	// GetType returns the cloud provider type ex: AWS, Azure etc
 	GetType() config.PlatformType
 	// StorageSupport indicates if we support Windows storage on this provider

--- a/test/e2e/providers/none/none.go
+++ b/test/e2e/providers/none/none.go
@@ -9,6 +9,7 @@ import (
 	client "k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 // Provider is a provider struct for testing platform=none
@@ -24,7 +25,7 @@ func New(clientset *clusterinfo.OpenShift) (*Provider, error) {
 }
 
 // GenerateMachineSet is not supported for platform=none and throws an exception
-func (p *Provider) GenerateMachineSet(_ bool, replicas int32) (*mapi.MachineSet, error) {
+func (p *Provider) GenerateMachineSet(_ bool, replicas int32, version windows.ServerVersion) (*mapi.MachineSet, error) {
 	return nil, fmt.Errorf("MachineSet generation not supported for platform=none")
 }
 

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/machineset"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 const (
@@ -119,7 +120,11 @@ func getNetwork() string {
 }
 
 // GenerateMachineSet generates the MachineSet object which is vSphere provider specific
-func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32) (*mapi.MachineSet, error) {
+func (p *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32, windowsServerVersion windows.ServerVersion) (*mapi.MachineSet, error) {
+	if windowsServerVersion != windows.Server2022 {
+		return nil, fmt.Errorf("vSphere does not support Windows Server %s", windowsServerVersion)
+	}
+
 	// create new machine provider spec for deploying Windows node
 	providerSpec, err := p.newVSphereMachineProviderSpec()
 	if err != nil {

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
+	e2e_windows "github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 const (
@@ -292,8 +293,7 @@ func (tc *testContext) sshSetup() error {
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
 	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022.
 	powershellDefaultCommand := command
-	if tc.CloudProvider.GetType() == config.VSpherePlatformType ||
-		tc.CloudProvider.GetType() == config.GCPPlatformType || tc.CloudProvider.GetType() == config.AzurePlatformType {
+	if tc.windowsServerVersion == e2e_windows.Server2022 {
 		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
 	}
 

--- a/test/e2e/windows/version.go
+++ b/test/e2e/windows/version.go
@@ -1,0 +1,24 @@
+package windows
+
+type ServerVersion string
+
+const (
+	// Server2019 represent Windows Server 2019
+	Server2019 ServerVersion = "2019"
+	// Server2022 represent Windows Server 2022
+	Server2022 ServerVersion = "2022"
+)
+
+// SupportedVersions are the Windows Server versions supported by the e2e test.
+// "" implies the default which is Server2022
+var SupportedVersions = []ServerVersion{Server2019, Server2022, ""}
+
+// IsSupported checks if the given version is supported
+func IsSupported(version ServerVersion) bool {
+	for _, v := range SupportedVersions {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ func TestWMCO(t *testing.T) {
 
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
-
+	log.Printf("Testing against Windows Server %s\n", testCtx.windowsServerVersion)
 	// Create the namespace test resources can be deployed in, as well as required resources within said namespace.
 	require.NoError(t, testCtx.ensureNamespace(testCtx.workloadNamespace, testCtx.workloadNamespaceLabels), "error creating test namespace")
 	require.NoError(t, testCtx.sshSetup(), "unable to setup SSH requirements")


### PR DESCRIPTION
- Make Windows version configurable in the e2e tests by using an environment variable, WINDOWS_SERVER_VERSION.
- Make Windows version configurable in machineset.sh using a command line option

This is a manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1586

