### PR TITLE
[hack] Improve vSphere CSI Manifests

### DIFF
--- a/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
+++ b/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
@@ -143,28 +143,3 @@ spec:
           operator: Exists
         - effect: NoSchedule
           operator: Exists
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: example-windows-pvc
-  namespace: openshift-cluster-csi-drivers
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
-  storageClassName: example-windows-sc
-  volumeMode: Filesystem
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: example-windows-sc
-  namespace: openshift-cluster-csi-drivers
-provisioner: csi.vsphere.vmware.com
-allowVolumeExpansion: true  # Optional: only applicable to vSphere 7.0U1 and above
-parameters:
-  #datastoreurl: "ds:///vmfs/volumes/vsan:52cdfa80721ff516-ea1e993113acfc77/"  # Optional Parameter
-  csi.storage.k8s.io/fstype: "ntfs"

--- a/hack/manifests/csi/vsphere/02-example-namespace.yaml
+++ b/hack/manifests/csi/vsphere/02-example-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-storage-example
+  labels:
+    # Windows storage resources must be deployed in a privileged namespace with a disabled pod security admission label
+    # synchronization
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: privileged

--- a/hack/manifests/csi/vsphere/03-example-sc.yaml
+++ b/hack/manifests/csi/vsphere/03-example-sc.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-windows-sc
+  namespace: windows-storage-example
+provisioner: csi.vsphere.vmware.com
+parameters:
+  # vSphere Container Storage Plug-in only supports NTFS file system on Windows nodes
+  csi.storage.k8s.io/fstype: "ntfs"

--- a/hack/manifests/csi/vsphere/04-example-pvc.yaml
+++ b/hack/manifests/csi/vsphere/04-example-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-windows-pvc
+  namespace: windows-storage-example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: example-windows-sc
+  volumeMode: Filesystem

--- a/hack/manifests/csi/vsphere/05-example-deployment.yaml
+++ b/hack/manifests/csi/vsphere/05-example-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example-windows-pod
+  name: example-windows-pod
+  # must be in the same namespace as the PVC
+  namespace: windows-storage-example
+spec:
+  selector:
+    matchLabels:
+      app: example-windows-pod
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: example-windows-pod
+      name: example-windows-pod
+    spec:
+      os:
+        name: windows
+      tolerations:
+        - key: "os"
+          value: "Windows"
+          Effect: "NoSchedule"
+      containers:
+        - name: example-windows-container
+          image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
+          imagePullPolicy: IfNotPresent
+          command:
+            - pwsh.exe
+            - -command
+            - "$filepath='C:\\test\\csi\\timestamp.txt'; New-Item -Path $filepath -Force ;while (1) { Add-Content -Encoding Ascii $filepath $(Get-Date -Format u); sleep 10 }"
+          volumeMounts:
+            - name: test-volume
+              mountPath: "/test/"
+              readOnly: false
+      volumes:
+        - name: test-volume
+          persistentVolumeClaim:
+            claimName: example-windows-pvc
+      nodeSelector:
+        kubernetes.io/os: windows


### PR DESCRIPTION
Separates the manifests in the ideal order that they should be
deployed. 
Adds an example deployment spec and custom namespace used
to confirm a Windows pod with a storage mount file can be written to a
desired mount path.