### PR TITLE
WMCO removes reboot annotation instead of WICD

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -263,8 +263,8 @@ func (nc *nodeConfig) SafeReboot(ctx context.Context) error {
 	if err := nc.Windows.RebootAndReinitialize(); err != nil {
 		return err
 	}
-	// wait for WICD to remove Reboot annotation
-	if err := metadata.WaitForRebootAnnotationRemoval(ctx, nc.client, nc.node.Name); err != nil {
+	// Remove the reboot annotation after we can re-init an SSH connection so we know the reboot occurred successfully
+	if err := metadata.RemoveRebootAnnotation(ctx, nc.client, *nc.node); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR flips the waiting and removal of the reboot annotation, with WICD now waiting on WMCO to remove the annotation. The reason for this is to decouple WMCO's node controller from the WICD controller -- WMCO removes the reboot annotation as soon as the instance is reachable again after rebooting. Now the safeReboot() func returns after it has done just that, safely rebooted, without waiting on some extra WICD signal.