### PR TITLE
[docs] Adds operator-sdk prequisite and version

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -29,6 +29,9 @@ If you already have a configured cluster, move on to [Build](#build)
 
 ## Build
 
+### Prerequisites
+- [Install operator-sdk version 1.15.0 on your machine](https://sdk.operatorframework.io/docs/installation/).
+
 To manually build, see the subheading
 [below](#build-an-operator-image). To build and deploy automatically using the OLM hack script, jump ahead to
 [Deploy](#deploy-from-source). 


### PR DESCRIPTION
The refactor removed information about operator-sdk from the hacking.md This returns it.