### PR TITLE
WINC-1092: [release-4.11][docs] Drop AWS support in WMCO 5.x and lower

### DIFF
--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -5,14 +5,14 @@ may be relevant.
 ## Supported Cloud Providers based on OKD/OCP Version and WMCO version
 | Cloud Provider            | Supported OKD/OCP Version | Supported WMCO version |
 |---------------------------|---------------------------|------------------------|
-| Amazon Web Services (AWS) | 4.6+                      | WMCO 1.0+              |
 | VMware vSphere            | 4.7+                      | WMCO 2.0+              |
 | Platform none (BYOH)      | 4.8+                      | WMCO 3.1.0+            |
 | Azure                     | 4.11+                     | WMCO 6.0+              |
+| Amazon Web Services (AWS) | 4.11+                     | WMCO 6.0+              |
 
-Note: We added Azure support in 4.6 but given that Microsoft has [stopped publishing Windows Server 2019 images with
+Note: We added Azure and AWS support in 4.6 but given that Microsoft and AWS have [stopped publishing Windows Server 2019 images with
 Docker](https://techcommunity.microsoft.com/t5/containers/important-update-deprecation-of-docker-virtual-machine-images/ba-p/3646272),
-we have decided to drop Azure support for releases older than 6.0.0. For 5.y.z and below it was a requirement for
+we have decided to drop Azure and AWS support for releases older than 6.0.0. For 5.y.z and below it was a requirement for
 the Windows Server 2019 images to have Docker pre-installed. From 6.0.0 onwards we are using containerd as the
 runtime and it is WMCO's responsibility to manage that.
 


### PR DESCRIPTION
Explain why we are dropping AWS support in WMCO 5.x and lower.

(manually cherry picked from commit https://github.com/openshift/windows-machine-config-operator/commit/e0020e5fc991f9905b37a9ea92336910d542b012)