### PR TITLE
[release-4.13] Unblock aws-e2e-upgrade test

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -165,10 +165,6 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
   go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $GO_TEST_ARGS
 
   # Run the reconfiguration test
-  # The reconfiguration suite must be run directly before the deletion suite. This is because we do not
-  # currently wait for nodes to fully reconcile after changing the private key back to the valid key. Any tests
-  # added/moved in between these two suites may fail.
-  # This limitation will be removed with https://issues.redhat.com/browse/WINC-655
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
 fi

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
+	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
@@ -238,16 +240,17 @@ func (tc *testContext) deployNOOPDaemonSet() (*apps.DaemonSet, error) {
 // waitUntilDeploymentScaled will return nil if the daemonset is fully deployed across the Windows nodes
 func (tc *testContext) waitUntilDaemonsetScaled(name string, desiredReplicas int) error {
 	var ds *apps.DaemonSet
-	var err error
-	for i := 0; i < retryCount; i++ {
-		ds, err = tc.client.K8s.AppsV1().DaemonSets(tc.workloadNamespace).Get(context.TODO(), name, meta.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("could not get daemonset %s: %w", name, err)
-		}
-		if int(ds.Status.NumberAvailable) == desiredReplicas {
-			return nil
-		}
-		time.Sleep(retryInterval)
+	err := wait.PollImmediateWithContext(context.TODO(), retry.Interval, retry.Timeout,
+		func(ctx context.Context) (done bool, err error) {
+			ds, err = tc.client.K8s.AppsV1().DaemonSets(tc.workloadNamespace).Get(ctx, name, meta.GetOptions{})
+			if err != nil {
+				log.Printf("could not get daemonset %s: %s", name, err)
+				return false, nil
+			}
+			return int(ds.Status.NumberAvailable) == desiredReplicas, nil
+		})
+	if err != nil {
+		return fmt.Errorf("error waiting for daemonset %s to scale, current status: %+v: %w", name, ds.Status, err)
 	}
-	return fmt.Errorf("timed out waiting for daemonset %s to scale, current status: %+v", name, ds.Status)
+	return nil
 }

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -23,10 +23,6 @@ func reconfigurationTestSuite(t *testing.T) {
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
 		t.Run("Re-add removed instance", tc.testReAddInstance)
 	}
-	// testPrivateKeyChange must be the last test run in the reconfiguration suite. This is because we do not currently
-	// wait for nodes to fully come back up after changing the private key back to the valid key. Only the deletion test
-	// suite should run after this. Any other tests may result in flakes.
-	// This limitation will be removed with https://issues.redhat.com/browse/WINC-655
 	t.Run("Change private key", testPrivateKeyChange)
 }
 

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -181,9 +181,9 @@ func testPrivateKeyChange(t *testing.T) {
 	err = tc.validateUpgradeableCondition(meta.ConditionTrue)
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 
-	// Re-create the known private key so SSH connection can be re-established
-	// TODO: Remove dependency on this secret by rotating keys as part of https://issues.redhat.com/browse/WINC-655
-	require.NoError(t, tc.createPrivateKeySecret(true), "error confirming known private key secret exists")
+	// revert key changes so the test suite is able to SSH into the VMs
+	require.NoError(t, tc.createPrivateKeySecret(true))
+	require.NoError(t, tc.waitForNewMachineNodes())
 }
 
 // waitForBYOHPrivateKeyUpdate waits until all BYOH Nodes annotations are updated to reflect the expected private key


### PR DESCRIPTION
Includes two cherry-picks required to stop the aws-e2e-upgrade noop daemonset test from failing almost every run.
