### PR TITLE
[aws] Avoid Windows Server 2019 `Containers` image

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -80,7 +80,7 @@ get_aws_ms() {
 
   local filter="Windows_Server-2022-English-Core-Base-????.??.??"
   if [ "$winver" == "2019" ]; then
-    filter="Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
+    filter="Windows_Server-2019-English-Core-Base-????.??.??"
   fi
 
   # get the AMI id for the Windows VM

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -60,7 +60,7 @@ func newEC2Client(region string) (*ec2.EC2, error) {
 func getWindowsAMIFilter(windowsServerVersion windows.ServerVersion) string {
 	switch windowsServerVersion {
 	case windows.Server2019:
-		return "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
+		return "Windows_Server-2019-English-Core-Base-????.??.??"
 	case windows.Server2022:
 	default:
 	}


### PR DESCRIPTION
This PR moves away from using Windows Server 2019 that have Docker pre-installed in CI as these images have been pulled from AWS. We had been using them for test coverage as we required pre-installed Docker runtime in 4.10 and below, before moving to containerd (WMCO-managed).
Moved to `Core` instead of `Full` as we use that in for 2022 images and it is more lightweight/faster startup time.