### PR TITLE
[build] Update Dockerfile to use ubi9 images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -107,7 +107,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -65,7 +65,7 @@ WORKDIR /build/windows-machine-config-operator/csi-proxy
 COPY csi-proxy/ .
 RUN GOOS=windows make build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=base
 
 WORKDIR /payload/


### PR DESCRIPTION
This PR updates the Dockerfiles to use ubi9 images which is in sync with the rest of the base images used.