### PR TITLE
[release-4.11] [aws] Avoid Windows Server 2019 `Containers` image

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -79,7 +79,7 @@ get_aws_ms() {
   local provider=$4
 
   # get the AMI id for the Windows VM
-  ami_id=$(aws ec2 describe-images --region ${region} --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output json | jq -r '.[2].id')
+  ami_id=$(aws ec2 describe-images --region ${region} --filters "Name=name,Values=Windows_Server-2019-English-Core-Base*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output json | jq -r '.[0].id')
   if [ -z "$ami_id" ]; then
         error-exit "unable to find AMI ID for Windows Server 2019 1809"
   fi

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -96,18 +96,19 @@ func New(oc *clusterinfo.OpenShift, infraStatus *config.InfrastructureStatus) (*
 	return awsProvider, nil
 }
 
-// getLatestWindowsAMI returns the imageid of the latest released "Windows Server with Containers" image
+// getLatestWindowsAMI returns the imageid of the latest released Windows Server 2019 image.
+// Images with Docker pre-installed ("with Containers") have been removed by Amazon
 func getLatestWindowsAMI(ec2Client *ec2.EC2) (string, error) {
 	// Have to create these variables, as the below functions require pointers to them
 	windowsAMIOwner := "amazon"
 	windowsAMIFilterName := "name"
 	// This filter will grab all ami's that match the exact name. The '?' indicate any character will match.
-	// The ami's will have the name format: Windows_Server-2019-English-Full-ContainersLatest-2022.01.19
+	// The ami's will have the name format: Windows_Server-2019-English-Core-Base-2023.07.12
 	// so the question marks will match the date of creation
 	// The image obtained by using windowsAMIFilterValue is compatible with the test container image -
 	// "mcr.microsoft.com/powershell:lts-nanoserver-1809".
 	// If the windowsAMIFilterValue changes, the test container image also needs to be changed.
-	windowsAMIFilterValue := "Windows_Server-2019-English-Full-ContainersLatest-????.??.??"
+	windowsAMIFilterValue := "Windows_Server-2019-English-Core-Base-????.??.??"
 	searchFilter := ec2.Filter{Name: &windowsAMIFilterName, Values: []*string{&windowsAMIFilterValue}}
 
 	describedImages, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{


### PR DESCRIPTION
This is an manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1723