### PR TITLE
WINC-998: Clear proxy variables from Windows nodes

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	// SupportedProxyVars is a list of the supported proxy variables
-	SupportedProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+	// WatchedEnvironmentVars is a list of the WMCO watched environment variables
+	WatchedEnvironmentVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 	// clusterWideProxyVars is a map of the global egress proxy variables and values from WMCO's environment
 	clusterWideProxyVars map[string]string
 )
@@ -363,7 +363,7 @@ func GetProxyVars() map[string]string {
 	// if clusterWideProxyVars is not already cached, initialize it. We never expect these values to change during
 	// runtime as OLM restarts the operator when the global cluster proxy config changes
 	clusterWideProxyVars = make(map[string]string, 3)
-	for _, envVar := range SupportedProxyVars {
+	for _, envVar := range WatchedEnvironmentVars {
 		value, found := os.LookupEnv(envVar)
 		if found {
 			// on Windows, hostname lists are separated by semicolons rather than the Linux default of commas

--- a/pkg/daemon/cleanup/cleanup_test.go
+++ b/pkg/daemon/cleanup/cleanup_test.go
@@ -137,6 +137,46 @@ func TestMergeServices(t *testing.T) {
 	}
 }
 
+func TestMerge(t *testing.T) {
+	testIO := []struct {
+		name     string
+		list1    []string
+		list2    []string
+		expected []string
+	}{
+		{
+			name:     "both empty",
+			list1:    []string{},
+			list2:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "one empty",
+			list1:    []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+			list2:    []string{},
+			expected: []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+		},
+		{
+			name:     "different lists",
+			list1:    []string{"HTTP_PROXY"},
+			list2:    []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+			expected: []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+		},
+		{
+			name:     "overlapping lists",
+			list1:    []string{"HTTP_PROXY", "HTTPS_PROXY"},
+			list2:    []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+			expected: []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"},
+		},
+	}
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			out := merge(test.list1, test.list2)
+			assert.ElementsMatch(t, out, test.expected)
+		})
+	}
+}
+
 func newTestService(name string, dependencies []string) *fake.FakeService {
 	return fake.NewFakeService(
 		name,

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -301,7 +301,7 @@ func (sc *ServiceController) reconcileEnvironmentVariables(envVars map[string]st
 	err = wait.PollUntilContextTimeout(sc.ctx, 15*time.Second, 5*time.Minute, true,
 		func(ctx context.Context) (done bool, err error) {
 			stillNeedsReboot := false
-			for _, varName := range cluster.SupportedProxyVars {
+			for _, varName := range cluster.WatchedEnvironmentVars {
 				cmd := fmt.Sprintf("[Environment]::GetEnvironmentVariable('%s', 'Process')", varName)
 				out, err := sc.psCmdRunner.Run(cmd)
 				if err != nil {

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 	core "k8s.io/api/core/v1"
@@ -50,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
+	"github.com/openshift/windows-machine-config-operator/pkg/daemon/envvar"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/manager"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/powershell"
 	"github.com/openshift/windows-machine-config-operator/pkg/daemon/winsvc"
@@ -285,7 +285,7 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 // reconcileEnvironmentVariables makes sure that the proxy variables exist as expected, or are safely rectified.
 // Returns a boolean expressing whether the instance is awaiting a reboot.
 func (sc *ServiceController) reconcileEnvironmentVariables(envVars map[string]string, node core.Node) (bool, error) {
-	restartRequired, err := sc.ensureVarsAreUpToDate(envVars)
+	restartRequired, err := envvar.EnsureVarsAreUpToDate(envVars)
 	if err != nil {
 		return false, err
 	}
@@ -317,44 +317,6 @@ func (sc *ServiceController) reconcileEnvironmentVariables(envVars map[string]st
 		return true, fmt.Errorf("error waiting for environment vars to get picked up by processes: %w", err)
 	}
 	return false, nil
-}
-
-// ensureVarsAreUpToDate ensures that the proxy environment variables are set as expected on the instance
-// If there's any changes, an instance restart is required to ensure all processes pick up the updated values.
-func (sc *ServiceController) ensureVarsAreUpToDate(envVars map[string]string) (bool, error) {
-	// systemEnvVarRegistryPath is where system level environment variables are stored in the Windows OS
-	const systemEnvVarRegistryPath = `SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
-	restartRequired := false
-	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, systemEnvVarRegistryPath, registry.ALL_ACCESS)
-	if err != nil {
-		return false, fmt.Errorf("unable to open Windows system registry key %s: %w", systemEnvVarRegistryPath, err)
-	}
-	defer func() { // always close the registry key, without swallowing any error returned before the defer call
-		closeErr := registryKey.Close()
-		if closeErr != nil {
-			klog.Errorf("could not close key %v: %v", registryKey, closeErr)
-		}
-	}()
-	for key, expectedVal := range envVars {
-		actualVal, _, err := registryKey.GetStringValue(key)
-		if err != nil && err != registry.ErrNotExist {
-			return false, fmt.Errorf("unable to read environment variable %s: %w", key, err)
-		}
-
-		if actualVal != expectedVal {
-			klog.Infof("updating environment variable %s", key)
-			// Because we modify env vars are the "system" level rather than the ephemeral "process" level,
-			// we cannot use os.Setenv, which is a wrapper for syscall.SetEnvironmentVariable
-			// As per Microsoft docs: "Calling SetEnvironmentVariable has no effect on the system environment variables"
-			err := registryKey.SetStringValue(key, expectedVal)
-			if err != nil {
-				// Do not log value as proxy information is sensitive
-				return false, fmt.Errorf("unable to set environment variable %s: %w", key, err)
-			}
-			restartRequired = true
-		}
-	}
-	return restartRequired, nil
 }
 
 // reconcileServices ensures that all the services passed in via the services slice are created, configured properly

--- a/pkg/daemon/envvar/envvar.go
+++ b/pkg/daemon/envvar/envvar.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envvar
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+	"k8s.io/klog/v2"
+)
+
+// systemEnvVarRegistryPath is where system level environment variables are stored in the Windows OS
+const systemEnvVarRegistryPath = `SYSTEM\CurrentControlSet\Control\Session Manager\Environment`
+
+// EnsureVarsAreUpToDate ensures that the proxy environment variables are set as expected on the instance
+// If there's any changes, an instance restart is required to ensure all processes pick up the updated values.
+func EnsureVarsAreUpToDate(envVars map[string]string) (bool, error) {
+	restartRequired := false
+	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, systemEnvVarRegistryPath, registry.ALL_ACCESS)
+	if err != nil {
+		return false, fmt.Errorf("unable to open Windows system registry key %s: %w",
+			systemEnvVarRegistryPath, err)
+	}
+	defer func() { // always close the registry key, without swallowing any error returned before the defer call
+		closeErr := registryKey.Close()
+		if closeErr != nil {
+			klog.Errorf("could not close key %v: %v", registryKey, closeErr)
+		}
+	}()
+	for key, expectedVal := range envVars {
+		actualVal, _, err := registryKey.GetStringValue(key)
+		if err != nil && err != registry.ErrNotExist {
+			return false, fmt.Errorf("unable to read environment variable %s: %w", key, err)
+		}
+
+		if actualVal != expectedVal {
+			klog.Infof("updating environment variable %s", key)
+			// Because we modify env vars are the "system" level rather than the ephemeral "process" level,
+			// we cannot use os.Setenv, which is a wrapper for syscall.SetEnvironmentVariable
+			// As per Microsoft docs: "Calling SetEnvironmentVariable has no effect on the system environment variables"
+			err := registryKey.SetStringValue(key, expectedVal)
+			if err != nil {
+				// Do not log value as proxy information is sensitive
+				return false, fmt.Errorf("unable to set environment variable %s: %w", key, err)
+			}
+			restartRequired = true
+		}
+	}
+	return restartRequired, nil
+}

--- a/pkg/daemon/envvar/envvar.go
+++ b/pkg/daemon/envvar/envvar.go
@@ -2,10 +2,13 @@
 
 /*
 Copyright 2023.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +30,7 @@ const systemEnvVarRegistryPath = `SYSTEM\CurrentControlSet\Control\Session Manag
 
 // EnsureVarsAreUpToDate ensures that the proxy environment variables are set as expected on the instance
 // If there's any changes, an instance restart is required to ensure all processes pick up the updated values.
-func EnsureVarsAreUpToDate(envVars map[string]string) (bool, error) {
+func EnsureVarsAreUpToDate(envVars map[string]string, watchedEnvVars []string) (bool, error) {
 	restartRequired := false
 	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, systemEnvVarRegistryPath, registry.ALL_ACCESS)
 	if err != nil {
@@ -40,6 +43,20 @@ func EnsureVarsAreUpToDate(envVars map[string]string) (bool, error) {
 			klog.Errorf("could not close key %v: %v", registryKey, closeErr)
 		}
 	}()
+
+	var envVarsToRemove []string
+	for _, watchedEnvVar := range watchedEnvVars {
+		if _, ok := envVars[watchedEnvVar]; !ok {
+			envVarsToRemove = append(envVarsToRemove, watchedEnvVar)
+		}
+	}
+	if len(envVarsToRemove) != 0 {
+		restartRequired, err = EnsureEnvVarsAreRemoved(registryKey, envVarsToRemove)
+		if err != nil {
+			return false, fmt.Errorf("error removing envionment variables %v: %v", envVarsToRemove, err)
+		}
+	}
+
 	for key, expectedVal := range envVars {
 		actualVal, _, err := registryKey.GetStringValue(key)
 		if err != nil && err != registry.ErrNotExist {
@@ -56,6 +73,24 @@ func EnsureVarsAreUpToDate(envVars map[string]string) (bool, error) {
 				// Do not log value as proxy information is sensitive
 				return false, fmt.Errorf("unable to set environment variable %s: %w", key, err)
 			}
+			restartRequired = true
+		}
+	}
+	return restartRequired, nil
+}
+
+// EnsureEnvVarsAreRemoved ensures that the given environment variables are removed from the instance's Windows registry
+// An instance restart is required after they are removed to ensure all processes pick up the updated values.
+func EnsureEnvVarsAreRemoved(registryKey registry.Key, envVarsToRemove []string) (bool, error) {
+	restartRequired := false
+	for _, envVar := range envVarsToRemove {
+		err := registryKey.DeleteValue(envVar)
+		if err != nil {
+			if err != registry.ErrNotExist {
+				return false, err
+			}
+		} else {
+			klog.Infof("Removed environment variable %s", envVar)
 			restartRequired = true
 		}
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -520,7 +520,10 @@ func (nc *nodeConfig) Deconfigure() error {
 	if err := nc.Windows.Deconfigure(nc.wmcoNamespace, wicdKC); err != nil {
 		return fmt.Errorf("error deconfiguring instance: %w", err)
 	}
-
+	// Wait for reboot annotation removal. This prevents deleting the node until the node no longer needs reboot.
+	if err := metadata.WaitForRebootAnnotationRemoval(context.TODO(), nc.client, nc.node.Name); err != nil {
+		return err
+	}
 	nc.log.Info("instance has been deconfigured", "node", nc.node.GetName())
 	return nil
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -52,7 +52,11 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 	}
 	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847
 	files := &[]servicescm.FileInfo{}
-	return servicescm.NewData(services, files, cluster.GetProxyVars())
+	var watchedEnvVars []string
+	for _, envVar := range cluster.WatchedEnvironmentVars {
+		watchedEnvVars = append(watchedEnvVars, envVar)
+	}
+	return servicescm.NewData(services, files, cluster.GetProxyVars(), watchedEnvVars)
 }
 
 // containerdConfiguration returns the service specification for the Windows containerd service


### PR DESCRIPTION
This PR implements the following scenarios:
1. On existing Windows nodes, when an cluster-wide proxy is removed WICD is able to remove the ENV variables on the instance.
2. When a node deconfiguration occurs, WICD cleanup command will remove the ENV vars set on the instance if cluster-wide proxy is enabled. This includes HTTP_PROXY, HTTPS_PROXY, NO_PROXY being removed from the instance along with the keys set in the Windows registry.