### PR TITLE
[release-4.12] Revert "[nodeconfig] Ensure cached WICD creds are set"

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -136,12 +136,6 @@ func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServ
 			return nil, err
 		}
 	}
-	if nodeConfigCache.credentials == nil {
-		nodeConfigCache.credentials, err = getWICDCredentials()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	return &nodeConfig{client: c, k8sclientset: clientset, Windows: win, platformType: platformType,
 		wmcoNamespace: wmcoNamespace, clusterServiceCIDR: clusterServiceCIDR,


### PR DESCRIPTION
Reverts commit e8839a128ed9dce8c202468d088ba629e8c7b89b which was a temporary fix for [OCPBUGS-13790](https://issues.redhat.com//browse/OCPBUGS-13790) given [WINC-948: WICD uses a kubeconfig to authenticate](https://github.com/openshift/windows-machine-config-operator/pull/1516)  was unable to be backported to the release-4.12 branch in time for the 7.1.0 release.

[Slack discussion](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1684417674870159)