### PR TITLE
[release-4.14] WINC-1098: Block upgrades when migrating from in-tree to CSI

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/certificates"
+	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/condition"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
@@ -64,6 +65,16 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 		return nil
 	}
 
+	csiEnabled, err := cluster.CSIStorageEnabled(r.platform)
+	if err != nil {
+		return err
+	}
+	if csiEnabled {
+		if labelsToApply == nil {
+			labelsToApply = make(map[string]string)
+		}
+		labelsToApply[metadata.CSIConfiguredLabel] = "true"
+	}
 	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 		instanceInfo, r.signer, labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
@@ -73,15 +84,52 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 	// Check if the instance was configured by a previous version of WMCO and must be deconfigured before being
 	// configured again.
 	if instanceInfo.UpgradeRequired() {
+		blocked := r.upgradeBlocked(instanceInfo.Node, csiEnabled)
+		if blocked {
+			blockMessage := fmt.Sprintf("node upgrade has been blocked, as it can not be ensured that workloads "+
+				"will not be disrupted. If an in-tree persistent storage volume is in use, please ensure the CSI "+
+				"drivers for the given node have been deployed. This block must be overriden by applying the "+
+				"label %s=true to the node. It is recommended to unblock Nodes individually, and to wait for the upgrade "+
+				"to complete sucessfully before unblocking another Node.", metadata.AllowUpgradeLabel)
+			r.log.Info(blockMessage)
+			r.recorder.Eventf(instanceInfo.Node, core.EventTypeWarning, "UpgradeBlocked", blockMessage)
+			return metadata.ApplyBlockedLabel(context.TODO(), r.client, *instanceInfo.Node)
+		}
 		// Instance requiring an upgrade indicates that node object is present with the version annotation
 		r.log.Info("instance requires upgrade", "node", instanceInfo.Node.GetName(), "version",
 			instanceInfo.Node.GetAnnotations()[metadata.VersionAnnotation], "expected version", version.Get())
+		if err = metadata.RemoveBlockedLabel(context.TODO(), r.client, *instanceInfo.Node); err != nil {
+			return fmt.Errorf("error removing upgrade block label: %w", err)
+		}
+
 		if err := nc.Deconfigure(); err != nil {
 			return err
 		}
 	}
 
 	return nc.Configure()
+}
+
+// upgradeBlocked returns whether the upgrade should be blocked if an upgrade will break storage functionality.
+func (r *instanceReconciler) upgradeBlocked(node *core.Node, upgradingToCSI bool) bool {
+	// Only consider the case of vSphere and Azure. Safely migrating in-tree storage on other platforms is not supported
+	// by WMCO.
+	if r.platform != config.VSpherePlatformType && r.platform != config.AzurePlatformType {
+		return false
+	}
+	if !upgradingToCSI {
+		return false
+	}
+	if value := node.GetLabels()[metadata.AllowUpgradeLabel]; value == "true" {
+		return false
+	}
+	if value := node.GetLabels()[metadata.CSIConfiguredLabel]; value == "true" {
+		return false
+	}
+	if len(node.Status.VolumesAttached) == 0 {
+		return false
+	}
+	return true
 }
 
 // instanceFromNode returns an instance object for the given node. Requires a username that can be used to SSH into the

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 )
 
 func TestGetAddress(t *testing.T) {
@@ -59,6 +63,77 @@ func TestGetAddress(t *testing.T) {
 			// The output can be any valid address in the expected list, so check that the output is one of the possible
 			// correct ones
 			assert.Contains(t, test.expectedOut, out)
+		})
+	}
+}
+
+func TestUpgradeBlocked(t *testing.T) {
+	testCases := []struct {
+		name           string
+		override       bool
+		hasCSILabel    bool
+		volumeMounted  bool
+		upgradingToCSI bool
+		expected       bool
+	}{
+		{
+			name:           "Upgrading from in tree to in tree with a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  true,
+			upgradingToCSI: false,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from in tree with a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  true,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from in tree without a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  false,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from already migrated Node with a volume",
+			override:       false,
+			hasCSILabel:    true,
+			volumeMounted:  true,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			node := core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "node",
+					Annotations: make(map[string]string),
+					Labels:      make(map[string]string),
+				},
+				Status: core.NodeStatus{
+					VolumesAttached: []core.AttachedVolume{},
+				},
+			}
+			if tt.override {
+				node.Labels[metadata.AllowUpgradeLabel] = ""
+			}
+			if tt.hasCSILabel {
+				node.Labels[metadata.CSIConfiguredLabel] = "true"
+			}
+			if tt.volumeMounted {
+				node.Status.VolumesInUse = []core.UniqueVolumeName{"test"}
+			}
+			fakeClient := clientfake.NewClientBuilder().WithObjects(&node).Build()
+			r := instanceReconciler{client: fakeClient}
+			result := r.upgradeBlocked(&node, tt.upgradingToCSI)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -212,21 +212,31 @@ func TestUpgrade(t *testing.T) {
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfBYOHNodes), false, true)
 	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 
-	// Basic testing to ensure the Node object is in a good state
-	t.Run("Nodes ready", tc.testNodesBecomeReadyAndSchedulable)
-	t.Run("Node annotations", tc.testNodeAnnotations)
-	t.Run("Node Metadata", tc.testNodeMetadata)
-
 	if inTreeUpgrade {
-		// Deploy the CSI drivers and wait for a CSI node to be created
-		// This is a requirement for storage workloads to go back to ready
 		vsphereProvider, ok := tc.CloudProvider.(*vsphere.Provider)
 		require.True(t, ok, "in tree upgrade must be ran on vSphere")
+
+		// Check that Node upgrades have been blocked for Nodes with storage volumes attached
+		require.NoError(t, tc.waitForBlockedUpgrade())
+
+		// Deploy the required CSI drivers and unblock the upgrade
 		require.NoError(t, vsphereProvider.EnsureWindowsCSIDrivers(tc.client.K8s))
 		log.Printf("waiting for csinodes to reflect driver deployment")
 		err = tc.waitForCSINodesWithDrivers(gc.allNodes())
 		require.NoError(t, err)
+		require.NoError(t, tc.allowUpgrade(gc.allNodes()))
 	}
+
+	// wait for Configured windows nodes to be upgraded to expected version
+	err = tc.waitForConfiguredWindowsNodes(int32(numberOfMachineNodes), true, false)
+	require.NoError(t, err, "timed out waiting for Windows Machine nodes to be upgraded to current version")
+	err = tc.waitForConfiguredWindowsNodes(int32(numberOfBYOHNodes), true, true)
+	require.NoError(t, err, "timed out waiting for BYOH Windows nodes to be upgraded to current version")
+
+	// Basic testing to ensure the Node object is in a good state
+	t.Run("Nodes ready", tc.testNodesBecomeReadyAndSchedulable)
+	t.Run("Node annotations", tc.testNodeAnnotations)
+	t.Run("Node Metadata", tc.testNodeMetadata)
 
 	// test that any workloads deployed on the node have not been broken by the upgrade
 	t.Run("Workloads ready", tc.testWorkloadsAvailable)
@@ -281,4 +291,49 @@ func (tc *testContext) waitForCSINodesWithDrivers(nodes []v1.Node) error {
 		}
 		return true, nil
 	})
+}
+
+// waitForBlockedUpgrade waits until all Windows nodes that should be blocked from upgrading, have been blocked
+func (tc *testContext) waitForBlockedUpgrade() error {
+	return wait.PollImmediate(retry.Interval, 10*time.Minute, func() (bool, error) {
+		nodes, err := tc.client.K8s.CoreV1().Nodes().List(context.TODO(),
+			metav1.ListOptions{LabelSelector: storageTestLabel + "=true"})
+		if err != nil {
+			log.Printf("error listing Windows Nodes: %s", err)
+			return false, nil
+		}
+		for _, node := range nodes.Items {
+			log.Printf("checking that node %s is blocked from upgrading", node.GetName())
+			if value := node.GetLabels()[metadata.UpgradeBlockedLabel]; value != "true" {
+				log.Printf("node %s not annotated as blocked", node.GetName())
+				return false, nil
+			}
+			upgradedVersion, err := getWMCOVersion()
+			if err != nil {
+				log.Printf("error getting WMCO version: %s", err)
+				return false, nil
+			}
+			log.Printf("checking that node %s has not been upgraded to %s", node.GetName(), upgradedVersion)
+			if node.GetLabels()[metadata.DesiredVersionAnnotation] == upgradedVersion {
+				return false, fmt.Errorf("%s has been upgraded", node.GetName())
+			}
+		}
+		return true, nil
+	})
+}
+
+// allowUpgrade applies the required label to unblock the upgrade of a Windows Node
+func (tc *testContext) allowUpgrade(nodes []v1.Node) error {
+	patch, err := metadata.GenerateAddPatch(map[string]string{metadata.AllowUpgradeLabel: "true"}, nil)
+	if err != nil {
+		return fmt.Errorf("error generating patch: %w", err)
+	}
+	for _, node := range nodes {
+		_, err = tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), node.GetName(), types.JSONPatchType, patch,
+			metav1.PatchOptions{})
+		if err != nil {
+			return fmt.Errorf("error patching Node %s: %w", node.GetName(), err)
+		}
+	}
+	return nil
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -208,9 +208,9 @@ func TestUpgrade(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfMachineNodes), false, false)
-	assert.NoError(t, err, "timed out waiting for Windows Machine nodes")
+	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfBYOHNodes), false, true)
-	assert.NoError(t, err, "timed out waiting for BYOH Windows nodes")
+	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 
 	// Basic testing to ensure the Node object is in a good state
 	t.Run("Nodes ready", tc.testNodesBecomeReadyAndSchedulable)

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,10 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strconv"
+	"strings"
 
+	"golang.org/x/mod/semver"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -23,4 +26,14 @@ func Print() {
 // Get() returns the operator version
 func Get() string {
 	return Version
+}
+
+// Major returns only the Major portion of the operator version semver
+func Major() (int, error) {
+	semverParsableVersion := Get()
+	if version := Get(); !strings.HasPrefix(version, "v") {
+		semverParsableVersion = "v" + version
+	}
+	majorVersion := strings.TrimPrefix(semver.Major(semverParsableVersion), "v")
+	return strconv.Atoi(majorVersion)
 }


### PR DESCRIPTION
Blocks the upgrade of Nodes if it will disrupt workloads which have an attached storage volume. Workloads will be disrupted if WMCO is upgrading a node to a kubelet version which is using CSI, from a version which uses in tree volumes.

Users can apply the label
windowsmachineconfig.openshift.io/allow-upgrade in order to unblock the upgrade, and have WMCO upgrade the Node. This allows for the user to confirm that upgraded Nodes have functional storage capabilities, before upgrading any other Nodes.