### PR TITLE
[build] Disable cgo in build containers

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
 LABEL stage=build
 
+# Disable cgo as it breaks containerd builds
+ENV CGO_ENABLED=0
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 
@@ -57,7 +60,6 @@ RUN GOOS=windows go build -o azure-cloud-node-manager.exe ./cmd/cloud-node-manag
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
 # Build csi-proxy

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,6 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
 LABEL stage=build
 
+# Disable cgo as it breaks containerd builds
+ENV CGO_ENABLED=0
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -5,6 +5,10 @@
 # build stage for building binaries
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
 LABEL stage=build
+
+# Disable cgo as it breaks containerd builds
+ENV CGO_ENABLED=0
+
 WORKDIR /build/
 
 # dos2unix is needed to build CNI plugins
@@ -65,7 +69,6 @@ RUN GOOS=windows go build -o azure-cloud-node-manager.exe ./cmd/cloud-node-manag
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
 RUN ./build_windows.sh
 
 # Build csi-proxy


### PR DESCRIPTION
cgo is now being enabled by the base image we use. This is causing containerd builds to fail with:
unrecognized command-line option '-mthreads'; did you mean '-pthread'?

In this commit cgo is being explicity disabled to fix this issue and unblock builds.