### PR TITLE
[test] Use updated vSphere FSS ConfigMap values

### DIFF
--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -224,6 +224,7 @@ func (p *Provider) ensureFSSConfigMap(client client.Interface) error {
 			"online-volume-extend":             "true",
 			"topology-preferential-datastores": "true",
 			"csi-windows-support":              "true",
+			"use-csinode-id":                   "true",
 		},
 		BinaryData: nil,
 	}


### PR DESCRIPTION
Adds the use-csinode-id flag which is being set to true for Linux nodes. Without this change Windows node CSI configuration fails.