### PR TITLE
Prevent reconfigure test from leaving Machine nodes in a bad state

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -169,10 +169,6 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $GO_TEST_ARGS
 
   # Run the reconfiguration test
-  # The reconfiguration suite must be run directly before the deletion suite. This is because we do not
-  # currently wait for nodes to fully reconcile after changing the private key back to the valid key. Any tests
-  # added/moved in between these two suites may fail.
-  # This limitation will be removed with https://issues.redhat.com/browse/WINC-655
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
 fi

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -23,10 +23,6 @@ func reconfigurationTestSuite(t *testing.T) {
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
 		t.Run("Re-add removed instance", tc.testReAddInstance)
 	}
-	// testPrivateKeyChange must be the last test run in the reconfiguration suite. This is because we do not currently
-	// wait for nodes to fully come back up after changing the private key back to the valid key. Only the deletion test
-	// suite should run after this. Any other tests may result in flakes.
-	// This limitation will be removed with https://issues.redhat.com/browse/WINC-655
 	t.Run("Change private key", testPrivateKeyChange)
 }
 

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -181,9 +181,9 @@ func testPrivateKeyChange(t *testing.T) {
 	err = tc.validateUpgradeableCondition(meta.ConditionTrue)
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 
-	// Re-create the known private key so SSH connection can be re-established
-	// TODO: Remove dependency on this secret by rotating keys as part of https://issues.redhat.com/browse/WINC-655
-	require.NoError(t, tc.createPrivateKeySecret(true), "error confirming known private key secret exists")
+	// revert key changes so the test suite is able to SSH into the VMs
+	require.NoError(t, tc.createPrivateKeySecret(true))
+	require.NoError(t, tc.waitForNewMachineNodes())
 }
 
 // waitForBYOHPrivateKeyUpdate waits until all BYOH Nodes annotations are updated to reflect the expected private key


### PR DESCRIPTION
Running the reconfiguration test causes Machine backed nodes to be deleted, without waiting for a Node to replace them. This is bleeding over to the deletion test suite, and causing failures, and potential false positives there.