### PR TITLE
Refresh machines list on Azure creation test

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -173,6 +173,8 @@ func (tc *testContext) testMachineConfiguration(t *testing.T) {
 		// Replace the known private key with a randomly generated one.
 		err = tc.createPrivateKeySecret(false)
 		require.NoError(t, err, "error replacing private key secret")
+		// Wait for machines with the known key to become Running, so that the machine list is up-to-date
+		machines, err = tc.waitForWindowsMachines(int(gc.numberOfMachineNodes), "Running", false)
 	}
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "Windows node creation failed")


### PR DESCRIPTION
Before, the list of machines for the Azure creation test kept outdated information about machines that got reconciled by deletion, making the log collection fail with no longer existing items.

This change introduces a wait after changing the private key on Azure and updates the list of machines with the resulting ones after WMCO reconciles.