### PR TITLE
OCPBUGS-5002: Copy Azure setup files only on Azure 

### DIFF
--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -317,7 +317,7 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 // findHostName returns the actual host name of the instance by running the 'hostname' command
 func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
 	// We don't need to pass most args here as we just need to be able to run commands on the instance.
-	win, err := windows.New("", instanceInfo, instanceSigner)
+	win, err := windows.New("", instanceInfo, instanceSigner, nil)
 	if err != nil {
 		return "", fmt.Errorf("error instantiating Windows instance: %w", err)
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -125,7 +125,7 @@ func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServ
 	}
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
-	win, err := windows.New(clusterDNS, instanceInfo, signer)
+	win, err := windows.New(clusterDNS, instanceInfo, signer, &platformType)
 	if err != nil {
 		return nil, fmt.Errorf("error instantiating Windows instance from VM: %w", err)
 	}

--- a/pkg/windows/windows_test.go
+++ b/pkg/windows/windows_test.go
@@ -3,8 +3,44 @@ package windows
 import (
 	"testing"
 
+	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig/payload"
 )
+
+func TestGetFilesToTransfer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		platform *config.PlatformType
+	}{
+		{
+			name:     "test AWS",
+			platform: func() *config.PlatformType { t := config.AWSPlatformType; return &t }(),
+		},
+		{
+			name:     "test Azure",
+			platform: func() *config.PlatformType { t := config.AzurePlatformType; return &t }(),
+		},
+		{
+			name:     "test Nil",
+			platform: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			files := getFilesToTransfer(test.platform)
+			if test.platform != nil && *test.platform == config.AzurePlatformType {
+				file := files[payload.AzureCloudNodeManagerPath]
+				assert.Equal(t, K8sDir, file)
+			} else {
+				_, exists := files[payload.AzureCloudNodeManagerPath]
+				assert.False(t, exists)
+			}
+		})
+	}
+}
 
 func TestSplitPath(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
AzureCloudNodeManagerPath was being copied to all platforms, causing
errors. This change ensures AzureCloudNodeManagerPath is only copied
on Azure.