### PR TITLE
Use operator image to extend must-gather collection with WMCO's specific resources

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -109,8 +109,19 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
+FROM registry.redhat.io/openshift4/ose-cli:latest AS cli
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=operator
+
+# install tools required for must-gather collection script
+RUN INSTALL_PKGS=" \
+      rsync \
+      tar \
+      " && \
+    microdnf install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    microdnf clean all
 
 WORKDIR /payload/
 # Copy WICD
@@ -158,6 +169,11 @@ COPY pkg/internal/windows-defender-exclusion.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /
+
+# Copy must-gather collection scripts and binaries
+COPY must-gather/collection-scripts/* /usr/bin/
+COPY --from=cli /usr/bin/oc /usr/bin
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -68,6 +68,15 @@ RUN GOOS=windows make build
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=base
 
+# install required tools for must-gather collection script
+RUN INSTALL_PKGS=" \
+      rsync \
+      tar \
+      " && \
+    microdnf install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    microdnf clean all
+
 WORKDIR /payload/
 # Copy hybrid-overlay-node.exe
 COPY --from=build /build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe .

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -81,6 +81,7 @@ COPY cmd cmd
 COPY controllers controllers
 COPY bundle bundle
 COPY hack hack
+COPY must-gather must-gather
 COPY pkg pkg
 COPY test test
 COPY vendor vendor
@@ -119,6 +120,9 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
+FROM registry.redhat.io/openshift4/ose-cli:latest AS cli
+
+# the selected operator image for CI should have rsync and tar, required for must-gather collection script
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
 LABEL stage=operator
 
@@ -168,6 +172,11 @@ COPY --from=build /build/windows-machine-config-operator/pkg/internal/windows-de
 COPY --from=build /build/windows-machine-config-operator/pkg/internal/hns.psm1 .
 
 WORKDIR /
+
+# Copy must-gather collection scripts and binaries
+COPY --from=build /build/windows-machine-config-operator/must-gather/collection-scripts/* /usr/bin/
+COPY --from=cli /usr/bin/oc /usr/bin
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -22,6 +22,8 @@ COPY .git .git
 RUN make build
 RUN make build-daemon
 
+FROM registry.redhat.io/openshift4/ose-cli:latest AS cli
+
 FROM wmco-base:latest
 LABEL stage=operator
 
@@ -40,6 +42,11 @@ COPY pkg/internal/windows-defender-exclusion.ps1 .
 COPY pkg/internal/hns.psm1 .
 
 WORKDIR /
+
+# Copy must-gather collection scripts and binaries
+COPY must-gather/collection-scripts/* /usr/bin/
+COPY --from=cli /usr/bin/oc /usr/bin
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_UID=1001 \

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -77,7 +77,8 @@ E.g. getting logs for any given service:
 ```shell script
 $ oc adm node-logs -l kubernetes.io/os=windows --path=journal -u <LOG_NAME>
 ```
-The same command is executed when collecting logs with `oc adm must-gather`.
+The same command is executed when collecting logs with `oc adm must-gather`. For specific WMCO collection see
+[support for must-gather](../must-gather/README.md).
 
 Other Windows application logs from the EventLog can also be collected by specifying the respective service on a `-u` flag.
 To view logs from all applications logging to the event logs on the Windows machine, run:

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -172,6 +172,9 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
 fi
 
+# collect operator resources using must-gather tool
+oc adm must-gather --timeout=2m --image="${OPERATOR_IMAGE}" --dest-dir="${ARTIFACT_DIR}/must-gather"
+
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step
 if ! $SKIP_NODE_DELETION; then

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,111 @@
+# Support for OpenShift Must-Gather
+This tool is shipped in the operator images as a complement for [OpenShift must-gather](https://github.com/openshift/must-gather)
+to expands its capabilities to gather specific information for the OpenShift Windows Machine Config Operator.
+
+## Usage
+To gather only OpenShift Windows Machine Config Operator information use the following command: 
+```shell script
+oc adm must-gather --image="$(oc get packagemanifests openshift-windows-machine-config-operator \
+  -n openshift-marketplace \
+  -o jsonpath='{.status.channels[0].currentCSVDesc.annotations.containerImage}')"
+```
+where a custom image for the must-gather command is pulled directly from the operator packagemanifests, so that 
+it works on any cluster where OpenShift Windows Machine Config Operator is available.
+
+To gather the default [OpenShift must-gather](https://github.com/openshift/must-gather) in addition to OpenShift 
+Windows Machine Config Operator information you should fetch the operator image and combine both images with the 
+following command:
+```shell script
+oc adm must-gather --image-stream=openshift/must-gather \
+    --image="$(oc get packagemanifests openshift-windows-machine-config-operator \
+        -n openshift-marketplace \
+        -o jsonpath='{.status.channels[0].currentCSVDesc.annotations.containerImage}')"
+ ```
+
+In case the OpenShift Windows Machine Config Operator was deployed directly to the cluster, without OLM, you can
+use the following command to gather the information using the image from the operator deployment:
+```shell script
+oc adm must-gather --image=$(oc get deployment.apps/windows-machine-config-operator \
+  -n openshift-windows-machine-config-operator \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name == "manager")].image}')
+```
+
+## Collection script data
+As a result of the above commands a local directory will be crated with a dump of the resources for OpenShift Windows
+Machine Config Operator with the following structure:
+
+- The `openshift-windows-machine-config-operator` namespace and its children objects, including but not limited to:
+  - the `windows-instance` ConfigMap
+  - the `windows-services` ConfigMap
+  - the `windows-machine-config-operator` pod logs
+
+In order to get data about other parts of the cluster that are not specific to OpenShift Windows Machine Config Operator
+you should run `oc adm must-gather` without passing the custom image. Run `oc adm must-gather -h` to see more options.
+
+## Must gather sample output
+The following snippet shows a sample output of the directory tree for the OpenShift Windows Machine Config Operator 
+must-gather:
+```
+├── namespaces
+│   └── openshift-windows-machine-config-operator
+│       ├── apps
+│       │   ├── daemonsets.yaml
+│       │   ├── deployments.yaml
+│       │   ├── replicasets.yaml
+│       │   └── statefulsets.yaml
+│       ├── apps.openshift.io
+│       │   └── deploymentconfigs.yaml
+│       ├── autoscaling
+│       │   └── horizontalpodautoscalers.yaml
+│       ├── batch
+│       │   ├── cronjobs.yaml
+│       │   └── jobs.yaml
+│       ├── build.openshift.io
+│       │   ├── buildconfigs.yaml
+│       │   └── builds.yaml
+│       ├── core
+│       │   ├── configmaps.yaml
+│       │   ├── endpoints.yaml
+│       │   ├── events.yaml
+│       │   ├── persistentvolumeclaims.yaml
+│       │   ├── pods.yaml
+│       │   ├── replicationcontrollers.yaml
+│       │   ├── secrets.yaml
+│       │   └── services.yaml
+│       ├── discovery.k8s.io
+│       │   └── endpointslices.yaml
+│       ├── image.openshift.io
+│       │   └── imagestreams.yaml
+│       ├── k8s.ovn.org
+│       │   ├── egressfirewalls.yaml
+│       │   └── egressqoses.yaml
+│       ├── monitoring.coreos.com
+│       │   └── servicemonitors.yaml
+│       ├── networking.k8s.io
+│       │   └── networkpolicies.yaml
+│       ├── openshift-windows-machine-config-operator.yaml
+│       ├── pods
+│       │   ├── windows-machine-config-operator-644f6675c8-4hwhw
+│       │   │   ├── manager
+│       │   │   │   └── manager
+│       │   │   │       └── logs
+│       │   │   │           ├── current.log
+│       │   │   │           ├── previous.insecure.log
+│       │   │   │           └── previous.log
+│       │   │   └── windows-machine-config-operator-644f6675c8-4hwhw.yaml
+│       │   └── windows-machine-config-operator-registry-server-7f8667b5fcgcfpb
+│       │       ├── windows-machine-config-operator-registry-server
+│       │       │   └── windows-machine-config-operator-registry-server
+│       │       │       └── logs
+│       │       │           ├── current.log
+│       │       │           ├── previous.insecure.log
+│       │       │           └── previous.log
+│       │       └── windows-machine-config-operator-registry-server-7f8667b5fcgcfpb.yaml
+│       ├── policy
+│       │   └── poddisruptionbudgets.yaml
+│       └── route.openshift.io
+│           └── routes.yaml
+├── gather-debug.log
+└── version
+
+```

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Usage:
+# ./gather [BASE_COLLECTION_PATH]
+#
+# where:
+#   BASE_COLLECTION_PATH is an optional argument to define the path of the collection directory, defaults
+#   to `/must-gather`
+
+get_timestamp(){
+  date '+%Y-%m-%d %H:%M:%S'
+}
+
+log(){
+  echo "$(get_timestamp) ${*}"
+}
+
+WMCO_DEFAULT_NS="openshift-windows-machine-config-operator"
+WMCO_SUB_NAME="windows-machine-config-operator"
+
+# TODO: add support for community operator
+# WMCO_COMMUNITY_SUB_NAME="community-windows-machine-config-operator"
+
+# read collection path or use default
+BASE_COLLECTION_PATH="${1:-/must-gather}"
+
+# ensure path exists
+mkdir -p "${BASE_COLLECTION_PATH}"
+
+# define a local cache for kube API to improve the discovery and
+# avoid client-side throttling
+export KUBECACHEDIR=$(mktemp -d)
+
+echo "Must-gather script started with KUBECACHEDIR: ${KUBECACHEDIR}"
+echo "For must-gather version file see: ${BASE_COLLECTION_PATH}/version"
+echo "For script debug logs check ${BASE_COLLECTION_PATH}/gather-debug.log"
+
+# find WMCO version from subscription
+WMCO_SUB_VERSION=$(oc get packagemanifests ${WMCO_SUB_NAME} --cache-dir=${KUBECACHEDIR} \
+  -n openshift-marketplace \
+  -o jsonpath='{.status.channels[0].currentCSVDesc.version}')
+# generate /must-gather/version file with product and version
+# see https://github.com/openshift/enhancements/blob/master/enhancements/oc/must-gather.md#must-gather-images
+echo "${WMCO_SUB_NAME}" > ${BASE_COLLECTION_PATH}/version
+echo "${WMCO_SUB_VERSION}" >> ${BASE_COLLECTION_PATH}/version
+
+# find install namespace since WMCO could be installed in a different namespace
+WMCO_NS=$(oc get subs --cache-dir=${KUBECACHEDIR} -A \
+  -o template \
+  --template '{{range .items}}{{if eq .spec.name "'"${WMCO_SUB_NAME}"'"}}{{.metadata.namespace}}{{end}}{{end}}')
+
+# use namespace from subscription, otherwise use default. This case is useful when the operator is deployed directly
+if [ -z "${WMCO_NS}" ]; then
+    echo "${WMCO_SUB_NAME} subscription not detected. Using ${WMCO_DEFAULT_NS} as default namespace"
+    WMCO_NS=${WMCO_DEFAULT_NS}
+fi
+
+# list of operator resources to collect; as of now, only WMCO namespace
+wmco_resources+=(
+  ns/$WMCO_NS
+)
+
+log "Collecting resources for ${WMCO_SUB_NAME} ${WMCO_SUB_VERSION}" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+for resource in ${wmco_resources[@]}; do
+  log "Inspecting $resource" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir ${BASE_COLLECTION_PATH} --all-namespaces ${resource} >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "Finish inspecting $resource" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+done
+log "Collection completed" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+
+# cleanup
+rm -rf ${KUBECACHEDIR}
+
+# success
+exit 0


### PR DESCRIPTION
As the OpenShift Windows Machine Config operator increases in complexity and number of customers, it is
important to provide an easy-to-use tool to collect information that can be used to troubleshoot issues.

This PR extends the support for OpenShift must-gather in WMCO ([WINC-462](https://issues.redhat.com/browse/WINC-462)) by preparing the operator image as a compatible "must-gather" image so that the collection scripts can be executed with information that is specific to the operator.

In addition, opened a [mid-stream PR](https://gitlab.cee.redhat.com/openshift-winc-midstream/openshift-winc-midstream/-/merge_requests/291) to include the novel collection tool in the WMCO image.

### Motivation

As per the OpenShift [must-gather guidelines](https://github.com/openshift/must-gather/blob/master/README.md?plain=1#L10-L12):

> The data collection scripts should only include collection logic for components that are included as part of the 
> OpenShift CVO payload. Outside components are encouraged to produce a similar "must-gather" image.

WMCO is an optional day-two operator that is not included as part of the OpenShift CVO payload, so introducing the
logic of the collection script in the WMCO repository reduces the complexity of the OpenShift must-gather image and 
allows updates independently of the CVO payload, considering that WMCO follows a different release cycle.

Eventually, the Windows specific logic currently [included](https://github.com/openshift/must-gather/blob/master/collection-scripts/gather_windows_node_logs#L19) in the OpenShift must-gather image could be ported to the proposed must-gather tools within WMCO.

### Pros and Cons

Pros:
 - Easier to maintain and release independently of the OpenShift must-gather image
 - Exactly match a single version of the operator it is inspecting
 - A single, low-arg client command for users to collect information
 - Reduces the complexity of the OpenShift must-gather image
 
Cons:
 - Increase the size of the WMCO image by ~130MB given that it includes required tools: `oc`, `rsync` and `tar`


### Testing

I'm proposing the usage of the novel collection script as part of the E2E test suite with the required adjustment in the images built in CI and for local development using the approach recommended to the users; i.e. invoking the `oc adm must-gather` passing a custom image pointing to the corresponding operator image (`--image="${OPERATOR_IMAGE}"`). See [[e2e] Use must-gather in CI and local development](https://github.com/openshift/windows-machine-config-operator/pull/1663/commits/6f570d915f75fd61a10a0a304066509f9d000a7c). The latter adds more complexity to the E2E but provides a standard report of the operator state during the E2E execution.

A sample output of the must-gather tool running in a CI job can be found [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_windows-machine-config-operator/1663/pull-ci-openshift-windows-machine-config-operator-master-aws-e2e-operator/1673332891666354176/artifacts/aws-e2e-operator/windows-e2e-operator-test/artifacts/). 
