### PR TITLE
OCPBUGS-18294: WMCO is not reacting to new environment variables

### DIFF
--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -282,12 +282,9 @@ func (cmData *Data) ValidateExpectedContent(expected *Data) error {
 	if len(cmData.EnvironmentVars) != len(expected.EnvironmentVars) {
 		return fmt.Errorf("unexpected number of environment variable")
 	}
-	for _, expectedEnvVar := range expected.EnvironmentVars {
-		if cmData.EnvironmentVars[expectedEnvVar] != expected.EnvironmentVars[expectedEnvVar] {
-			return fmt.Errorf("required environment variable %s is not present as expected."+
-				"expected: %s, actual: %s", expectedEnvVar, expected.EnvironmentVars[expectedEnvVar],
-				cmData.EnvironmentVars[expectedEnvVar])
-		}
+	if !reflect.DeepEqual(cmData.EnvironmentVars, expected.EnvironmentVars) {
+		return fmt.Errorf("required environment variables are not present as expected "+
+			"expected: %v, actual: %v", cmData.EnvironmentVars, expected.EnvironmentVars)
 	}
 	if len(cmData.WatchedEnvironmentVars) != len(expected.WatchedEnvironmentVars) {
 		return fmt.Errorf("unexpected number of watched environment variable")

--- a/pkg/servicescm/servicescm_test.go
+++ b/pkg/servicescm/servicescm_test.go
@@ -198,6 +198,30 @@ func TestGenerate(t *testing.T) {
 			assert.NoError(t, parsed.ValidateExpectedContent(data))
 		})
 	}
+	t.Run("ConfigMaps with different envVar values", func(t *testing.T) {
+		services := testServices
+		files := testFiles
+		existingEnvVars := map[string]string{
+			"HTTP_PROXY":  "proxy_endpoint:3128/",
+			"HTTPS_PROXY": "proxy_endpoint:3128/",
+			"NO_PROXY":    "localhost",
+		}
+		expectedEnvVars := map[string]string{
+			"HTTP_PROXY":  "proxy_endpoint:3128/",
+			"HTTPS_PROXY": "proxy_endpoint:3128/",
+			"NO_PROXY":    "localhost, example.com",
+		}
+		watchedEnvVars := testEnvVars
+		expectedData, err := NewData(&services, &files, expectedEnvVars, watchedEnvVars)
+		require.NoError(t, err)
+		existingData, err := NewData(&services, &files, existingEnvVars, watchedEnvVars)
+		require.NoError(t, err)
+		configMap, err := Generate(Name, "testNamespace", existingData)
+		require.NoError(t, err)
+		parsed, err := Parse(configMap.Data)
+		require.NoError(t, err)
+		assert.Error(t, parsed.ValidateExpectedContent(expectedData))
+	})
 }
 
 func TestGetBootstrapServices(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug where WMCO is not reacting to changes in the env vars as expected by deleting and re-creating the
invalid services CM object. This was caused by a flawed comparison between the expected and existing CM object.
Fixes: #OCPBUGS-18294

