### PR TITLE
WINC-1043: Test upgrading to CSI storage, from in-tree drivers

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -178,6 +178,8 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
 fi
 
 if [[ "$TEST" = "upgrade-setup" ]]; then
+  # TODO: Remove this after adding it to the appropriate release jobs
+  export UPGRADE_FROM_IN_TREE=true
   go test ./test/e2e/... -run=TestWMCO/create/Creation -v -timeout=90m -args $GO_TEST_ARGS
   go test ./test/e2e/... -run=TestWMCO/create/Nodes_ready_and_schedulable -v -timeout=90m -args $GO_TEST_ARGS
   # Run the storage test, skipping deletion of the created workload in order to test that it persists across the upgrade
@@ -186,6 +188,8 @@ if [[ "$TEST" = "upgrade-setup" ]]; then
 fi
 
 if [[ "$TEST" = "upgrade-test" ]]; then
+  # TODO: Remove this after adding it to the appropriate release jobs
+  export UPGRADE_FROM_IN_TREE=true
   go test ./test/e2e/... -run=TestUpgrade -v -timeout=20m -args $GO_TEST_ARGS
 fi
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -180,6 +180,9 @@ fi
 if [[ "$TEST" = "upgrade-setup" ]]; then
   go test ./test/e2e/... -run=TestWMCO/create/Creation -v -timeout=90m -args $GO_TEST_ARGS
   go test ./test/e2e/... -run=TestWMCO/create/Nodes_ready_and_schedulable -v -timeout=90m -args $GO_TEST_ARGS
+  # Run the storage test, skipping deletion of the created workload in order to test that it persists across the upgrade
+  go test ./test/e2e/... -run=TestWMCO/storage -v -timeout=15m -args $GO_TEST_ARGS --skip-workload-deletion=true
+  go test ./test/e2e/... -run=TestWMCO/create/Node_Logs -v -timeout=10m -args $GO_TEST_ARGS
 fi
 
 if [[ "$TEST" = "upgrade-test" ]]; then

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -161,6 +162,7 @@ func (tc *testContext) waitForWindowsNodeRemoval(isBYOH bool) error {
 
 // testWindowsNodeDeletion tests the Windows node deletion from the cluster.
 func (tc *testContext) testWindowsNodeDeletion(t *testing.T) {
+	tc.cleanupDeployments()
 	// Deploy a DaemonSet and wait until its pods have been made ready on each Windows node. DaemonSet pods cannot be
 	// drained from a Node.
 	// Doing this ensures that WMCO is able to handle containers being present on the instance when deconfiguring.
@@ -278,4 +280,21 @@ func (tc *testContext) waitUntilDaemonsetScaled(name string, desiredReplicas int
 		time.Sleep(retryInterval)
 	}
 	return fmt.Errorf("timed out waiting for daemonset %s to scale, current status: %+v", name, ds.Status)
+}
+
+// cleanupWorkloads attempts to delete all deployments that exist within the testContext workload namespace
+func (tc *testContext) cleanupDeployments() {
+	deployments, err := tc.client.K8s.AppsV1().Deployments(tc.workloadNamespace).List(context.TODO(), meta.ListOptions{})
+	if err != nil {
+		log.Printf("error getting deployment list: %s", err)
+		return
+	}
+	for _, deployment := range deployments.Items {
+		log.Printf("deleting deployment %s", deployment.GetName())
+		err := tc.client.K8s.AppsV1().Deployments(tc.workloadNamespace).Delete(context.TODO(), deployment.GetName(),
+			meta.DeleteOptions{})
+		if err != nil {
+			log.Printf("error deleting deployment %s: %s", deployment.GetName(), err)
+		}
+	}
 }

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -27,7 +27,10 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"kubelet/kubelet.log",
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
-		"csi-proxy/csi-proxy.log",
+	}
+	// TODO: Always collect csi-proxy log when no longer upgrading from in-tree to CSI for any platform
+	if !inTreeUpgrade {
+		mandatoryLogs = append(mandatoryLogs, "csi-proxy/csi-proxy.log")
 	}
 	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
 	for _, node := range gc.allNodes() {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,6 +27,8 @@ var (
 	numberOfBYOHNodes int
 	// privateKeyPath is the path of the private key file used to configure the Windows node
 	privateKeyPath string
+	// skipWorkloadDeletion indicates that worklaods should not be deleted when tests complete
+	skipWorkloadDeletion bool
 	// wmcoNamespace is the namespace WMCO is deployed to
 	wmcoNamespace string
 	// windowsServerVersion is the Windows Server version to test against
@@ -148,6 +150,8 @@ func TestMain(m *testing.M) {
 		"Namespace that WMCO is deployed to")
 	flag.StringVar(&privateKeyPath, "private-key-path", "",
 		"path of the private key file used to configure the Windows node")
+	flag.BoolVar(&skipWorkloadDeletion, "skip-workload-deletion", false,
+		"skips deletion of workloads at the end of tests")
 	flag.Func("windows-server-version", "Windows Server version to test. "+
 		"Supported versions: 2019 or 2022 (default 2022)",
 		func(value string) error {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,6 +27,9 @@ var (
 	numberOfBYOHNodes int
 	// privateKeyPath is the path of the private key file used to configure the Windows node
 	privateKeyPath string
+	// inTreeUpgrade indicates if tests should be ran to test upgrading from an in-tree storage solution to CSI.
+	// This will cause in tree storage volumes and related resources to be deployed where appropriate, instead of CSI.
+	inTreeUpgrade bool
 	// skipWorkloadDeletion indicates that worklaods should not be deleted when tests complete
 	skipWorkloadDeletion bool
 	// wmcoNamespace is the namespace WMCO is deployed to
@@ -166,6 +169,9 @@ func TestMain(m *testing.M) {
 			return nil
 		})
 	flag.Parse()
+	if val := os.Getenv("UPGRADE_FROM_IN_TREE"); val == "true" {
+		inTreeUpgrade = true
+	}
 
 	os.Exit(m.Run())
 }

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -5,10 +5,13 @@ import (
 	"log"
 	"testing"
 
+	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
 
 // testStorage tests that persistent volumes can be accessed by Windows pods
@@ -17,6 +20,9 @@ func testStorage(t *testing.T) {
 	require.NoError(t, err)
 	if !tc.StorageSupport() {
 		t.Skip("storage is not supported on this platform")
+	}
+	if inTreeUpgrade && tc.CloudProvider.GetType() != config.VSpherePlatformType {
+		t.Skip("in tree upgrade is only testable on vSphere")
 	}
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
@@ -27,9 +33,16 @@ func testStorage(t *testing.T) {
 	// Create the PVC and choose the node the deployment will be scheduled on. This is necessary as ReadWriteOnly
 	// volumes can only be bound to a single node.
 	// https://docs.openshift.com/container-platform/4.12/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage
-	var pvcVolumeSource *core.PersistentVolumeClaimVolumeSource
-	pvc, err := tc.CloudProvider.CreatePVC(tc.client.K8s, tc.workloadNamespace)
-	require.NoError(t, err)
+	var pvc *core.PersistentVolumeClaim
+	if inTreeUpgrade {
+		vsphereProvider, ok := tc.CloudProvider.(*vsphere.Provider)
+		require.True(t, ok, "in tree upgrade must be ran on vSphere")
+		pvc, err = vsphereProvider.CreateInTreePVC(tc.client.K8s, tc.workloadNamespace)
+		require.NoError(t, err)
+	} else {
+		pvc, err = tc.CloudProvider.CreatePVC(tc.client.K8s, tc.workloadNamespace)
+		require.NoError(t, err)
+	}
 	if !skipWorkloadDeletion {
 		defer func() {
 			err := tc.client.K8s.CoreV1().PersistentVolumeClaims(tc.workloadNamespace).Delete(context.TODO(),
@@ -39,7 +52,7 @@ func testStorage(t *testing.T) {
 			}
 		}()
 	}
-	pvcVolumeSource = &core.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
+	pvcVolumeSource := &core.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
 	affinity, err := getAffinityForNode(&gc.allNodes()[0])
 	require.NoError(t, err)
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
 
 const (
@@ -216,6 +217,17 @@ func TestUpgrade(t *testing.T) {
 	t.Run("Node annotations", tc.testNodeAnnotations)
 	t.Run("Node Metadata", tc.testNodeMetadata)
 
+	if inTreeUpgrade {
+		// Deploy the CSI drivers and wait for a CSI node to be created
+		// This is a requirement for storage workloads to go back to ready
+		vsphereProvider, ok := tc.CloudProvider.(*vsphere.Provider)
+		require.True(t, ok, "in tree upgrade must be ran on vSphere")
+		require.NoError(t, vsphereProvider.EnsureWindowsCSIDrivers(tc.client.K8s))
+		log.Printf("waiting for csinodes to reflect driver deployment")
+		err = tc.waitForCSINodesWithDrivers(gc.allNodes())
+		require.NoError(t, err)
+	}
+
 	// test that any workloads deployed on the node have not been broken by the upgrade
 	t.Run("Workloads ready", tc.testWorkloadsAvailable)
 	t.Run("Node Logs", tc.testNodeLogs)
@@ -240,4 +252,33 @@ func (tc *testContext) testWorkloadsAvailable(t *testing.T) {
 			return true, nil
 		})
 	assert.NoError(t, err)
+}
+
+// waitForCSINodes waits for a CSINode to exist for each node with a driver loaded, indicating CSI functionality has
+// been enabled for the given node.
+func (tc *testContext) waitForCSINodesWithDrivers(nodes []v1.Node) error {
+	return wait.PollImmediate(retry.Interval, 10*time.Minute, func() (bool, error) {
+		csinodes, err := tc.client.K8s.StorageV1().CSINodes().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			log.Printf("error listing CSINodes: %s", err)
+			return false, nil
+		}
+		for _, node := range nodes {
+			var ready bool
+			for _, csinode := range csinodes.Items {
+				if csinode.GetName() == node.GetName() {
+					if len(csinode.Spec.Drivers) != 1 {
+						log.Printf("CSINode for %s is missing driver", node.GetName())
+						break
+					}
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -223,7 +223,7 @@ func TestUpgrade(t *testing.T) {
 
 // testWorkloadsAvailable tests that all workloads deployed on Windows nodes by the test suite are available
 func (tc *testContext) testWorkloadsAvailable(t *testing.T) {
-	err := wait.PollImmediateWithContext(context.TODO(), retry.Interval, retry.ResourceChangeTimeout,
+	err := wait.PollImmediateWithContext(context.TODO(), retry.Interval, retry.Timeout,
 		func(ctx context.Context) (bool, error) {
 			deployments, err := tc.client.K8s.AppsV1().Deployments(tc.workloadNamespace).List(ctx, metav1.ListOptions{})
 			if err != nil {


### PR DESCRIPTION
Adds various changes required to test upgrading a Windows node from a version of WMCO which supports in-tree storage drivers, to a version that does not.

The changes within `Enable upgrading from in-tree to CSI ` should be reverted when branching for OCP 4.15 occurs, as they will break the tests. Those changes have been labeled with a TODO, and have been purposely been made easily removable.