### PR TITLE
[WIP] WINC-1098: Block upgrades if it will break storage workloads

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetAddress(t *testing.T) {
@@ -59,6 +61,77 @@ func TestGetAddress(t *testing.T) {
 			// The output can be any valid address in the expected list, so check that the output is one of the possible
 			// correct ones
 			assert.Contains(t, test.expectedOut, out)
+		})
+	}
+}
+
+func TestUpgradeBlocked(t *testing.T) {
+	testCases := []struct {
+		name             string
+		override         bool
+		hasCSIAnnotation bool
+		volumeMounted    bool
+		upgradingToCSI   bool
+		expected         bool
+	}{
+		{
+			name:             "Upgrading from in tree to in tree with a volume mounted",
+			override:         false,
+			hasCSIAnnotation: false,
+			volumeMounted:    true,
+			upgradingToCSI:   false,
+			expected:         false,
+		},
+		{
+			name:             "Upgrading from in tree with a volume mounted",
+			override:         false,
+			hasCSIAnnotation: false,
+			volumeMounted:    true,
+			upgradingToCSI:   true,
+			expected:         false,
+		},
+		{
+			name:             "Upgrading from in tree without a volume mounted",
+			override:         false,
+			hasCSIAnnotation: false,
+			volumeMounted:    false,
+			upgradingToCSI:   true,
+			expected:         false,
+		},
+		{
+			name:             "Upgrading from already migrated Node with a volume",
+			override:         false,
+			hasCSIAnnotation: true,
+			volumeMounted:    true,
+			upgradingToCSI:   true,
+			expected:         false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			node := core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "node",
+					Annotations: make(map[string]string),
+					Labels:      make(map[string]string),
+				},
+				Status: core.NodeStatus{
+					VolumesAttached: []core.AttachedVolume{},
+				},
+			}
+			if tt.override {
+				node.Labels[AllowUpgradeLabel] = "true"
+			}
+			if tt.hasCSIAnnotation {
+				node.Annotations[CSIAnnotation] = "true"
+			}
+			if tt.volumeMounted {
+				node.Status.VolumesInUse = []core.UniqueVolumeName{"test"}
+			}
+			fakeClient := clientfake.NewClientBuilder().WithObjects(&node).Build()
+			r := instanceReconciler{client: fakeClient}
+			result := r.upgradeBlocked(&node, tt.upgradingToCSI)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Blocks the upgrade of Nodes if it will disrupt workloads which have an attached storage volume. Workloads will be disrupted if WMCO is upgrading a node to a kubelet version which is using CSI, from a version which uses in tree volumes. WMCO will unblock the upgrade when it sees that there is an installed CSI driver on the node, through the CSINode cluster object.

In the case of a false positive, users can apply the label windowsmachineconfig.openshift.io/force-upgrade if they wish to override the upgrade block, and have WMCO upgrade the Node. This allows for WMCO to be a bit more cautious when determining if the upgrade will break anything.