### PR TITLE
[release-4.13] [build] Update Dockerfile to use ubi9 images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -102,7 +102,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -60,7 +60,7 @@ COPY containernetworking-plugins/ .
 ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=base
 
 WORKDIR /payload/


### PR DESCRIPTION
This PR updates the Dockerfiles to use ubi9 images which is in sync with the rest of the base images used.

(cherry picked from commit 06ae6644de01d21981626e2226ac41293ea4c7eb)