### PR TITLE
OCPBUGS-18554: Fix "error removing HNS network when cleaning up BYOH proxy nodes"

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -234,8 +234,8 @@ type Windows interface {
 	Bootstrap(string, string, string) error
 	// ConfigureWICD ensures that the Windows Instance Config Daemon is running on the node
 	ConfigureWICD(string, string) error
-	// Deconfigure removes all files and networks created by WMCO and runs the WICD cleanup command.
-	Deconfigure(string, string) error
+	// RemoveFilesAndNetworks removes all files and networks created by WMCO
+	RemoveFilesAndNetworks() error
 	// RunWICDCleanup ensures the WICD service is stopped and runs the cleanup command that ensures all WICD-managed
 	// services are also stopped
 	RunWICDCleanup(string, string) error
@@ -429,12 +429,7 @@ func (vm *windows) RunWICDCleanup(watchNamespace, wicdKubeconfig string) error {
 	return nil
 }
 
-func (vm *windows) Deconfigure(watchNamespace, wicdKubeconfig string) error {
-	vm.log.Info("deconfiguring")
-
-	if err := vm.RunWICDCleanup(watchNamespace, wicdKubeconfig); err != nil {
-		return fmt.Errorf("unable to cleanup the Windows instance: %w", err)
-	}
+func (vm *windows) RemoveFilesAndNetworks() error {
 	if err := vm.ensureHNSNetworksAreRemoved(); err != nil {
 		return fmt.Errorf("unable to ensure HNS networks are removed: %w", err)
 	}


### PR DESCRIPTION
This PR re-orders a deconfiguration step removing files and HNS networks
to be after the instance has finished rebooting. This way WMCO is guaranteed
to only interact with the instance when it is reachable via SSH.

Previously, we were hitting timing issues where, after WICD cleanup is ran,
WMCO's configmap and node controllers would race, resulting in WMCO issuing
SSH commands while the node is still rebooting. These would fail and cause 
deconfiguration to reconcile again, leading to timeouts in CI for our deletion suite.