### PR TITLE
[release-4.12] submodule update 05/16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WMCO_VERSION ?= 7.1.0
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
-KUBELET_GIT_VERSION=v1.25.8+27e744f
+KUBELET_GIT_VERSION=v1.25.8+37a9a08
 KUBE-PROXY_GIT_VERSION=v1.25.1+72939b9
 CONTAINERD_GIT_VERSION=v1.6.19-4-geab1c5444
 


### PR DESCRIPTION
* https://github.com/openshift/ovn-kubernetes/commit/401c3ae3508d24dccb5fce60cf903d1718f90832
* Updates reported kubelet version, no actual version change included.