### PR TITLE
[build] Update base images to 4.14

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.19-openshift-4.13
+  tag: rhel-9-release-golang-1.19-openshift-4.14

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.14 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.14 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.14 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -117,7 +117,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.14
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.14 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/


### PR DESCRIPTION
This PR updates the base images used in WMCO Dockerfiles to build from 4.14 OCP release.