### PR TITLE
Use ParseCompatibleVersion when parsing ignition

### DIFF
--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -52,14 +52,14 @@ func New(c client.Client) (*Ignition, error) {
 		return nil, err
 	}
 
-	configuration, report, err := ignCfg.Parse(renderedWorker.Spec.Config.Raw)
+	configuration, report, err := ignCfg.ParseCompatibleVersion(renderedWorker.Spec.Config.Raw)
 	if err != nil || report.IsFatal() {
 		return nil, fmt.Errorf("failed to parse MachineConfig ignition: %v\nReport: %v", err, report)
 	}
 	ign := &Ignition{
 		config: configuration,
 	}
-	log.V(1).Info("parsed", "machineconfig", renderedWorker.GetName(), "ignition version",
+	log.V(1).Info("parsed", "machineconfig", renderedWorker.GetName(), "using ignition version",
 		configuration.Ignition.Version)
 
 	ccList := mcfg.ControllerConfigList{}


### PR DESCRIPTION
Uses this function instead of Parse(), so that this can be backported to release-4.13. This will stop wmco 8.y.z from crashing upon cluster upgrade to 4.14, due to it being unable to parse the 3.4 ignition spec present on 4.14.