### PR TITLE
WINC-1053: [build] Update to 4.15 image and prep for 10.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 9.0.0
+WMCO_VERSION ?= 10.15.0
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
 # dos2unix is needed to build CNI plugins

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -119,7 +119,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
 WORKDIR /build/windows-machine-config-operator/

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.13"
+LABEL com.redhat.openshift.versions="=v4.14"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=8.0.0 <9.0.0'
+    olm.skipRange: '>=9.0.0 <10.15.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -17,7 +17,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v9.0.0
+  name: windows-machine-config-operator.v10.15.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -25,8 +25,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.14/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.14/windows_containers/byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.15/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.15/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -36,8 +36,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
-    * OCP 4.14 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.14/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.15 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.15/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -47,7 +47,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.14/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -132,9 +132,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
-    - [Azure](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
-    - [GCP](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
+    - [AWS](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs
@@ -143,7 +143,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.14/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.15/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:
@@ -478,4 +478,4 @@ spec:
   minKubeVersion: 1.27.0
   provider:
     name: Red Hat
-  version: 9.0.0
+  version: 10.15.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v2.0.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  com.redhat.openshift.versions: "=v4.13"
+  com.redhat.openshift.versions: "=v4.14"
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v9.0.0
+  - currentCSV: windows-machine-config-operator.v10.15.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=8.0.0 <9.0.0'
+    olm.skipRange: '>=9.0.0 <10.15.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -23,8 +23,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.14/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.14/windows_containers/byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.15/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.15/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -34,8 +34,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
-    * OCP 4.14 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.14/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.15 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.15/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -45,7 +45,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.14/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -130,9 +130,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
-    - [Azure](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
-    - [GCP](https://docs.openshift.com/container-platform/4.14/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
+    - [AWS](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs
@@ -141,7 +141,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.14/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.15/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -150,7 +150,7 @@ get_operator_sdk() {
 
 get_packagemanifests_version() {
   # Find the line that has a semver pattern in it, such as v2.0.0
-  local VERSION=$(grep -o v.\.\.\.. $MANIFEST_LOC/windows-machine-config-operator.package.yaml)
+  local VERSION=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' $MANIFEST_LOC/windows-machine-config-operator.package.yaml)
   # return the version without the 'v' at the beginning.
   echo ${VERSION:1}
 }


### PR DESCRIPTION
Update Dockerfiles to use 4.15 base image and prep for 10.15.0 release
This change bumps the operator and OCP version according to the WMCO 10.15.0 release.
Dockerfile and the annotations.yaml file will use v4.14 until v4.15 index images are CVP supported.

Commands ran: 'make bundle'

