### PR TITLE
[test] SMB storage testing on Platform none

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -152,6 +152,6 @@ func (a *Provider) StorageSupport() bool {
 	return false
 }
 
-func (a *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
+func (a *Provider) CreatePVC(_ client.Interface, _ string, _ *core.PersistentVolume) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on AWS")
 }

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -122,7 +122,7 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string, _ *core.PersistentVolume) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on azure")
 }
 

--- a/test/e2e/providers/cloudprovider.go
+++ b/test/e2e/providers/cloudprovider.go
@@ -27,8 +27,9 @@ type CloudProvider interface {
 	// StorageSupport indicates if we support Windows storage on this provider
 	StorageSupport() bool
 	// CreatePVC creates a new PersistentVolumeClaim that can be used by a workload. The PVC will be created with
-	// the given client, in the given namespace.
-	CreatePVC(client.Interface, string) (*core.PersistentVolumeClaim, error)
+	// the given client, in the given namespace. If a PV is provided, the PVC will be provisioned from the PVC. Else,
+	// it will be dynamically provisioned via a StorageClass.
+	CreatePVC(client.Interface, string, *core.PersistentVolume) (*core.PersistentVolumeClaim, error)
 }
 
 // NewCloudProvider returns a CloudProvider interface or an error

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -99,7 +99,7 @@ func (p *Provider) StorageSupport() bool {
 	return false
 }
 
-func (p *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(_ client.Interface, _ string, _ *core.PersistentVolume) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on gcp")
 }
 

--- a/test/e2e/providers/nutanix/nutanix.go
+++ b/test/e2e/providers/nutanix/nutanix.go
@@ -86,6 +86,6 @@ func (a *Provider) StorageSupport() bool {
 	return false
 }
 
-func (a *Provider) CreatePVC(_ client.Interface, _ string) (*core.PersistentVolumeClaim, error) {
+func (a *Provider) CreatePVC(_ client.Interface, _ string, _ *core.PersistentVolume) (*core.PersistentVolumeClaim, error) {
 	return nil, fmt.Errorf("storage not supported on Nutanix")
 }

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -157,7 +157,7 @@ func (p *Provider) CreateInTreePVC(client client.Interface, namespace string) (*
 }
 
 // CreatePVC creates a PVC for a dynamically provisioned volume
-func (p *Provider) CreatePVC(client client.Interface, namespace string) (*core.PersistentVolumeClaim, error) {
+func (p *Provider) CreatePVC(client client.Interface, namespace string, _ *core.PersistentVolume) (*core.PersistentVolumeClaim, error) {
 	if err := p.EnsureWindowsCSIDrivers(client); err != nil {
 		return nil, err
 	}

--- a/test/e2e/smb/smb.go
+++ b/test/e2e/smb/smb.go
@@ -1,0 +1,556 @@
+package smb
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	storage "k8s.io/api/storage/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	client "k8s.io/client-go/kubernetes"
+)
+
+var (
+	smbNamespace          = "csi-smb-controller"
+	smbDriverName         = "smb.csi.k8s.io"
+	smbServiceAccountName = "smb-controller"
+)
+
+// EnsureSMBControllerResources deploys all required resources to enable Nodes on the cluster to mount SMB volumes
+func EnsureSMBControllerResources(c client.Interface) error {
+	if err := ensureCSIControllerNamespace(c); err != nil {
+		return err
+	}
+	if err := ensureCSIDriver(c); err != nil {
+		return err
+	}
+	if err := ensureSMBRBAC(c); err != nil {
+		return err
+	}
+	if err := ensureCSIController(c); err != nil {
+		return err
+	}
+	if err := ensureWindowsCSIDaemonset(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureCSIControllerNamespace ensures the controller namespace exists
+func ensureCSIControllerNamespace(c client.Interface) error {
+	_, err := c.CoreV1().Namespaces().Get(context.TODO(), smbNamespace, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return err
+		}
+	} else if err == nil {
+		return nil
+	}
+	ns := core.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name:   smbNamespace,
+			Labels: map[string]string{"pod-security.kubernetes.io/enforce": "privileged"},
+		},
+	}
+	_, err = c.CoreV1().Namespaces().Create(context.TODO(), &ns, meta.CreateOptions{})
+	return err
+}
+
+// ensureCSIDriver ensures the CSIDriver exists in the correct state
+func ensureCSIDriver(c client.Interface) error {
+	isFalse := false
+	isTrue := true
+	desiredDriver := storage.CSIDriver{
+		ObjectMeta: meta.ObjectMeta{Name: smbDriverName},
+		Spec: storage.CSIDriverSpec{
+			AttachRequired: &isFalse,
+			PodInfoOnMount: &isTrue,
+		},
+	}
+	driver, err := c.StorageV1().CSIDrivers().Get(context.TODO(), smbDriverName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return err
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(desiredDriver.Spec, driver.Spec) {
+			// already as expected, nothing to do here.
+			return nil
+		}
+		err = c.StorageV1().CSIDrivers().Delete(context.TODO(), smbDriverName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting smb driver: %w", err)
+		}
+	}
+	_, err = c.StorageV1().CSIDrivers().Create(context.TODO(), &desiredDriver, meta.CreateOptions{})
+	return err
+}
+
+// ensureCSIController ensures the smb-controller deployment exists in the correct state
+func ensureCSIController(c client.Interface) error {
+	isTrue := true
+	controllerName := "smb-controller"
+	controller := apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{
+			Name: controllerName,
+		},
+		Spec: apps.DeploymentSpec{
+			Selector: &meta.LabelSelector{
+				MatchLabels: map[string]string{"app": controllerName},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{"app": controllerName},
+				},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Args: []string{"-v=2", "--csi-address=$(ADDRESS)", "--leader-election", "--leader-election-namespace=kube-system", "--extra-create-metadata=true"},
+							Env: []core.EnvVar{
+								{Name: "ADDRESS", Value: "/csi/csi.sock"},
+							},
+							Image: "registry.k8s.io/sig-storage/csi-provisioner:v3.3.0",
+							Name:  "csi-provisioner",
+							SecurityContext: &core.SecurityContext{
+								Privileged: &isTrue,
+								SeccompProfile: &core.SeccompProfile{
+									Type: core.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									MountPath: "/csi",
+									Name:      "socket-dir",
+								},
+							},
+						},
+						{
+							Args:  []string{"--csi-address=/csi/csi.sock", "--probe-timeout=3s", "--health-port=29642", "--v=2"},
+							Name:  "liveness-probe",
+							Image: "registry.k8s.io/sig-storage/livenessprobe:v2.8.0",
+							SecurityContext: &core.SecurityContext{
+								Privileged: &isTrue,
+								SeccompProfile: &core.SeccompProfile{
+									Type: core.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									MountPath: "/csi",
+									Name:      "socket-dir",
+								},
+							},
+						},
+						{
+							Args: []string{"--v=5", "--endpoint=$(CSI_ENDPOINT)", "--metrics-address=0.0.0.0:29644"},
+							Env: []core.EnvVar{
+								{
+									Name:  "CSI_ENDPOINT",
+									Value: "unix:///csi/csi.sock",
+								},
+							},
+							Image: "registry.k8s.io/sig-storage/smbplugin:v1.10.0",
+							LivenessProbe: &core.Probe{
+								FailureThreshold: 5,
+								ProbeHandler: core.ProbeHandler{
+									Exec: nil,
+									HTTPGet: &core.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.IntOrString{Type: intstr.String, StrVal: "healthz"}},
+								},
+								InitialDelaySeconds: 30,
+								PeriodSeconds:       30,
+								TimeoutSeconds:      10,
+							},
+							Name: "smb",
+							Ports: []core.ContainerPort{
+								{
+									ContainerPort: 29642,
+									Name:          "healthz",
+									Protocol:      "TCP",
+								},
+								{
+									ContainerPort: 29644,
+									Name:          "metrics",
+									Protocol:      "TCP",
+								},
+							},
+							SecurityContext: &core.SecurityContext{
+								Privileged:     &isTrue,
+								SeccompProfile: &core.SeccompProfile{Type: core.SeccompProfileTypeRuntimeDefault},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									MountPath: "/csi",
+									Name:      "socket-dir",
+								},
+							},
+						},
+					},
+					PriorityClassName:  "system-cluster-critical",
+					ServiceAccountName: smbServiceAccountName,
+					Volumes: []core.Volume{
+						{
+							Name: "socket-dir",
+							VolumeSource: core.VolumeSource{
+								EmptyDir: &core.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// See if the deployment already exists in the state we expect it to be in.
+	existingController, err := c.AppsV1().Deployments(smbNamespace).Get(context.TODO(), controllerName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing SMB controller: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingController.Spec, controller.Spec) {
+			// DaemonSet is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the deployment as it has the wrong spec.
+		err = c.AppsV1().Deployments(smbNamespace).Delete(context.TODO(), controllerName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing SMB controller: %w", err)
+
+		}
+	}
+	_, err = c.AppsV1().Deployments(smbNamespace).Create(context.TODO(), &controller, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating SMB controller: %w", err)
+	}
+	return nil
+}
+
+// ensureSMBServiceAccount ensures the controller's service account exists
+func ensureSMBServiceAccount(c client.Interface) error {
+	_, err := c.CoreV1().ServiceAccounts(smbNamespace).Get(context.TODO(), smbServiceAccountName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return err
+		}
+	} else if err == nil {
+		return nil
+	}
+	sa := core.ServiceAccount{
+		ObjectMeta: meta.ObjectMeta{
+			Name: smbServiceAccountName,
+		},
+	}
+	_, err = c.CoreV1().ServiceAccounts(smbNamespace).Create(context.TODO(), &sa, meta.CreateOptions{})
+	return err
+}
+
+// ensureSMBClusterRole ensures the controller's ClusterRole exists with the correct permissions
+func ensureSMBClusterRole(c client.Interface) error {
+	clusterRole := rbac.ClusterRole{
+		ObjectMeta: meta.ObjectMeta{
+			Name: smbServiceAccountName,
+		},
+		Rules: []rbac.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumeclaims"},
+				Verbs:     []string{"get", "list", "watch", "update"},
+			},
+			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"storageclasses"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+			},
+			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"csinodes"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				ResourceNames: []string{"privileged"},
+				Resources:     []string{"securitycontextconstraints"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+	// See if the CR already exists in the state we expect it to be in.
+	existingClusterRole, err := c.RbacV1().ClusterRoles().Get(context.TODO(), smbServiceAccountName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing SMB CR: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingClusterRole.Rules, clusterRole.Rules) {
+			// DaemonSet is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the deployment as it has the wrong spec.
+		err = c.RbacV1().ClusterRoles().Delete(context.TODO(), smbServiceAccountName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing SMB CR: %w", err)
+
+		}
+	}
+	_, err = c.RbacV1().ClusterRoles().Create(context.TODO(), &clusterRole, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating SMB CR: %w", err)
+	}
+	return nil
+}
+
+// ensureSMBClusterRoleBinding ensures the controller's ClusterRoleBinding exists with the correct Subject and RoleRef
+func ensureSMBClusterRoleBinding(c client.Interface) error {
+	clusterRoleBinding := rbac.ClusterRoleBinding{
+		ObjectMeta: meta.ObjectMeta{
+			Name: smbServiceAccountName,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:      rbac.ServiceAccountKind,
+				Name:      smbServiceAccountName,
+				Namespace: smbNamespace,
+			},
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "ClusterRole",
+			Name:     smbServiceAccountName,
+		},
+	}
+	// See if the CRB already exists in the state we expect it to be in.
+	existingClusterRoleBinding, err := c.RbacV1().ClusterRoleBindings().Get(context.TODO(), smbServiceAccountName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing SMB CRB: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) &&
+			reflect.DeepEqual(existingClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
+			// DaemonSet is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the deployment as it has the wrong spec.
+		err = c.RbacV1().ClusterRoles().Delete(context.TODO(), smbServiceAccountName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing SMB CR: %w", err)
+
+		}
+	}
+	_, err = c.RbacV1().ClusterRoleBindings().Create(context.TODO(), &clusterRoleBinding, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating SMB CR: %w", err)
+	}
+	return nil
+}
+
+// ensureSMBRBAC ensures all the required RBAC resources exist
+func ensureSMBRBAC(c client.Interface) error {
+	if err := ensureSMBServiceAccount(c); err != nil {
+		return err
+	}
+	if err := ensureSMBClusterRole(c); err != nil {
+		return err
+	}
+	if err := ensureSMBClusterRoleBinding(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureWindowsCSIDaemonset ensures the Windows CSI node DaemonSet exists with the correct spec
+func ensureWindowsCSIDaemonset(c client.Interface) error {
+	dsName := "csi-smb-node-win"
+	directoryType := core.HostPathDirectory
+	directoryOrCreate := core.HostPathDirectoryOrCreate
+	ds := apps.DaemonSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name: dsName,
+		},
+		Spec: apps.DaemonSetSpec{
+			Selector: &meta.LabelSelector{MatchLabels: map[string]string{"app": dsName}},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{
+					Labels: map[string]string{"app": dsName},
+				},
+				Spec: core.PodSpec{
+					PriorityClassName:  "system-node-critical",
+					NodeSelector:       map[string]string{core.LabelOSStable: "windows"},
+					ServiceAccountName: smbServiceAccountName,
+					OS:                 &core.PodOS{Name: core.Windows},
+					Tolerations: []core.Toleration{
+						{
+							Key:    "os",
+							Value:  "Windows",
+							Effect: core.TaintEffectNoSchedule,
+						},
+					},
+					Containers: []core.Container{
+						{
+							Name:  "node-driver-registrar",
+							Image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0",
+							Args:  []string{"--v=5", "--csi-address=$(ADDRESS)", "-kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
+							Env: []core.EnvVar{
+								{
+									Name:  "ADDRESS",
+									Value: `unix://C:\\csi\\csi.sock`,
+								},
+								{
+									Name:  "DRIVER_REG_SOCK_PATH",
+									Value: `C:\\var\\lib\\kubelet\\plugins\\smb.csi.k8s.io\\csi.sock`,
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									Name:      "plugin-dir",
+									MountPath: "/csi",
+								},
+								{
+									Name:      "registration-dir",
+									MountPath: "/registration",
+								},
+							},
+						},
+						{
+							Name:  "smb-csi-node",
+							Image: "registry.k8s.io/sig-storage/smbplugin:v1.10.0",
+							Args:  []string{"--endpoint=$(CSI_ENDPOINT)", "--nodeid=$(NODE_NAME)", "--remove-smb-mapping-during-unmount=true"},
+							Env: []core.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name:  "CSI_ENDPOINT",
+									Value: `unix://C:\\csi\\csi.sock`,
+								},
+							},
+							VolumeMounts: []core.VolumeMount{
+								{
+									Name:      "plugin-dir",
+									MountPath: "/csi",
+								},
+								{
+									Name:      "pod-mount-dir",
+									MountPath: "/var/lib/kubelet",
+								},
+								{
+									Name:      "csi-proxy-smb-pipe-v1",
+									MountPath: `\\.\pipe\csi-proxy-smb-v1`,
+								},
+								{
+									Name:      "csi-proxy-filesystem-v1",
+									MountPath: `\\.\pipe\csi-proxy-filesystem-v1`,
+								},
+							},
+						},
+					},
+					Volumes: []core.Volume{
+						{
+							Name: "registration-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet\plugins_registry\`,
+									Type: &directoryType,
+								},
+							},
+						},
+						{
+							Name: "plugin-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet\plugins\smb.csi.k8s.io\`,
+									Type: &directoryOrCreate,
+								},
+							},
+						},
+						{
+							Name: "pod-mount-dir",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `C:\var\lib\kubelet`,
+									Type: &directoryType,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-smb-pipe-v1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-smb-v1`,
+								},
+							},
+						},
+						{
+							Name: "csi-proxy-filesystem-v1",
+							VolumeSource: core.VolumeSource{
+								HostPath: &core.HostPathVolumeSource{
+									Path: `\\.\pipe\csi-proxy-filesystem-v1`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// See if the DaemonSet already exists in the state we expect it to be in.
+	existingDS, err := c.AppsV1().DaemonSets(smbNamespace).Get(context.TODO(), dsName, meta.GetOptions{})
+	if err != nil {
+		if !k8sapierrors.IsNotFound(err) {
+			return fmt.Errorf("error getting existing Windows CSI DaemonSet: %w", err)
+		}
+	} else if err == nil {
+		if reflect.DeepEqual(existingDS.Spec, ds.Spec) {
+			// DaemonSet is already as expected, nothing to do here.
+			return nil
+		}
+		// Delete the DaemonSet as it has the wrong spec.
+		err = c.AppsV1().DaemonSets(smbNamespace).Delete(context.TODO(), dsName, meta.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting existing Windows CSI DaemonSet: %w", err)
+
+		}
+	}
+	_, err = c.AppsV1().DaemonSets(smbNamespace).Create(context.TODO(), &ds, meta.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating Windows CSI DaemonSet: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -2,16 +2,23 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"math/rand"
+	"strconv"
 	"testing"
+	"time"
 
 	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/windows-machine-config-operator/controllers"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/smb"
 )
 
 // testStorage tests that persistent volumes can be accessed by Windows pods
@@ -40,7 +47,14 @@ func testStorage(t *testing.T) {
 		pvc, err = vsphereProvider.CreateInTreePVC(tc.client.K8s, tc.workloadNamespace)
 		require.NoError(t, err)
 	} else {
-		pvc, err = tc.CloudProvider.CreatePVC(tc.client.K8s, tc.workloadNamespace)
+		var pv *core.PersistentVolume
+		if tc.CloudProvider.GetType() == config.NonePlatformType {
+			err = smb.EnsureSMBControllerResources(tc.client.K8s)
+			require.NoError(t, err)
+			pv, err = tc.createSMBPV()
+			require.NoError(t, err)
+		}
+		pvc, err = tc.CloudProvider.CreatePVC(tc.client.K8s, tc.workloadNamespace, pv)
 		require.NoError(t, err)
 	}
 	if !skipWorkloadDeletion {
@@ -68,4 +82,102 @@ func testStorage(t *testing.T) {
 			}
 		}()
 	}
+}
+
+// createSMBPV creates a Persistent Volume backed by an SMB share created on one of the Windows Nodes
+func (tc *testContext) createSMBPV() (*core.PersistentVolume, error) {
+	err := tc.loadExistingNodes()
+	if err != nil {
+		return nil, fmt.Errorf("error loading existing nodes: %w", err)
+	}
+	node := gc.allNodes()[0]
+	addr, err := controllers.GetAddress(node.Status.Addresses)
+	if err := tc.checkSMBPortOpen(addr); err != nil {
+		return nil, fmt.Errorf("port unreachable")
+	}
+	username := "SMBUser"
+	password := generateWindowsPassword()
+	shareName := "TestShare"
+	createShareCommand := fmt.Sprintf("$Password = (ConvertTo-SecureString -Force -AsPlainText '%s');"+
+		"New-LocalUser -Name '%s' -Password $Password;"+
+		"mkdir /smbshare;"+
+		"New-SmbShare -Name '%s' -Path C:\\smbshare -FullAccess '%s'", password, username, shareName, username)
+	if err != nil {
+		return nil, fmt.Errorf("error getting address: %w", err)
+	}
+	if out, err := tc.runPowerShellSSHJob("create-smb-share", createShareCommand, addr); err != nil {
+		return nil, fmt.Errorf("error creating SMB share %s: %w", out, err)
+	}
+	secretName := "smbcreds"
+	credentialSecret := core.Secret{
+		ObjectMeta: meta.ObjectMeta{
+			Name: secretName,
+		},
+		StringData: map[string]string{"username": username, "password": password},
+		Type:       "generic",
+	}
+	_, err = tc.client.K8s.CoreV1().Secrets(tc.workloadNamespace).Create(context.TODO(), &credentialSecret, meta.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating smbcreds secret")
+	}
+	shareAddress := fmt.Sprintf("//%s/%s", addr, shareName)
+	pv := core.PersistentVolume{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "pv-smb",
+		},
+		Spec: core.PersistentVolumeSpec{
+			Capacity: core.ResourceList{
+				core.ResourceStorage: resource.MustParse("5Gi"),
+			},
+			PersistentVolumeSource: core.PersistentVolumeSource{
+				CSI: &core.CSIPersistentVolumeSource{
+					Driver:           "smb.csi.k8s.io",
+					ReadOnly:         false,
+					VolumeHandle:     "smb-vol-1",
+					VolumeAttributes: map[string]string{"source": shareAddress},
+					NodeStageSecretRef: &core.SecretReference{
+						Name:      secretName,
+						Namespace: tc.workloadNamespace,
+					},
+				},
+			},
+			AccessModes:                   []core.PersistentVolumeAccessMode{core.ReadWriteMany},
+			PersistentVolumeReclaimPolicy: core.PersistentVolumeReclaimRetain,
+			StorageClassName:              "smb",
+			MountOptions: []string{
+				"dir_mode=0777",
+				"file_mode=0777",
+				"uid=1001",
+				"gid=1001",
+				"noperm",
+				"mfsymlinks",
+				"cache=strict",
+				"noserverino",
+			},
+		},
+	}
+	return tc.client.K8s.CoreV1().PersistentVolumes().Create(context.TODO(), &pv, meta.CreateOptions{})
+}
+
+// checkSMBPortOpen returns no error if port 445 is reachable at the given address
+func (tc *testContext) checkSMBPortOpen(addr string) error {
+	_, err := tc.runJob("check-smb-port-status", []string{"nc", "-v", "-z", addr, "445"})
+	return err
+}
+
+// generateWindowsPassword generates a random password usable for a Windows user account
+func generateWindowsPassword() string {
+	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	// Ensure password requirements are hit by including a mix of lowercase letters, a number, and a special character
+	passwordLength := 32
+	password := make([]byte, passwordLength)
+	// Pick 30 characters from the lowercase letter set
+	letterSet := "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < passwordLength-2; i++ {
+		password[i] = letterSet[r.Intn(len(letterSet)-1)]
+	}
+	// Pick one number from 0-9, and add a special character
+	password[passwordLength-2] = strconv.Itoa(r.Intn(10))[0]
+	password[passwordLength-1] = '-'
+	return string(password)
 }


### PR DESCRIPTION
Adds storage testing on platform none clusters. After deploying the SMB
storage drivers, the test suite creates an SMB fileshare on one of the
Windows nodes and a PersistentVolume which is able to access it.

As part of this commit the CreatePVC() method of the Provider interface
was given an extra optional parameter of a PV. This is necessary to make
use of the previously described changes.