### PR TITLE
Remove unnecessary poll wait times

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -424,7 +424,7 @@ func (nc *nodeConfig) setNode(quickCheck bool) error {
 	}
 
 	instanceAddress := nc.GetIPv4Address()
-	err := wait.Poll(retryInterval, retryTimeout, func() (bool, error) {
+	err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 		nodes, err := nc.k8sclientset.CoreV1().Nodes().List(context.TODO(),
 			meta.ListOptions{LabelSelector: WindowsOSLabel})
 		if err != nil {

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -755,7 +755,7 @@ func (vm *windows) stopService(svc *service) error {
 	}
 
 	// Wait until the service has stopped
-	err = wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
+	err = wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
 		serviceRunning, err := vm.isRunning(svc.name)
 		if err != nil {
 			vm.log.V(1).Error(err, "unable to check if Windows service is running", "service", svc.name)
@@ -783,7 +783,7 @@ func (vm *windows) deleteService(svc *service) error {
 	}
 
 	// Wait until the service is fully deleted
-	err = wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
+	err = wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
 		exists, err := vm.serviceExists(svc.name)
 		if err != nil {
 			vm.log.V(1).Error(err, "unable to check if Windows service exists", "service", svc.name)
@@ -859,7 +859,7 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 	var err error
 	// VIP HNS endpoint created by the operator is also deleted when the HNS networks are deleted.
 	for _, network := range []string{BaseOVNKubeOverlayNetwork, OVNKubeOverlayNetwork} {
-		err = wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
+		err = wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
 			// reinitialize and retry on failure to avoid connection reset SSH errors
 			if err := vm.removeHNSNetwork(network); err != nil {
 				vm.log.V(1).Error(err, "error removing %s HNS network", "network", network)


### PR DESCRIPTION
Switches from using Poll() to PollImmediate() where appropriate. Each of these uses have the potential to not require the wait period before attempting to perform the task being polled. These unecessary wait periods of 5 and 15 seconds add up, and they should be avoided where possible.