### PR TITLE
WINC-1023: Remove WICD node deletion RBAC permission

### DIFF
--- a/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -13,4 +13,3 @@ rules:
   - watch
   - get
   - patch
-  - delete

--- a/config/wicd/windows-instance-config-daemon-cluster-role.yaml
+++ b/config/wicd/windows-instance-config-daemon-cluster-role.yaml
@@ -12,4 +12,3 @@ rules:
       - watch
       - get
       - patch
-      - delete


### PR DESCRIPTION
WICD in WMCO 8.0.1 was given the node delete permission so that WMCO could successfully upgrade from 7.0.1. The permissions can now be removed as it is not needed to upgrade from the next 8 release to 9.0.0.

- Removed the delete verb from `config/wicd/windows-instance-config-daemon-cluster-role.yaml` 
- Ran `make bundle`. 
- Reverted unnecessary changes to `bundle/manifests/windows-instance-config-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml`.