### PR TITLE
OCPBUGS-13780,OCPBUGS-14700: Use latest and version CM for cleanup

### DIFF
--- a/pkg/daemon/cleanup/cleanup_test.go
+++ b/pkg/daemon/cleanup/cleanup_test.go
@@ -97,6 +97,46 @@ func TestRemoveServices(t *testing.T) {
 	}
 }
 
+func TestMergeServices(t *testing.T) {
+	testIO := []struct {
+		name     string
+		list1    []servicescm.Service
+		list2    []servicescm.Service
+		expected []servicescm.Service
+	}{
+		{
+			name:     "both empty",
+			list1:    []servicescm.Service{},
+			list2:    []servicescm.Service{},
+			expected: []servicescm.Service{},
+		},
+		{
+			name:     "one empty",
+			list1:    []servicescm.Service{{Name: "service1"}, {Name: "service2"}},
+			list2:    []servicescm.Service{},
+			expected: []servicescm.Service{{Name: "service1"}, {Name: "service2"}},
+		},
+		{
+			name:  "different services",
+			list1: []servicescm.Service{{Name: "service1"}, {Name: "service2", Dependencies: []string{"service1"}}},
+			list2: []servicescm.Service{{Name: "service3"}, {Name: "service4", Dependencies: []string{"service3"}}},
+			expected: []servicescm.Service{{Name: "service1"}, {Name: "service2", Dependencies: []string{"service1"}},
+				{Name: "service3"}, {Name: "service4", Dependencies: []string{"service3"}}},
+		},
+		{
+			name:     "overlapping services",
+			list1:    []servicescm.Service{{Name: "service1"}, {Name: "service2"}},
+			list2:    []servicescm.Service{{Name: "service2", Dependencies: []string{"service1"}}, {Name: "service3"}},
+			expected: []servicescm.Service{{Name: "service1"}, {Name: "service2"}, {Name: "service3"}}},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			out := mergeServices(test.list1, test.list2)
+			assert.ElementsMatch(t, out, test.expected)
+		})
+	}
+}
+
 func newTestService(name string, dependencies []string) *fake.FakeService {
 	return fake.NewFakeService(
 		name,

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -13,6 +13,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
@@ -55,7 +56,7 @@ func (tc *testContext) testBYOHRemoval(t *testing.T) {
 	// Remove all entries from the windows-instances ConfigMap, causing all node objects to be deleted
 	require.NoError(t, tc.clearWindowsInstanceConfigMap(),
 		"error removing windows-instances ConfigMap entries")
-	err = tc.waitForWindowsNodes(0, true, false, true)
+	err = tc.waitForWindowsNodeRemoval(true)
 	require.NoError(t, err, "Removing ConfigMap entries did not cause Windows node deletion")
 
 	// For each node that was deleted, check that all the expected services have been removed
@@ -110,6 +111,26 @@ func (tc *testContext) checkNetworksRemoved(address string) (bool, error) {
 		strings.Contains(out, "VIPEndpoint")), nil
 }
 
+// waitForWindowsNodeRemoval returns when there are zero Windows nodes of the given type, machine or byoh, in the cluster
+func (tc *testContext) waitForWindowsNodeRemoval(isBYOH bool) error {
+	labelSelector := core.LabelOSStable + "=windows"
+	if isBYOH {
+		// BYOH label is set to true
+		labelSelector = fmt.Sprintf("%s,%s=true", labelSelector, controllers.BYOHLabel)
+	} else {
+		// BYOH label is not set
+		labelSelector = fmt.Sprintf("%s,!%s", labelSelector, controllers.BYOHLabel)
+	}
+	return wait.PollImmediate(retryInterval, 10*time.Minute, func() (done bool, err error) {
+		nodes, err := tc.client.K8s.CoreV1().Nodes().List(context.TODO(),
+			meta.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, nil
+		}
+		return len(nodes.Items) == 0, nil
+	})
+}
+
 // testWindowsNodeDeletion tests the Windows node deletion from the cluster.
 func (tc *testContext) testWindowsNodeDeletion(t *testing.T) {
 	// Deploy a DaemonSet and wait until its pods have been made ready on each Windows node. DaemonSet pods cannot be
@@ -145,8 +166,8 @@ func (tc *testContext) testWindowsNodeDeletion(t *testing.T) {
 		require.NoError(t, err, "error updating Windows MachineSet")
 
 		// we are waiting 10 minutes for all windows machines to get deleted.
-		err = tc.waitForWindowsNodes(expectedNodeCount, true, false, false)
-		require.NoError(t, err, "Windows node deletion failed")
+		err = tc.waitForWindowsNodeRemoval(false)
+		require.NoError(t, err, "Windows Machine Node deletion failed")
 	}
 	t.Run("BYOH node removal", tc.testBYOHRemoval)
 


### PR DESCRIPTION
Uses the union of the services present in the services CM for the version that configured it as well as the latest CM present in the cluster. This ensures that all services will be accounted for when cleaning up an instance.