### PR TITLE
[nodeconfig] Set node in NodeConfig constructor

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -110,7 +110,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)
 		}
 
-		if err := nc.SafeReboot(ctx, node); err != nil {
+		if err := nc.SafeReboot(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("full instance reboot failed: %w", err)
 		}
 	}


### PR DESCRIPTION
Allow a NodeConfig object to populate its node field on construction. 
This removed the need to call setNode to populate the node object in each of the exported NodeConfig methods. 
It also removed the need to pass in node objects to functions upon the NodeConfig struct, which was a bad pattern.