### PR TITLE
[release-4.10][build] Configure cgo exclusion

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,10 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 as build
 LABEL stage=build
 
+# Add exclusion from forced cgo enabling as it breaks containerd builds
+# TODO: Remove as part of https://issues.redhat.com/browse/WINC-1095
+ENV GO_COMPLIANCE_CGO_ENABLED_EXCLUDE=1
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,6 +1,10 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 as build
 LABEL stage=build
 
+# Add exclusion from forced cgo enabling as it breaks containerd builds
+# TODO: Remove as part of https://issues.redhat.com/browse/WINC-1095
+ENV GO_COMPLIANCE_CGO_ENABLED_EXCLUDE=1
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,6 +7,10 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 as 
 LABEL stage=build
 WORKDIR /build/
 
+# Add exclusion from forced cgo enabling as it breaks containerd builds
+# TODO: Remove as part of https://issues.redhat.com/browse/WINC-1095
+ENV GO_COMPLIANCE_CGO_ENABLED_EXCLUDE=1
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -23,6 +23,9 @@ SKIP_NODE_DELETION=""
 WMCO_PATH_OPTION=""
 
 export CGO_ENABLED=0
+# Add exclusion from forced cgo enabling as it breaks containerd builds
+# TODO: Remove as part of https://issues.redhat.com/browse/WINC-1095
+export GO_COMPLIANCE_CGO_ENABLED_EXCLUDE=1
 
 get_WMCO_logs() {
   retries=0


### PR DESCRIPTION
cgo is now being enabled by the base image we use. This is causing containerd builds to fail with:
unrecognized command-line option '-mthreads'; did you mean '-pthread'?

In this PR, we enable the cgo exclusion the OCP wrapper looks for to fix this issue and unblock builds.