### PR TITLE
OCPBUGS-17528: Get kubeletCA from controller configuration

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -327,6 +327,13 @@ spec:
         - apiGroups:
           - machineconfiguration.openshift.io
           resources:
+          - controllerconfigs
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
           - machineconfigs
           verbs:
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -180,6 +180,13 @@ rules:
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
+  - controllerconfigs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
   - machineconfigs
   verbs:
   - list

--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -13,8 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Watch permission are needed in order to populate the cache. We use a cached client to list machineconfig resources.
+// Watch permission are needed in order to populate the cache. We use a cached client to list machineconfig and
+// controllerconfig resources.
 //+kubebuilder:rbac:groups="machineconfiguration.openshift.io",resources=machineconfigs,verbs=list;watch
+//+kubebuilder:rbac:groups="machineconfiguration.openshift.io",resources=controllerconfigs,verbs=list;watch
 
 const (
 	// kubeletSystemdName is the name of the systemd service that the kubelet runs under,
@@ -27,15 +29,14 @@ const (
 	// RenderedWorkerPrefix allows identification of the rendered worker MachineConfig, the combination of all worker
 	// MachineConfigs.
 	RenderedWorkerPrefix = "rendered-worker-"
-	// KubeletCACertPath is the path to the kubelet's client CA certificate as defined in ignition
-	KubeletCACertPath = "/etc/kubernetes/kubelet-ca.crt"
 	// CloudConfigPath is the path to the cloud config file as defined in ignition
 	CloudConfigPath = "/etc/kubernetes/cloud.conf"
 )
 
-// Ignition is a representation of an Ignition file
+// Ignition is a representation of an Ignition resource
 type Ignition struct {
-	config ignCfgTypes.Config
+	config        ignCfgTypes.Config
+	kubeletCAData []byte
 }
 
 // New returns a new instance of Ignition
@@ -60,7 +61,31 @@ func New(c client.Client) (*Ignition, error) {
 	}
 	log.V(1).Info("parsed", "machineconfig", renderedWorker.GetName(), "ignition version",
 		configuration.Ignition.Version)
+
+	ccList := mcfg.ControllerConfigList{}
+	if err := c.List(context.TODO(), &ccList); err != nil {
+		return nil, err
+	}
+	var kubeletCAData []byte
+	for _, item := range ccList.Items {
+		if item.Spec.KubeAPIServerServingCAData != nil {
+			log.V(1).Info("processing kubelet-ca", "ControllerConfig", item.Name)
+			kubeletCAData = item.Spec.KubeAPIServerServingCAData
+			break
+		}
+	}
+	if len(kubeletCAData) == 0 {
+		return nil, fmt.Errorf("cannot find kubelet-ca")
+	}
+	// set kubelet-ca raw data
+	ign.kubeletCAData = kubeletCAData
+
 	return ign, nil
+}
+
+// GetKubeletCAData is a getter for kubelet CA raw data
+func (ign *Ignition) GetKubeletCAData() []byte {
+	return ign.kubeletCAData
 }
 
 // GetFiles is a getter for the files embedded within the ignition spec

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -346,13 +346,17 @@ func (nc *nodeConfig) createFilesFromIgnition() (map[string]string, error) {
 		return nil, err
 	}
 
-	filesToTransfer := map[string]struct{}{
-		ignition.KubeletCACertPath: {},
-	}
+	filesToTransfer := map[string]struct{}{}
 	if _, ok := kubeletArgs[ignition.CloudConfigOption]; ok {
 		filesToTransfer[ignition.CloudConfigPath] = struct{}{}
 	}
 	filePathsToContents := make(map[string]string)
+	// process kubelet-ca
+	filePathsToContents[windows.K8sDir+"\\"+KubeletClientCAFilename] = string(ign.GetKubeletCAData())
+	// loop through all the files in the ignition if they are files to transfer
+	if len(filesToTransfer) == 0 {
+		return filePathsToContents, nil
+	}
 	// For each new file in the ignition file check if is a file we are interested in and, if so, decode its contents
 	for _, ignFile := range ign.GetFiles() {
 		if _, ok := filesToTransfer[ignFile.Node.Path]; ok {


### PR DESCRIPTION
This change pulls the kubelet CA from the machine's controller configuration, given it is getting removed from the machine ignition files.

Refs:
- https://github.com/openshift/machine-config-operator/pull/3787