### PR TITLE
OCPBUGS-19502: Enable proxy removal test

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -160,7 +160,7 @@ if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   printf "\n####### Testing service reconciliation #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $GO_TEST_ARGS
   printf "\n####### Testing cluster-wide proxy #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/cluster-wide_proxy -v -timeout=10m -args $GO_TEST_ARGS
+  go test ./test/e2e/... -run=TestWMCO/cluster-wide_proxy -v -timeout=20m -args $GO_TEST_ARGS
 fi
 
 if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -163,7 +163,8 @@ func (tc *testContext) checkEnvVarsRemoved(address string) (bool, error) {
 			return false, nil
 		}
 		for _, svcName := range windows.RequiredServices {
-			svcEnvVars, err := tc.getProxyEnvVarsFromService(address, svcName)
+			svcEnvVars, err := tc.getProxyEnvVarsFromService(address, svcName,
+				fmt.Sprintf("%s-%s", svcName, "removed"))
 			if err != nil {
 				return false, fmt.Errorf("error retrieving service level ENV vars: %w", err)
 			}


### PR DESCRIPTION
This PR enables running proxy removal test which was disabled due to its unreliable behavior.
It has now been modified to wait for the reboot annotation to be applied and to be removed before running the tests.
