### PR TITLE
[release-4.12] OCPBUGS-14260: Check for minimum OCP version

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -296,6 +296,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - clusterversions
           - infrastructures
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -150,6 +150,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
   - infrastructures
   verbs:
   - get

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -235,3 +235,44 @@ func TestGetDNS(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckOpenShiftVersion(t *testing.T) {
+	var tests = []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{
+			name:    "valid version",
+			version: "4.12.3",
+			wantErr: false,
+		},
+		{
+			name:    "invalid version",
+			version: "4.12.0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid semver",
+			version: "4.12.0.3",
+			wantErr: true,
+		},
+		{
+			name:    "empty version",
+			version: "",
+			wantErr: true,
+		},
+		{
+			name:    "ci version",
+			version: "4.12.0-0.ci.test-2023-06-05-164148-ci-op-grimvr6c-latest",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkOpenShiftVersion(tt.version)
+			assert.Equal(t, err != nil, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
OCPBUGS-4862 fixed an issue where deletion of a BYOH node object resulted in it hanging in the `Ready,SchedulingDisabled` state. This was fixed in OCP 4.12.3 and as a result any WMCO upgrades from 7.0.1 needs to be on versions greater than that. Otherwise BYOH node upgrades will fail and could potentially cause workload disruptions. To prevent that from happening stop WMCO 7.1.0 from running if the OCP version is below 4.12.3.

Fixes OCPBUGS-14260