### PR TITLE
Add csi-proxy logs collection in e2e test suite

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -27,6 +27,7 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"kubelet/kubelet.log",
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
+		"csi-proxy/csi-proxy.log",
 	}
 	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
 	for _, node := range gc.allNodes() {


### PR DESCRIPTION
This PR adds the csi-proxy.log to the list of required logs to collect in the e2e test suite, so that the csi-proxy logs are kept in the artifact folder.

Follow-up to:
- https://github.com/openshift/windows-machine-config-operator/pull/1530