### PR TITLE
OCPBUGS-15461: Fix WICD RBAC comparisons

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 
 	config "github.com/openshift/api/config/v1"
@@ -579,8 +580,8 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
 	}
 	if err == nil {
 		// check if existing RoleBinding's contents are as expected, delete it if not
-		if existingRB.RoleRef == expectedRB.RoleRef &&
-			len(existingRB.Subjects) == len(expectedRB.Subjects) && existingRB.Subjects[0] == expectedRB.Subjects[0] {
+		if existingRB.RoleRef.Name == expectedRB.RoleRef.Name &&
+			reflect.DeepEqual(existingRB.Subjects, expectedRB.Subjects) {
 			return nil
 		}
 		err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Delete(context.TODO(), wicdRBACResourceName,
@@ -628,8 +629,8 @@ func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding() error {
 	}
 	if err == nil {
 		// check if existing ClusterRoleBinding's contents are as expected, delete it if not
-		if existingCRB.RoleRef == expectedCRB.RoleRef &&
-			len(existingCRB.Subjects) == len(expectedCRB.Subjects) && existingCRB.Subjects[0] == expectedCRB.Subjects[0] {
+		if existingCRB.RoleRef.Name == expectedCRB.RoleRef.Name &&
+			reflect.DeepEqual(existingCRB.Subjects, expectedCRB.Subjects) {
 			return nil
 		}
 		err = r.k8sclientset.RbacV1().ClusterRoleBindings().Delete(context.TODO(), wicdRBACResourceName,


### PR DESCRIPTION
The check for the existing windows-instance-config-daemon ClusterRoleBinding and RoleBinding objects with the expected objects was not doing deep compares. This caused the the existing object not to be deleted in the case where the WMCO namespace was changing.

Fixes OCPBUGS-15461