### PR TITLE
Move node cordoning to WICD

### DIFF
--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -14,3 +14,22 @@ rules:
   - get
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -221,12 +221,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - pods/eviction
-          verbs:
-          - create
-        - apiGroups:
-          - ""
-          resources:
           - secrets
           verbs:
           - create
@@ -242,12 +236,6 @@ spec:
           verbs:
           - create
           - delete
-          - get
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          verbs:
           - get
         - apiGroups:
           - certificates.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,12 +74,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/eviction
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -95,12 +89,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
   - get
 - apiGroups:
   - certificates.k8s.io

--- a/config/wicd/windows-instance-config-daemon-cluster-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role.yaml
@@ -13,3 +13,22 @@ rules:
       - get
       - patch
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - get

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -61,7 +61,6 @@ import (
 //+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=delete;get;list;patch;watch
-//+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;create;delete
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;create;delete
 

--- a/pkg/daemon/drainhelper/drainhelper.go
+++ b/pkg/daemon/drainhelper/drainhelper.go
@@ -1,0 +1,46 @@
+package drainhelper
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/drain"
+)
+
+// ErrWriter is a wrapper to enable error-level logging inside kubectl drainer implementation
+type ErrWriter struct {
+	log logr.Logger
+}
+
+func (ew ErrWriter) Write(p []byte) (n int, err error) {
+	// log error
+	ew.log.Error(err, string(p))
+	return len(p), nil
+}
+
+// OutWriter is a wrapper to enable info-level logging inside kubectl drainer implementation
+type OutWriter struct {
+	log logr.Logger
+}
+
+func (ow OutWriter) Write(p []byte) (n int, err error) {
+	// log info
+	ow.log.Info(string(p))
+	return len(p), nil
+}
+
+// NewDrainHelper returns new drain.Helper
+func NewDrainHelper(ctx context.Context, client kubernetes.Interface, logger klog.Logger) *drain.Helper {
+	return &drain.Helper{
+		Ctx:    ctx,
+		Client: client,
+		ErrOut: &ErrWriter{logger},
+		// Evict all pods regardless of their controller and orphan status
+		Force: true,
+		// Prevents erroring out in case a DaemonSet's pod is on the node
+		IgnoreAllDaemonSets: true,
+		Out:                 &OutWriter{logger},
+	}
+}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -36,8 +36,6 @@ import (
 	"github.com/openshift/windows-machine-config-operator/version"
 )
 
-//+kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get
-
 const (
 	// HybridOverlaySubnet is an annotation applied by the cluster network operator which is used by the hybrid overlay
 	HybridOverlaySubnet = "k8s.ovn.org/hybrid-overlay-node-subnet"


### PR DESCRIPTION
This PR includes changes to ensure that Node is only marked as fully configured by WICD by applying the version annotation, only once the node is actually fully configured. This includes the node entering the ready state, and being marked as schedulable. 