### PR TITLE
Adjust verbosity for csi-proxy service

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -45,7 +45,7 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 		kubeletConfiguration,
 		hybridOverlayConfiguration(vxlanPort, debug),
 		kubeProxyConfiguration(debug),
-		csiProxyConfiguration(),
+		csiProxyConfiguration(debug),
 	}
 	if platform == config.AzurePlatformType && ccmEnabled {
 		*services = append(*services, azureCloudNodeManagerConfiguration())
@@ -164,9 +164,11 @@ func kubeProxyConfiguration(debug bool) servicescm.Service {
 }
 
 // csiProxyConfiguration returns the Service definition for csi-proxy
-func csiProxyConfiguration() servicescm.Service {
+func csiProxyConfiguration(debug bool) servicescm.Service {
 	serviceCmd := fmt.Sprintf("%s -log_file=%s -logtostderr=false -windows-service", windows.CSIProxyPath,
 		windows.CSIProxyLog)
+	// Set log level
+	serviceCmd = fmt.Sprintf("%s %s", serviceCmd, klogVerbosityArg(debug))
 	return servicescm.Service{
 		Name:                   "csi-proxy",
 		Command:                serviceCmd,


### PR DESCRIPTION
This change updates the configuration of the csi-proxy service so that it can adjust verbosity based on the operator's debug flag.


The following snippet shows the configuration of the csi-proxy service.
```powershell
PS C:\var\log\wicd> sc.exe qc csi-proxy
[SC] QueryServiceConfig SUCCESS

SERVICE_NAME: csi-proxy
        TYPE               : 10  WIN32_OWN_PROCESS
        START_TYPE         : 3   DEMAND_START
        ERROR_CONTROL      : 0   IGNORE
        BINARY_PATH_NAME   : C:\k\csi-proxy.exe -log_file=C:\var\log\csi-proxy\csi-proxy.log -logtostderr=false -windows-service --v=4
        LOAD_ORDER_GROUP   :
        TAG                : 0
        DISPLAY_NAME       : csi-proxy
        DEPENDENCIES       :
        SERVICE_START_NAME : LocalSystem

```

Follow-up to:
- https://github.com/openshift/windows-machine-config-operator/pull/1530