### PR TITLE
Skip BYOH removal test when no BYOH nodes

### DIFF
--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -51,6 +51,9 @@ func (tc *testContext) clearWindowsInstanceConfigMap() error {
 
 // testBYOHRemoval tests that nodes are properly removed and deconfigured after removing ConfigMap entries
 func (tc *testContext) testBYOHRemoval(t *testing.T) {
+	if gc.numberOfBYOHNodes == 0 {
+		t.Skip("No BYOH nodes present")
+	}
 	// Get list of BYOH nodes before the node objects are deleted
 	byohNodes, err := tc.listFullyConfiguredWindowsNodes(true)
 	require.NoError(t, err, "error getting BYOH node list")


### PR DESCRIPTION
This change bypasses the execution of the BYOH removal test when the number of BYOH nodes is zero, so that the e2e test suite passes.

Before `hack/run-ci-e2e-test.sh -t basic -m 1 -c 0` failed with:
```
	=== RUN   TestWMCO/destroy/Deletion/BYOH_node_removal
    delete_test.go:57: 
                Error Trace:    /home/jvaldes/Projects/windows-machine-config-operator/test/e2e/delete_test.go:57
                Error:          Received unexpected error:
                                error retrieving windows-instances ConfigMap: configmaps "windows-instances" not found
                Test:           TestWMCO/destroy/Deletion/BYOH_node_removal
                Messages:       error removing windows-instances ConfigMap entries
```