### PR TITLE
[release-4.13] [hack] Improve vSphere CSI Manifests

### DIFF
--- a/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
+++ b/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
@@ -1,0 +1,145 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vmware-vsphere-csi-driver-node-windows
+  namespace: openshift-cluster-csi-drivers
+spec:
+  selector:
+    matchLabels:
+      app: vmware-vsphere-csi-driver-node-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vmware-vsphere-csi-driver-node-windows
+    spec:
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: windows
+      serviceAccountName: vmware-vsphere-csi-driver-node-sa
+      containers:
+        - name: node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: DRIVER_REG_SOCK_PATH
+              value: 'C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock'
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 3
+        - name: vsphere-csi-node
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: MAX_VOLUMES_PER_NODE
+              value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+            - name: X_CSI_MODE
+              value: node
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: 'false'
+            - name: X_CSI_SPEC_DISABLE_LEN_CHECK
+              value: "true"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: X_CSI_LOG_LEVEL
+              value: DEBUG
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
+              value: "1"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: 'C:\csi'
+            - name: pods-mount-dir
+              mountPath: 'C:\var\lib\kubelet'
+            - name: csi-proxy-volume-v1
+              mountPath: \\.\pipe\csi-proxy-volume-v1
+            - name: csi-proxy-filesystem-v1
+              mountPath: \\.\pipe\csi-proxy-filesystem-v1
+            - name: csi-proxy-disk-v1
+              mountPath: \\.\pipe\csi-proxy-disk-v1
+            - name: csi-proxy-system-v1alpha1
+              mountPath: \\.\pipe\csi-proxy-system-v1alpha1
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins_registry\'
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins\csi.vsphere.vmware.com\'
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: \var\lib\kubelet
+            type: Directory
+        - name: csi-proxy-disk-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-disk-v1
+            type: ''
+        - name: csi-proxy-volume-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-volume-v1
+            type: ''
+        - name: csi-proxy-filesystem-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-filesystem-v1
+            type: ''
+        - name: csi-proxy-system-v1alpha1
+          hostPath:
+            path: \\.\pipe\csi-proxy-system-v1alpha1
+            type: ''
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/hack/manifests/csi/vsphere/02-example-namespace.yaml
+++ b/hack/manifests/csi/vsphere/02-example-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-storage-example
+  labels:
+    # Windows storage resources must be deployed in a privileged namespace with a disabled pod security admission label
+    # synchronization
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: privileged

--- a/hack/manifests/csi/vsphere/03-example-sc.yaml
+++ b/hack/manifests/csi/vsphere/03-example-sc.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-windows-sc
+  namespace: windows-storage-example
+provisioner: csi.vsphere.vmware.com
+parameters:
+  # vSphere Container Storage Plug-in only supports NTFS file system on Windows nodes
+  csi.storage.k8s.io/fstype: "ntfs"

--- a/hack/manifests/csi/vsphere/04-example-pvc.yaml
+++ b/hack/manifests/csi/vsphere/04-example-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-windows-pvc
+  namespace: windows-storage-example
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: example-windows-sc
+  volumeMode: Filesystem

--- a/hack/manifests/csi/vsphere/05-example-deployment.yaml
+++ b/hack/manifests/csi/vsphere/05-example-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example-windows-pod
+  name: example-windows-pod
+  # must be in the same namespace as the PVC
+  namespace: windows-storage-example
+spec:
+  selector:
+    matchLabels:
+      app: example-windows-pod
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: example-windows-pod
+      name: example-windows-pod
+    spec:
+      os:
+        name: windows
+      tolerations:
+        - key: "os"
+          value: "Windows"
+          Effect: "NoSchedule"
+      containers:
+        - name: example-windows-container
+          image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
+          imagePullPolicy: IfNotPresent
+          command:
+            - pwsh.exe
+            - -command
+            - "$filepath='C:\\test\\csi\\timestamp.txt'; New-Item -Path $filepath -Force ;while (1) { Add-Content -Encoding Ascii $filepath $(Get-Date -Format u); sleep 10 }"
+          volumeMounts:
+            - name: test-volume
+              mountPath: "/test/"
+              readOnly: false
+      volumes:
+        - name: test-volume
+          persistentVolumeClaim:
+            claimName: example-windows-pvc
+      nodeSelector:
+        kubernetes.io/os: windows


### PR DESCRIPTION
This commit separates the manifests in the ideal order that they should be deployed. It also adds an example deployment spec and custom namespace used to confirm a Windows pod with a storage mount file can be written to a desired mount path.