### PR TITLE
Refresh list of provisioned machines on Azure creation test

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -176,6 +176,11 @@ func (tc *testContext) testMachineConfiguration(t *testing.T) {
 	}
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "Windows node creation failed")
+	if tc.CloudProvider.GetType() == config.AzurePlatformType {
+		// Update the machines list
+		machines, err = tc.waitForWindowsMachines(int(gc.numberOfMachineNodes), "Running", false)
+		require.NoError(t, err, "error waiting for Windows Machines to be running")
+	}
 	tc.machineLogCollection(machines.Items)
 }
 


### PR DESCRIPTION
Before, the list of machines for the Azure creation test
kept outdated information about machines that got reconciled
by deletion, making the log collection fail with already
deleted machines.

This change introduces a wait after changing the private
key secret on Azure to check all machines provisioned with
the old windows-user-data were deleted and updates the list
of machines with the newly provisioned ones.