### PR TITLE
WINC-950: Test WMCO version upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,14 @@ run-ci-e2e-byoh-test:
 run-ci-e2e-upgrade-test:
 	hack/run-ci-e2e-test.sh -t upgrade
 
+.PHONY: upgrade-test-setup
+upgrade-test-setup:
+	hack/run-ci-e2e-test.sh -t upgrade-setup -s
+
+.PHONY: upgrade-test
+upgrade-test:
+	hack/run-ci-e2e-test.sh -t upgrade-test
+
 .PHONY: clean
 clean:
 	rm -rf ${OUTPUT_DIR}

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -58,8 +58,8 @@ while getopts ":m:c:b:st:w:" opt; do
       ;;
     t ) # test to run. Defaults to all. Other options are basic and upgrade.
       TEST=$OPTARG
-      if [[ "$TEST" != "all" && "$TEST" != "basic" && "$TEST" != "upgrade" ]]; then
-        echo "Invalid -t option $TEST. Valid options are all, basic or upgrade"
+      if [[ "$TEST" != "all" && "$TEST" != "basic" && "$TEST" != "upgrade" && "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
+        echo "Invalid -t option $TEST. Valid options are all, basic, upgrade, upgrade-setup, and upgrade-test"
         exit 1
       fi
       ;;
@@ -140,12 +140,15 @@ GO_TEST_ARGS="$BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-p
 # Test that the operator is running when the private key secret is not present
 printf "\n####### Testing operator deployed without private key secret #######\n" >> "$ARTIFACT_DIR"/wmco.log
 go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $GO_TEST_ARGS
-# Run the creation tests of the Windows VMs
-printf "\n####### Testing creation #######\n" >> "$ARTIFACT_DIR"/wmco.log
-go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $GO_TEST_ARGS
-# Get logs for the creation tests
-printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
-get_WMCO_logs
+
+if [[ "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
+  # Run the creation tests of the Windows VMs
+  printf "\n####### Testing creation #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  go test ./test/e2e/... -run=TestWMCO/create -v -timeout=90m -args $GO_TEST_ARGS
+  # Get logs for the creation tests
+  printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  get_WMCO_logs
+fi
 
 if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
@@ -171,6 +174,16 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
 fi
+
+if [[ "$TEST" = "upgrade-setup" ]]; then
+  go test ./test/e2e/... -run=TestWMCO/create/Creation -v -timeout=90m -args $GO_TEST_ARGS
+  go test ./test/e2e/... -run=TestWMCO/create/Nodes_ready_and_schedulable -v -timeout=90m -args $GO_TEST_ARGS
+fi
+
+if [[ "$TEST" = "upgrade-test" ]]; then
+  go test ./test/e2e/... -run=TestUpgrade -v -timeout=20m -args $GO_TEST_ARGS
+fi
+
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -20,12 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
-	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
@@ -51,6 +48,8 @@ func creationTestSuite(t *testing.T) {
 		// No point in running the other tests if creation failed
 		return
 	}
+	t.Run("Nodes ready and schedulable", tc.testNodesBecomeReadyAndSchedulable)
+	t.Run("Node annotations", tc.testNodeAnnotations)
 	t.Run("Node Metadata", tc.testNodeMetadata)
 	t.Run("Services ConfigMap validation", tc.testServicesConfigMap)
 	t.Run("Services running", tc.testExpectedServicesRunning)
@@ -175,7 +174,7 @@ func (tc *testContext) testMachineConfiguration(t *testing.T) {
 		err = tc.createPrivateKeySecret(false)
 		require.NoError(t, err, "error replacing private key secret")
 	}
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "Windows node creation failed")
 	tc.machineLogCollection(machines.Items)
 }
@@ -217,7 +216,7 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 	}
 	// Wait for Windows worker node to become available
 	t.Run("VM is configured by ConfigMap controller", func(t *testing.T) {
-		err := tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+		err := tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 		assert.NoError(t, err, "Windows node creation failed")
 	})
 	// Make a best effort attempt to collect logs from each BYOH instance
@@ -449,39 +448,15 @@ func (tc *testContext) waitForWindowsMachines(machineCount int, phase string, ig
 	return machines, err
 }
 
-// waitForWindowsNode waits until there exists nodeCount Windows nodes with the correct set of annotations.
-// if expectError = true, the function will wait for duration of 10 minutes if we are deleting all nodes i.e. 0 nodesCount
-// else 5 minutes for the nodes as the error would be thrown immediately, else we will wait for the duration given by
-// nodeCreationTime variable which is 20 minutes increasing the overall wait time in test suite
-func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVersion bool, isBYOH bool) error {
-	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac, metadata.VersionAnnotation,
-		nodeconfig.PubKeyHashAnnotation, controllers.UsernameAnnotation}
-
-	var creationTime time.Duration
+// waitForConfiguredWindowsNodes waits until there exists nodeCount Windows nodes that have reported they have been
+// configured by WICD. Specifically the signal for this is the version annotation is applied to the node by WICD, with
+// a value matching the desired version annotation.
+func (tc *testContext) waitForConfiguredWindowsNodes(nodeCount int32, checkVersion, isBYOH bool) error {
 	startTime := time.Now()
-	if expectError {
-		if nodeCount == 0 {
-			creationTime = time.Minute * 10
-		} else {
-			// The time we expect to wait, if the ignore label is
-			// not used while creating nodes.
-			creationTime = time.Minute * 5
-		}
-	} else {
-		creationTime = nodeCreationTime
-	}
-
-	privKey, pubKey, err := tc.getExpectedKeyPair()
-	if err != nil {
-		return fmt.Errorf("error getting the expected public/private key pair: %w", err)
-	}
-	pubKeyAnnotation := nodeconfig.CreatePubKeyHashAnnotation(pubKey)
 
 	// We are waiting 20 minutes for each windows VM to be shown up in the cluster. The value comes from
-	// nodeCreationTime variable.  If we are testing a scale down from n nodes to 0, then we should
-	// not take the number of nodes into account. If we are testing node creation without applying the ignore label, we
-	// should throw error within 5 mins.
-	err = wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*creationTime, func() (done bool, err error) {
+	// nodeCreationTime variable.
+	err := wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*nodeCreationTime, func() (done bool, err error) {
 		nodes, err := tc.listFullyConfiguredWindowsNodes(isBYOH)
 		if err != nil {
 			log.Printf("failed to get list of configured Windows nodes: %s", err)
@@ -489,40 +464,6 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVe
 		}
 
 		for _, node := range nodes {
-			// check node status
-			readyCondition := false
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == v1.NodeReady {
-					readyCondition = true
-				}
-				if readyCondition && condition.Status != v1.ConditionTrue {
-					log.Printf("node %v is expected to be in Ready state", node.Name)
-					return false, nil
-				}
-			}
-			if !readyCondition {
-				log.Printf("expected node Status to have condition type Ready for node %v", node.Name)
-				return false, nil
-			}
-			// explicitly check for the external cloud provider taint for more helpful test logging
-			for _, taint := range node.Spec.Taints {
-				if taint.Key == cloudproviderapi.TaintExternalCloudProvider && taint.Effect == v1.TaintEffectNoSchedule {
-					log.Printf("expected node %s to not have the external cloud provider taint", node.GetName())
-					return false, nil
-				}
-			}
-			if node.Spec.Unschedulable {
-				log.Printf("expected node %s to be schedulable", node.Name)
-				return false, nil
-			}
-
-			for _, annotation := range annotations {
-				_, found := node.Annotations[annotation]
-				if !found {
-					log.Printf("node %s does not have annotation: %s", node.GetName(), annotation)
-					return false, nil
-				}
-			}
 			if checkVersion {
 				operatorVersion, err := getWMCOVersion()
 				if err != nil {
@@ -532,24 +473,6 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVe
 				if node.Annotations[metadata.VersionAnnotation] != operatorVersion {
 					log.Printf("node %s has mismatched version annotation %s. expected: %s", node.GetName(),
 						node.Annotations[metadata.VersionAnnotation], operatorVersion)
-					return false, nil
-				}
-			}
-			if node.Annotations[nodeconfig.PubKeyHashAnnotation] != pubKeyAnnotation {
-				log.Printf("node %s has mismatched pubkey annotation value %s expected: %s", node.GetName(),
-					node.Annotations[nodeconfig.PubKeyHashAnnotation], pubKeyAnnotation)
-				return false, nil
-			}
-			// Ensure username annotation is decipherable and correct. Skip if deconfiguring node
-			if !expectError {
-				username, err := crypto.DecryptFromJSONString(node.Annotations[controllers.UsernameAnnotation], privKey)
-				if err != nil {
-					log.Printf("error decrypting username annotation for node %s: %s", node.Name, err)
-					return false, nil
-				}
-				if username != tc.vmUsername() {
-					log.Printf("username %s does not match expected value %s for node %s:", username, tc.vmUsername(),
-						node.Name)
 					return false, nil
 				}
 			}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -29,9 +29,9 @@ import (
 func testNetwork(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "timed out waiting for Windows Machine nodes")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 	assert.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 
 	t.Run("East West Networking", tc.testEastWestNetworking)

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -57,10 +57,10 @@ func (tc *testContext) reconfigurationTest(t *testing.T) {
 	require.NoError(t, err)
 
 	// The Windows nodes should eventually be returned to the state we expect them to be in
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, true, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
 	assert.NoError(t, err, "error waiting for Windows Machine nodes to be reconfigured")
 
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	assert.NoError(t, err, "error waiting for Windows BYOH nodes to be reconfigured")
 
 	err = tc.validateUpgradeableCondition(metav1.ConditionTrue)
@@ -100,7 +100,7 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 
 	// wait for the node to be removed
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes-1, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes-1, true, true)
 	require.NoError(t, err, "error waiting for the removal of a node")
 
 	// update the ConfigMap again, re-adding the instance
@@ -119,7 +119,7 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	require.NoError(t, err, "error patching windows-instances ConfigMap data with add operation")
 
 	// wait for the node to be successfully re-added
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	assert.NoError(t, err, "error waiting for the Windows node to be re-added")
 
 	err = tc.validateUpgradeableCondition(metav1.ConditionTrue)

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -95,17 +95,17 @@ func (tc *testContext) testUserDataTamper(t *testing.T) {
 	assert.NoError(t, tc.waitForValidUserData(validUserDataSecret), "error waiting for valid userdata")
 }
 
-// waitForNewMachineNodes returns an error if waitForWindowsNodes returns the same Machine backed nodes
+// waitForNewMachineNodes returns an error if waitForConfiguredWindowsNodes returns the same Machine backed nodes
 func (tc *testContext) waitForNewMachineNodes() error {
 	var oldNodes []string
 	for _, node := range gc.machineNodes {
 		oldNodes = append(oldNodes, node.GetName())
 	}
 
-	// waitForWindowsNodes will re-populate gc.machineNodes with the configured nodes found
+	// waitForConfiguredWindowsNodes will re-populate gc.machineNodes with the configured nodes found
 	log.Printf("waiting for existing Machine nodes to be removed and replaced")
 	return wait.Poll(retryInterval, time.Minute*10, func() (done bool, err error) {
-		err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+		err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 		if err != nil {
 			log.Printf("error waiting for configured Windows Nodes: %s", err)
 			return false, nil
@@ -116,6 +116,10 @@ func (tc *testContext) waitForNewMachineNodes() error {
 					log.Printf("node %s is not a new Node, continuing to wait", oldNode)
 					return false, nil
 				}
+			}
+			if !tc.nodeReadyAndSchedulable(newNode) {
+				log.Printf("node %s is not yet ready and schedulable, continuing to wait", newNode.GetName())
+				return false, nil
 			}
 		}
 		return true, nil
@@ -159,6 +163,8 @@ func testPrivateKeyChange(t *testing.T) {
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
 		t.Skipf("Skipping for %s", config.VSpherePlatformType)
 	}
+	// Load the state of nodes before the test begins, this is required to determine if new Machine nodes were created
+	require.NoError(t, tc.loadExistingNodes())
 	err = tc.createPrivateKeySecret(false)
 	require.NoError(t, err, "error replacing known private key secret with a random key")
 	// Ensure operator communicates to OLM that upgrade is not safe when processing secret resources
@@ -166,11 +172,11 @@ func testPrivateKeyChange(t *testing.T) {
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 
 	// Ensure Machines nodes are re-created and configured using the new private key
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
-	assert.NoError(t, err, "error waiting for Windows nodes configured with newly created private key")
+	assert.NoError(t, tc.waitForNewMachineNodes(),
+		"error waiting for Machine nodes configured with newly created private key")
 	// Ensure public key hash and encrypted username annotations are updated correctly on BYOH nodes
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
-	assert.NoError(t, err, "error waiting for Windows nodes updated with newly created private key")
+	assert.NoError(t, tc.waitForBYOHPrivateKeyUpdate(),
+		"error waiting for BYOH nodes to be updated with the newly created private key")
 
 	err = tc.validateUpgradeableCondition(meta.ConditionTrue)
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
@@ -178,6 +184,25 @@ func testPrivateKeyChange(t *testing.T) {
 	// Re-create the known private key so SSH connection can be re-established
 	// TODO: Remove dependency on this secret by rotating keys as part of https://issues.redhat.com/browse/WINC-655
 	require.NoError(t, tc.createPrivateKeySecret(true), "error confirming known private key secret exists")
+}
+
+// waitForBYOHPrivateKeyUpdate waits until all BYOH Nodes annotations are updated to reflect the expected private key
+func (tc *testContext) waitForBYOHPrivateKeyUpdate() error {
+	return wait.Poll(retry.Interval, retry.ResourceChangeTimeout, func() (done bool, err error) {
+		nodes, err := tc.listFullyConfiguredWindowsNodes(true)
+		if err != nil {
+			return false, nil
+		}
+		for _, node := range nodes {
+			if pubKeyCorrect, err := tc.checkPubKeyAnnotation(&node); err != nil || !pubKeyCorrect {
+				return false, nil
+			}
+			if usernameCorrect, err := tc.checkUsernameAnnotation(&node); err != nil || !usernameCorrect {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
 }
 
 // generatePrivateKey generates a random RSA private key

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -17,9 +17,9 @@ func testStorage(t *testing.T) {
 	if !tc.StorageSupport() {
 		t.Skip("storage is not supported on this platform")
 	}
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 	require.Greater(t, len(gc.allNodes()), 0, "test requires at least one Windows node to run")
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -46,11 +46,11 @@ func upgradeTestSuite(t *testing.T) {
 	require.NoError(t, err, "error configuring upgrade")
 
 	// get current Windows node state
-	// TODO: waitForWindowsNodes currently loads nodes into global context, so we need this (even though BYOH
+	// TODO: waitForConfiguredWindowsNodes currently loads nodes into global context, so we need this (even though BYOH
 	// 		 nodes are not being upgraded/tested here). Remove as part of https://issues.redhat.com/browse/WINC-620
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, true, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
 	require.NoError(t, err, "wrong number of Machine controller nodes found")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	require.NoError(t, err, "wrong number of ConfigMap controller nodes found")
 
 	t.Run("Operator version upgrade", tc.testUpgradeVersion)


### PR DESCRIPTION
Adds the upgrade-test-setup and upgrade-test make targets, which are
designed to be ran before a WMCO upgrade occurs and after,
respectively. These targets will do basic testing on WMCO to ensure that
WMCO is able to upgrade nodes.