### PR TITLE
OCPBUGS-17217: Fix "WMCO does not wait for instance to reboot properly"

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -395,7 +396,11 @@ func (vm *windows) RebootAndReinitialize() error {
 	if _, err := vm.Run("Restart-Computer -Force", true); err != nil {
 		return fmt.Errorf("error rebooting the Windows VM: %w", err)
 	}
-	// Reinitialize the SSH connection after the VM reboot
+	// Wait for instance to be unreachable via SSH, implies reboot is underway
+	if err := vm.waitUntilUnreachable(); err != nil {
+		return fmt.Errorf("instance reboot failed to start: %w", err)
+	}
+	// Wait for instance to come back online and reinitialize the SSH connection after the reboot
 	if err := vm.reinitialize(); err != nil {
 		return fmt.Errorf("error reinitializing SSH connection after VM reboot: %w", err)
 	}
@@ -926,6 +931,15 @@ func (vm *windows) isContainersFeatureEnabled() (bool, error) {
 		return false, fmt.Errorf("failed to get Windows feature: %s: %w", containersFeatureName, err)
 	}
 	return strings.Contains(out, "Enabled"), nil
+}
+
+// waitUntilUnreachable tries to run a dummy command until it fails to see if the instance is reachable via SSH
+func (vm *windows) waitUntilUnreachable() error {
+	return wait.PollUntilContextTimeout(context.TODO(), retry.WindowsAPIInterval, retry.ResourceChangeTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := vm.Run("Get-Help", true)
+			return (err != nil), nil
+		})
 }
 
 func (vm *windows) reinitialize() error {


### PR DESCRIPTION
This PR adds a necessary wait to our instance reboot flow. 
After kicking off a reboot, we now first wait for the instance to become unreachable via SSH. 
Then it waits for the instance to be back online before returning the reboot as successful.

Previously WMCO checked if the instance is reachable directly after issuing the reboot request, 
which lead to false positives since the instance was viewed as successfully rebooted before the reboot even began.