### PR TITLE
[release-4.12] WINC-1028: Prep for 7.1.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 7.1.0
+WMCO_VERSION ?= 7.1.1
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v7.1.0
+  name: windows-machine-config-operator.v7.1.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -470,4 +470,4 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 7.1.0
+  version: 7.1.1

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v7.1.0
+  - currentCSV: windows-machine-config-operator.v7.1.1
     channels: alpha
 packageName: windows-machine-config-operator


### PR DESCRIPTION
This change bumps the patch version in prep for the next release.

Ran 'make bundle' after bumping version in the Makefile.