### PR TITLE
[daemon] Rename envVar function and variables

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -292,7 +292,7 @@ func (sc *ServiceController) reconcileEnvVarsAndCerts(envVars map[string]string,
 	if err != nil {
 		return false, err
 	}
-	envVarsUpdated, err := envvar.EnsureVarsAreUpToDate(envVars, watchedEnvVars)
+	envVarsUpdated, err := envvar.Reconcile(envVars, watchedEnvVars)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This PR renames the function EnsureVarsAreUpToDate to Reconcile. This removes name stuttering when calling this function form pacakge envVar. It also renames the boolean variable name to a more appt envVarsUpdated.