### PR TITLE
WINC-688: Support removing proxy certs from Windows nodes

### DIFF
--- a/pkg/daemon/certs/certs.go
+++ b/pkg/daemon/certs/certs.go
@@ -25,7 +25,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"reflect"
 	"syscall"
 	"unsafe"
 
@@ -33,19 +35,94 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Reconcile ensures the certificates in the given trusted CA bundle file are imported as system certificates.
-// Returns a boolean whether any certs needed to be reconciled
-func Reconcile(caBundle string) (bool, error) {
-	if caBundle == "" {
-		// TODO: ensure that all certs that we've added previously are removed https://issues.redhat.com/browse/WINC-688
+// importedCABundleFile tracks all the certs that the operator has imported into the node's local trust store
+const importedCABundleFile = "C:\\k\\imported-certs.pem"
+
+// Reconcile ensures the node's system certificates match the expected state as given by the trusted CA bundle file.
+// Returns a boolean whether any certs needed to be reconciled.
+// If this function returns true and a non-nil error, the instance must be rebooted anyway.
+func Reconcile(caBundlePath string) (bool, error) {
+	// caBundlePath will be empty when a cluster-wide proxy is being removed or not in use
+	certChange, err := reconcileCerts(caBundlePath)
+	if err != nil {
+		return false, err
+	}
+	// An error updating the imported bundle file will be self-corrected on the next reconcile, since it is the source
+	// of truth for determining whether certs need to be updated
+	return certChange, updateImportedCABundle(caBundlePath, certChange)
+}
+
+// reconcileCerts reconciles any discrepency between expected and existing Windows certificates by importing or
+// deleting certificates from the root system store. Returns a boolean if any certificates were imported or deleted
+func reconcileCerts(caBundlePath string) (bool, error) {
+	expectedCerts, err := getExpectedCerts(caBundlePath)
+	if err != nil {
+		return false, err
+	}
+	existingCerts, err := getExistingCerts()
+	if err != nil {
+		return false, err
+	}
+
+	if reflect.DeepEqual(expectedCerts, existingCerts) {
 		return false, nil
 	}
-	// Read expected certs from CA trust bundle file
-	expectedCerts, err := readCertsFromFile(caBundle)
+
+	// Open the root certificate store
+	systemStore, err := windows.CertOpenStore(windows.CERT_STORE_PROV_SYSTEM, 0, 0,
+		windows.CERT_SYSTEM_STORE_LOCAL_MACHINE, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr("ROOT"))))
 	if err != nil {
-		return false, fmt.Errorf("Failed to read certificate file: %v", err)
+		return false, fmt.Errorf("Failed to open root certificate store: %w", err)
 	}
-	return ensureCertsAreImported(expectedCerts)
+	defer func() {
+		if err := windows.CertCloseStore(systemStore, 0); err != nil {
+			klog.Error("Failed to close root system certificate store")
+		}
+	}()
+
+	certsImported, err := ensureCertsAreImported(systemStore, expectedCerts, existingCerts)
+	if err != nil {
+		return false, fmt.Errorf("Failed to import certificates: %w", err)
+	}
+	certsDeleted, err := ensureCertsAreDeleted(systemStore, expectedCerts, existingCerts)
+	if err != nil {
+		return false, fmt.Errorf("Failed to delete certificates: %w", err)
+	}
+	return (certsImported || certsDeleted), nil
+}
+
+// getExpectedCerts reads expected state of certs from the CA bundle file. Returns an empty slice if no proxy is in use.
+func getExpectedCerts(path string) ([]*x509.Certificate, error) {
+	var expectedCerts []*x509.Certificate
+	var err error
+	if path == "" {
+		return expectedCerts, nil
+	}
+
+	if expectedCerts, err = readCertsFromFile(path); err != nil {
+		return nil, fmt.Errorf("Failed to read certificate file %s: %w", path, err)
+	}
+	return expectedCerts, nil
+}
+
+// getExistingCerts populates existing certs using the previously imported CA trust bundle
+func getExistingCerts() ([]*x509.Certificate, error) {
+	var existingCerts []*x509.Certificate
+	exists, err := fileExists(importedCABundleFile)
+	if err != nil {
+		// If there is an error here due to file corruption, the file will get deleted and re-created when the node is
+		// reconfigured. This has the potential to leave stale certificates behind on the node.
+		return nil, err
+	}
+	// The file will not exist on first reconcile in which case existingCerts will be empty.
+	if !exists {
+		return existingCerts, nil
+	}
+
+	if existingCerts, err = readCertsFromFile(importedCABundleFile); err != nil {
+		return nil, fmt.Errorf("Failed to read certificate file %s: %w", importedCABundleFile, err)
+	}
+	return existingCerts, nil
 }
 
 // readCertsFromFile reads in any PEM-encoded certificates from the given file
@@ -106,28 +183,76 @@ func splitAtPEMCert() func(data []byte, atEOF bool) (advance int, token []byte, 
 	}
 }
 
-// ensureCertsAreImported imports the expected certificates into the instance's root system trust store, if not already
-// present. Returns a boolean if any certificates were imported
-func ensureCertsAreImported(expectedCerts []*x509.Certificate) (bool, error) {
-	// Open the root certificate store
-	systemStore, err := windows.CertOpenStore(windows.CERT_STORE_PROV_SYSTEM, 0, 0,
-		windows.CERT_SYSTEM_STORE_LOCAL_MACHINE, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr("ROOT"))))
+// fileExists checks if the file at the given path exists. Returns true if it exists, false if not, and error otherwise.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, newFileIOError(fmt.Errorf("failed to check if file %s exists: %w", path, err))
+	}
+}
+
+// updateImportedCABundle updates the previously imported CA bundle file, if needed.
+func updateImportedCABundle(caBundlePath string, certChange bool) error {
+	if caBundlePath == "" {
+		// When proxy is deconfigured, ensure the file is deleted to avoid leaking certs
+		return ensureFileIsRemoved(importedCABundleFile)
+	}
+	if certChange {
+		klog.Infof("copied file contents from %s to %s", caBundlePath, importedCABundleFile)
+		// When certs have been reconciled, update the previously imported CA trust bundle to hold the new cert bundle
+		return copyFile(caBundlePath, importedCABundleFile)
+	}
+	return nil
+}
+
+// ensureFileIsRemoved deletes the file at the given path. No-op if the file already does not exist
+func ensureFileIsRemoved(path string) error {
+	exists, err := fileExists(path)
 	if err != nil {
-		return false, fmt.Errorf("Failed to open root certificate store: %v", err)
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	klog.Infof("removed file %s", path)
+	return nil
+}
+
+// copyFile copies the file contents from the source file to the destination. Creates the destination file if needed.
+func copyFile(src, dst string) error {
+	r, err := os.Open(src)
+	if err != nil {
+		return err
 	}
 	defer func() {
-		if err := windows.CertCloseStore(systemStore, 0); err != nil {
-			klog.Error("Failed to close root system certificate store")
+		if err := r.Close(); err != nil {
+			klog.Errorf("Failed to close file %s", r.Name())
 		}
 	}()
-
-	// Get all existing from system store
-	existingCerts, err := getAllCerts(systemStore)
+	w, err := os.Create(dst)
 	if err != nil {
-		return false, fmt.Errorf("Failed to read certificate file: %v", err)
+		return err
 	}
+	defer func() {
+		if err := w.Close(); err != nil {
+			klog.Errorf("Failed to close file %s", w.Name())
+		}
+	}()
+	_, err = io.Copy(w, r)
+	return err
+}
 
-	certChange := false
+// ensureCertsAreImported imports the expected certificates into the instance's root system trust store, if not already
+// present. Returns a boolean if any certificates were imported
+func ensureCertsAreImported(store windows.Handle, expectedCerts, existingCerts []*x509.Certificate) (bool, error) {
+	certImported := false
 	for _, cert := range expectedCerts {
 		if containsCert(existingCerts, cert) {
 			// Cert already exists as expected, do nothing
@@ -135,40 +260,28 @@ func ensureCertsAreImported(expectedCerts []*x509.Certificate) (bool, error) {
 		}
 
 		// Add the certificate to the instance's system-wide trust store
-		if err := addCertToStore(systemStore, cert); err != nil {
+		if err := addCertToStore(store, cert); err != nil {
 			return false, err
 		}
-		certChange = true
+		certImported = true
 	}
-	return certChange, nil
+	return certImported, nil
 }
 
-// getAllCerts reads all the certs from the given certificate store
-func getAllCerts(store windows.Handle) ([]*x509.Certificate, error) {
-	var existingSystemCerts []*x509.Certificate
-	var certContext *windows.CertContext
-	var err error
-	for {
-		certContext, err = windows.CertEnumCertificatesInStore(store, certContext)
-		if err != nil {
-			if errors.Is(err, windows.Errno(windows.CRYPT_E_NOT_FOUND)) {
-				// Error code implies we have read all certs:
-				// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcertificatesinstore
-				break
+// ensureCertsAreDeleted deletes any existing certificates that are not in the expected list.
+// Returns a boolean if any certificates were deleted.
+func ensureCertsAreDeleted(store windows.Handle, expectedCerts, existingCerts []*x509.Certificate) (bool, error) {
+	certDeleted := false
+	for _, cert := range existingCerts {
+		// Any imported previously certs that are NOT in the new cert bundle should be removed
+		if !containsCert(expectedCerts, cert) {
+			if err := removeCertFromStore(store, cert); err != nil {
+				return false, err
 			}
-			return nil, fmt.Errorf("Error reading existing system certificate: %v", err)
+			certDeleted = true
 		}
-
-		// Convert the certificate bytes to Golang x509.Certificate
-		certBytes := unsafe.Slice(certContext.EncodedCert, certContext.Length)
-		x509Cert, err := x509.ParseCertificate(certBytes)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to parse certificate from bytes: %v", err)
-		}
-		existingSystemCerts = append(existingSystemCerts, x509Cert)
 	}
-	klog.Infof("found %d existing system certificates", len(existingSystemCerts))
-	return existingSystemCerts, nil
+	return certDeleted, nil
 }
 
 // containsCert checks if the target certificate exists in the given slice
@@ -195,4 +308,69 @@ func addCertToStore(store windows.Handle, cert *x509.Certificate) error {
 	}
 	klog.Infof("Certificate %s imported successfully.", cert.Subject.String())
 	return nil
+}
+
+// removeCertFromStore removes the given certificate from its associated certificate store
+func removeCertFromStore(store windows.Handle, cert *x509.Certificate) error {
+	// Windows CertContext holds the store which imported the cert, which is needed when deleting from the system store
+	certContext, err := retrieveCertContext(store, cert)
+	if err != nil {
+		return fmt.Errorf("failed to create content from x509 cert %s: %w", cert.Subject.String(), err)
+	}
+	if certContext == nil {
+		// Cert already doesn't exist, nothing to do
+		return nil
+	}
+
+	if err = windows.CertDeleteCertificateFromStore(certContext); err != nil {
+		return fmt.Errorf("failed to remove certificate %s: %w", cert.Subject.String(), err)
+	}
+	klog.V(1).Infof("Certificate %s removed successfully.", cert.Subject.String())
+	return nil
+}
+
+// retrieveCertContext finds the given certificate in the given store and returns its full context per Windows OS
+// Returns a nil CertContext if the cert is not found.
+func retrieveCertContext(store windows.Handle, targetCert *x509.Certificate) (*windows.CertContext, error) {
+	var certContext *windows.CertContext
+	var err error
+	for {
+		certContext, err = windows.CertEnumCertificatesInStore(store, certContext)
+		if err != nil {
+			if errors.Is(err, windows.Errno(windows.CRYPT_E_NOT_FOUND)) {
+				// Error code implies we have read all certs:
+				// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcertificatesinstore
+				break
+			}
+			return nil, fmt.Errorf("error reading existing system certificate: %w", err)
+		}
+
+		// Convert the certificate bytes to Golang x509.Certificate
+		certBytes := unsafe.Slice(certContext.EncodedCert, certContext.Length)
+		current, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate from bytes: %w", err)
+		}
+
+		if current.Equal(targetCert) {
+			klog.Infof("found %s existing system certificate", certContext.CertInfo.Subject)
+			return certContext, nil
+		}
+	}
+	klog.Infof("target cert not found in root system store: %s", targetCert.Subject)
+	return nil, nil
+}
+
+// FileIOError occurs when there is an failure interacting with the Windows filesystem
+type FileIOError struct {
+	err error
+}
+
+func (e *FileIOError) Error() string {
+	return e.err.Error()
+}
+
+// newFileIOError returns a new FileIOError
+func newFileIOError(err error) *FileIOError {
+	return &FileIOError{err: err}
 }

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -36,6 +37,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/jsonpath"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,6 +64,9 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
+// WICDController is the name of the WICD controller in logs and other outputs
+const WICDController = "WICD"
+
 // Options contains a list of options available when creating a new ServiceController
 type Options struct {
 	Config    *rest.Config
@@ -69,6 +74,7 @@ type Options struct {
 	Mgr       manager.Manager
 	cmdRunner powershell.CommandRunner
 	caBundle  string
+	recorder  record.EventRecorder
 }
 
 // setDefaults returns an Options based on the received options, with all nil or empty fields filled in with reasonable
@@ -110,6 +116,8 @@ type ServiceController struct {
 	psCmdRunner    powershell.CommandRunner
 	ctrl           controller.Controller
 	caBundle       string
+	// recorder to generate events
+	recorder record.EventRecorder
 }
 
 // Bootstrap starts all Windows services marked as necessary for node bootstrapping as defined in the given data
@@ -161,7 +169,8 @@ func RunController(ctx context.Context, watchNamespace, kubeconfig, caBundle str
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)
 	}
-	sc, err := NewServiceController(ctx, node.Name, watchNamespace, Options{Client: ctrlMgr.GetClient(), caBundle: caBundle})
+	sc, err := NewServiceController(ctx, node.Name, watchNamespace,
+		Options{Client: ctrlMgr.GetClient(), caBundle: caBundle, recorder: ctrlMgr.GetEventRecorderFor(WICDController)})
 	if err != nil {
 		return err
 	}
@@ -182,7 +191,7 @@ func NewServiceController(ctx context.Context, nodeName, watchNamespace string, 
 		return nil, err
 	}
 	return &ServiceController{client: o.Client, Manager: o.Mgr, ctx: ctx, nodeName: nodeName, psCmdRunner: o.cmdRunner,
-		watchNamespace: watchNamespace, caBundle: o.caBundle}, nil
+		watchNamespace: watchNamespace, caBundle: o.caBundle, recorder: o.recorder}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -293,22 +302,32 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 // Returns a boolean expressing whether the instance is awaiting a reboot.
 func (sc *ServiceController) reconcileEnvVarsAndCerts(envVars map[string]string, watchedEnvVars []string,
 	node core.Node) (bool, error) {
-	certsUpdated, err := certs.Reconcile(sc.caBundle)
-	if err != nil {
-		return false, err
-	}
 	envVarsUpdated, err := envvar.Reconcile(envVars, watchedEnvVars)
 	if err != nil {
 		return false, err
 	}
+	// Reconcile certs but only process the error after determining reboot status in case error happened after cert changes
+	certsUpdated, err := certs.Reconcile(sc.caBundle)
 	if certsUpdated || envVarsUpdated {
 		// If there's any changes, an instance restart is required to ensure all processes pick up the updates.
 		// Applying the reboot annotation results in an event picked up by WMCO's node controller to reboot the instance
-		if err = metadata.ApplyRebootAnnotation(sc.ctx, sc.client, node); err != nil {
-			return false, fmt.Errorf("error setting reboot annotation on node %s: %w", sc.nodeName, err)
+		if annotationErr := metadata.ApplyRebootAnnotation(sc.ctx, sc.client, node); annotationErr != nil {
+			return false, fmt.Errorf("error setting reboot annotation on node %s: %w", sc.nodeName, annotationErr)
 		}
-		return true, nil
+		if err == nil {
+			return true, nil
+		}
 	}
+	if err != nil {
+		var fileIOErr *certs.FileIOError
+		if errors.Is(err, fileIOErr) {
+			sc.recorder.Event(&node, core.EventTypeWarning, "CertificateReadError",
+				"File I/O error when reading imported certificates. This has the potential to leave stale "+
+					"certificates behind in the node's local trust store.")
+		}
+		return false, err
+	}
+
 	// Wait until the environment variables at the process level are set as expected.
 	// This will only be picked up after WMCO reboots the instance
 	err = wait.PollUntilContextTimeout(sc.ctx, 15*time.Second, 5*time.Minute, true,


### PR DESCRIPTION
WICD controller reacts to changes in the trusted CA bundle that involve
a certificate removal (cert rotation, user disabling cluster-wide proxy, etc). 
Certificates that are removed from the trusted CA bundle are in turn
removed from each Windows node's local trust store and processes. 
This is also the case when nodes are deconfigured. With this, no outgoing
traffic from the node will try to use removed certificates.