### PR TITLE
[hack] Remove version gen for csi-proxy 

### DIFF
--- a/hack/update_submodules.sh
+++ b/hack/update_submodules.sh
@@ -92,7 +92,7 @@ function update_submodules_for_branch() {
     # Update the submodule to the latest remote commit
     git submodule update --remote $submodule
     generate_submodule_commit $submodule
-    if [ "$submodule" = "kubelet" ] || [ "$submodule" = "kube-proxy" ] || [ "$submodule" = "containerd" ] || [ "$submodule" = "csi-proxy" ]; then
+    if [ "$submodule" = "kubelet" ] || [ "$submodule" = "kube-proxy" ] || [ "$submodule" = "containerd" ]; then
       generate_version_commit "$submodule"
     fi
   done


### PR DESCRIPTION
Version was being generated for csi-proxy, which is not required.
Removes this requirement.