### PR TITLE
[wicd][controller] Fix Reconcile unit test

### DIFF
--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -648,6 +648,14 @@ func TestReconcile(t *testing.T) {
 							metadata.DesiredVersionAnnotation: desiredVersion,
 						},
 					},
+					Status: core.NodeStatus{
+						Conditions: []core.NodeCondition{
+							{
+								Type:   core.NodeReady,
+								Status: core.ConditionTrue,
+							},
+						},
+					},
 				},
 				cm,
 			}
@@ -663,6 +671,8 @@ func TestReconcile(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
+			assert.NoError(t, err)
+
 			createdServices, err := getAllFakeServices(winSvcMgr)
 			require.NoError(t, err)
 


### PR DESCRIPTION
This commit fixes the WICD controller unit tests by adding a missing assert
for no error in the Reconcile func happy path.
waitUntilNodeReady() was introduced, which waits for a ready/schedulable node.
Before this, the test was passing despite the mock node not having these labels.