### PR TITLE
[release-4.13] WINC-1098: Block upgrades when migrating from in-tree to CSI

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -214,6 +214,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes/proxy
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
           - pods
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/proxy
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/certificates"
+	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/condition"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
@@ -64,6 +65,16 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 		return nil
 	}
 
+	csiEnabled, err := cluster.CSIStorageEnabled(r.platform)
+	if err != nil {
+		return err
+	}
+	if csiEnabled {
+		if labelsToApply == nil {
+			labelsToApply = make(map[string]string)
+		}
+		labelsToApply[metadata.CSIConfiguredLabel] = "true"
+	}
 	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 		instanceInfo, r.signer, labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
@@ -73,15 +84,52 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 	// Check if the instance was configured by a previous version of WMCO and must be deconfigured before being
 	// configured again.
 	if instanceInfo.UpgradeRequired() {
+		blocked := r.upgradeBlocked(instanceInfo.Node, csiEnabled)
+		if blocked {
+			blockMessage := fmt.Sprintf("node upgrade has been blocked, as it can not be ensured that workloads "+
+				"will not be disrupted. If an in-tree persistent storage volume is in use, please ensure the CSI "+
+				"drivers for the given node have been deployed. This block must be overriden by applying the "+
+				"label %s=true to the node. It is recommended to unblock Nodes individually, and to wait for the upgrade "+
+				"to complete sucessfully before unblocking another Node.", metadata.AllowUpgradeLabel)
+			r.log.Info(blockMessage)
+			r.recorder.Eventf(instanceInfo.Node, core.EventTypeWarning, "UpgradeBlocked", blockMessage)
+			return metadata.ApplyBlockedLabel(context.TODO(), r.client, *instanceInfo.Node)
+		}
 		// Instance requiring an upgrade indicates that node object is present with the version annotation
 		r.log.Info("instance requires upgrade", "node", instanceInfo.Node.GetName(), "version",
 			instanceInfo.Node.GetAnnotations()[metadata.VersionAnnotation], "expected version", version.Get())
+		if err = metadata.RemoveBlockedLabel(context.TODO(), r.client, *instanceInfo.Node); err != nil {
+			return fmt.Errorf("error removing upgrade block label: %w", err)
+		}
+
 		if err := nc.Deconfigure(); err != nil {
 			return err
 		}
 	}
 
 	return nc.Configure()
+}
+
+// upgradeBlocked returns whether the upgrade should be blocked if an upgrade will break storage functionality.
+func (r *instanceReconciler) upgradeBlocked(node *core.Node, upgradingToCSI bool) bool {
+	// Only consider the case of vSphere and Azure. Safely migrating in-tree storage on other platforms is not supported
+	// by WMCO.
+	if r.platform != config.VSpherePlatformType && r.platform != config.AzurePlatformType {
+		return false
+	}
+	if !upgradingToCSI {
+		return false
+	}
+	if value := node.GetLabels()[metadata.AllowUpgradeLabel]; value == "true" {
+		return false
+	}
+	if value := node.GetLabels()[metadata.CSIConfiguredLabel]; value == "true" {
+		return false
+	}
+	if len(node.Status.VolumesAttached) == 0 {
+		return false
+	}
+	return true
 }
 
 // instanceFromNode returns an instance object for the given node. Requires a username that can be used to SSH into the

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 )
 
 func TestGetAddress(t *testing.T) {
@@ -59,6 +63,77 @@ func TestGetAddress(t *testing.T) {
 			// The output can be any valid address in the expected list, so check that the output is one of the possible
 			// correct ones
 			assert.Contains(t, test.expectedOut, out)
+		})
+	}
+}
+
+func TestUpgradeBlocked(t *testing.T) {
+	testCases := []struct {
+		name           string
+		override       bool
+		hasCSILabel    bool
+		volumeMounted  bool
+		upgradingToCSI bool
+		expected       bool
+	}{
+		{
+			name:           "Upgrading from in tree to in tree with a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  true,
+			upgradingToCSI: false,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from in tree with a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  true,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from in tree without a volume mounted",
+			override:       false,
+			hasCSILabel:    false,
+			volumeMounted:  false,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+		{
+			name:           "Upgrading from already migrated Node with a volume",
+			override:       false,
+			hasCSILabel:    true,
+			volumeMounted:  true,
+			upgradingToCSI: true,
+			expected:       false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			node := core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:        "node",
+					Annotations: make(map[string]string),
+					Labels:      make(map[string]string),
+				},
+				Status: core.NodeStatus{
+					VolumesAttached: []core.AttachedVolume{},
+				},
+			}
+			if tt.override {
+				node.Labels[metadata.AllowUpgradeLabel] = ""
+			}
+			if tt.hasCSILabel {
+				node.Labels[metadata.CSIConfiguredLabel] = "true"
+			}
+			if tt.volumeMounted {
+				node.Status.VolumesInUse = []core.UniqueVolumeName{"test"}
+			}
+			fakeClient := clientfake.NewClientBuilder().WithObjects(&node).Build()
+			r := instanceReconciler{client: fakeClient}
+			result := r.upgradeBlocked(&node, tt.upgradingToCSI)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/mod/semver"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+
+	"github.com/openshift/windows-machine-config-operator/version"
 )
 
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
@@ -339,4 +341,24 @@ func IsCloudControllerOwnedByCCM(oclient configclient.Interface) (bool, error) {
 	}
 
 	return ownedByCCM, nil
+}
+
+// CSIStorageEnabled returns true if WMCO should configure Nodes to use CSI driver backed storage, and not in-tree
+// storage
+func CSIStorageEnabled(platform oconfig.PlatformType) (bool, error) {
+	var firstWMCOVersionWithCSISupport int
+	switch platform {
+	case oconfig.AzurePlatformType:
+		firstWMCOVersionWithCSISupport = 8
+	case oconfig.VSpherePlatformType:
+		firstWMCOVersionWithCSISupport = 9
+	default:
+		// All other platforms had in-tree storage removed in 4.12 or before, and must have CSI enabled
+		return true, nil
+	}
+	majorVersion, err := version.Major()
+	if err != nil {
+		return false, fmt.Errorf("error getting WMCO major version: %w", err)
+	}
+	return firstWMCOVersionWithCSISupport <= majorVersion, nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -21,6 +21,12 @@ const (
 	VersionAnnotation = "windowsmachineconfig.openshift.io/version"
 	// DesiredVersionAnnotation is a Node annotation, indicating the Service ConfigMap that should be used to configure it
 	DesiredVersionAnnotation = "windowsmachineconfig.openshift.io/desired-version"
+	// UpgradeBlockedLabel indicates that the Node's upgrade has been blocked by WMCO
+	UpgradeBlockedLabel = "windowsmachineconfig.openshift.io/upgrade-blocked"
+	// CSIConfiguredLabel indicates that this Node was configured to use CSI storage, and not in-tree storage
+	CSIConfiguredLabel = "windowsmachineconfig.openshift.io/configured-with-csi"
+	// AllowUpgradeLabel should be applied on a Node by a user, if they wish to unblock an upgrade
+	AllowUpgradeLabel = "windowsmachineconfig.openshift.io/allow-upgrade"
 )
 
 // generatePatch creates a patch applying the given operation onto each given annotation key and value
@@ -99,6 +105,11 @@ func ApplyDesiredVersionAnnotation(ctx context.Context, c client.Client, node co
 	return ApplyLabelsAndAnnotations(ctx, c, node, nil, map[string]string{DesiredVersionAnnotation: value})
 }
 
+// ApplyBlockedLabel applies a label to the given Node communicating that the Node's upgrade is blocked
+func ApplyBlockedLabel(ctx context.Context, c client.Client, node core.Node) error {
+	return ApplyLabelsAndAnnotations(ctx, c, node, map[string]string{UpgradeBlockedLabel: "true"}, nil)
+}
+
 // RemoveVersionAnnotation clears the version annotation from the node object, indicating the node is not configured
 func RemoveVersionAnnotation(ctx context.Context, c client.Client, node core.Node) error {
 	if _, present := node.GetAnnotations()[VersionAnnotation]; present {
@@ -109,6 +120,21 @@ func RemoveVersionAnnotation(ctx context.Context, c client.Client, node core.Nod
 		err = c.Patch(ctx, &node, client.RawPatch(kubeTypes.JSONPatchType, patchData))
 		if err != nil {
 			return fmt.Errorf("error removing version annotation from node %s: %w", node.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// RemoveBlockedLabel clears the blocked label from the given Node
+func RemoveBlockedLabel(ctx context.Context, c client.Client, node core.Node) error {
+	if _, present := node.GetLabels()[UpgradeBlockedLabel]; present {
+		patchData, err := GenerateRemovePatch([]string{UpgradeBlockedLabel}, []string{})
+		if err != nil {
+			return fmt.Errorf("error creating remove patch: %w", err)
+		}
+		err = c.Patch(ctx, &node, client.RawPatch(kubeTypes.JSONPatchType, patchData))
+		if err != nil {
+			return fmt.Errorf("error patching node %s: %w", node.GetName(), err)
 		}
 	}
 	return nil

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -10,9 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/azure"
 )
+
+// storageTestLabel indicates that this Node was chosen to have the storage workload attached to it, and the Node should
+// be blocked from migrating from in-tree to CSI.
+var storageTestLabel = "wmco-test/storage-attached"
 
 // testStorage tests that persistent volumes can be accessed by Windows pods
 func testStorage(t *testing.T) {
@@ -53,8 +59,16 @@ func testStorage(t *testing.T) {
 		}()
 	}
 	pvcVolumeSource := &core.PersistentVolumeClaimVolumeSource{ClaimName: pvc.GetName()}
-	affinity, err := getAffinityForNode(&gc.allNodes()[0])
+	selectedNode := &gc.allNodes()[0]
+	affinity, err := getAffinityForNode(selectedNode)
 	require.NoError(t, err)
+	if inTreeUpgrade {
+		patch, err := metadata.GenerateAddPatch(map[string]string{storageTestLabel: "true"}, nil)
+		require.NoError(t, err)
+		_, err = tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), selectedNode.GetName(), types.JSONPatchType, patch,
+			meta.PatchOptions{})
+		require.NoError(t, err, "error labeling node for upgrade test")
+	}
 
 	// The deployment will not come to ready if the volume is not able to be attached to the pod. If the deployment is
 	// successful, storage is working as expected.

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -208,9 +208,9 @@ func TestUpgrade(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfMachineNodes), false, false)
-	assert.NoError(t, err, "timed out waiting for Windows Machine nodes")
+	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfBYOHNodes), false, true)
-	assert.NoError(t, err, "timed out waiting for BYOH Windows nodes")
+	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 
 	// Basic testing to ensure the Node object is in a good state
 	t.Run("Nodes ready", tc.testNodesBecomeReadyAndSchedulable)

--- a/vendor/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
+++ b/vendor/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Summary is a top-level container for holding NodeStats and PodStats.
+type Summary struct {
+	// Overall node stats.
+	Node NodeStats `json:"node"`
+	// Per-pod stats.
+	Pods []PodStats `json:"pods"`
+}
+
+// NodeStats holds node-level unprocessed sample stats.
+type NodeStats struct {
+	// Reference to the measured Node.
+	NodeName string `json:"nodeName"`
+	// Stats of system daemons tracked as raw containers.
+	// The system containers are named according to the SystemContainer* constants.
+	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	SystemContainers []ContainerStats `json:"systemContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// The time at which data collection for the node-scoped (i.e. aggregate) stats was (re)started.
+	StartTime metav1.Time `json:"startTime"`
+	// Stats pertaining to CPU resources.
+	// +optional
+	CPU *CPUStats `json:"cpu,omitempty"`
+	// Stats pertaining to memory (RAM) resources.
+	// +optional
+	Memory *MemoryStats `json:"memory,omitempty"`
+	// Stats pertaining to network resources.
+	// +optional
+	Network *NetworkStats `json:"network,omitempty"`
+	// Stats pertaining to total usage of filesystem resources on the rootfs used by node k8s components.
+	// NodeFs.Used is the total bytes used on the filesystem.
+	// +optional
+	Fs *FsStats `json:"fs,omitempty"`
+	// Stats about the underlying container runtime.
+	// +optional
+	Runtime *RuntimeStats `json:"runtime,omitempty"`
+	// Stats about the rlimit of system.
+	// +optional
+	Rlimit *RlimitStats `json:"rlimit,omitempty"`
+}
+
+// RlimitStats are stats rlimit of OS.
+type RlimitStats struct {
+	Time metav1.Time `json:"time"`
+
+	// The max number of extant process (threads, precisely on Linux) of OS. See RLIMIT_NPROC in getrlimit(2).
+	// The operating system ceiling on the number of process IDs that can be assigned.
+	// On Linux, tasks (either processes or threads) consume 1 PID each.
+	MaxPID *int64 `json:"maxpid,omitempty"`
+	// The number of running process (threads, precisely on Linux) in the OS.
+	NumOfRunningProcesses *int64 `json:"curproc,omitempty"`
+}
+
+// RuntimeStats are stats pertaining to the underlying container runtime.
+type RuntimeStats struct {
+	// Stats about the underlying filesystem where container images are stored.
+	// This filesystem could be the same as the primary (root) filesystem.
+	// Usage here refers to the total number of bytes occupied by images on the filesystem.
+	// +optional
+	ImageFs *FsStats `json:"imageFs,omitempty"`
+}
+
+const (
+	// SystemContainerKubelet is the container name for the system container tracking Kubelet usage.
+	SystemContainerKubelet = "kubelet"
+	// SystemContainerRuntime is the container name for the system container tracking the runtime (e.g. docker) usage.
+	SystemContainerRuntime = "runtime"
+	// SystemContainerMisc is the container name for the system container tracking non-kubernetes processes.
+	SystemContainerMisc = "misc"
+	// SystemContainerPods is the container name for the system container tracking user pods.
+	SystemContainerPods = "pods"
+)
+
+// ProcessStats are stats pertaining to processes.
+type ProcessStats struct {
+	// Number of processes
+	// +optional
+	ProcessCount *uint64 `json:"process_count,omitempty"`
+}
+
+// PodStats holds pod-level unprocessed sample stats.
+type PodStats struct {
+	// Reference to the measured Pod.
+	PodRef PodReference `json:"podRef"`
+	// The time at which data collection for the pod-scoped (e.g. network) stats was (re)started.
+	StartTime metav1.Time `json:"startTime"`
+	// Stats of containers in the measured pod.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Containers []ContainerStats `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+	// Stats pertaining to CPU resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	CPU *CPUStats `json:"cpu,omitempty"`
+	// Stats pertaining to memory (RAM) resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	Memory *MemoryStats `json:"memory,omitempty"`
+	// Stats pertaining to network resources.
+	// +optional
+	Network *NetworkStats `json:"network,omitempty"`
+	// Stats pertaining to volume usage of filesystem resources.
+	// VolumeStats.UsedBytes is the number of bytes used by the Volume
+	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeStats []VolumeStats `json:"volume,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// EphemeralStorage reports the total filesystem usage for the containers and emptyDir-backed volumes in the measured Pod.
+	// +optional
+	EphemeralStorage *FsStats `json:"ephemeral-storage,omitempty"`
+	// ProcessStats pertaining to processes.
+	// +optional
+	ProcessStats *ProcessStats `json:"process_stats,omitempty"`
+}
+
+// ContainerStats holds container-level unprocessed sample stats.
+type ContainerStats struct {
+	// Reference to the measured container.
+	Name string `json:"name"`
+	// The time at which data collection for this container was (re)started.
+	StartTime metav1.Time `json:"startTime"`
+	// Stats pertaining to CPU resources.
+	// +optional
+	CPU *CPUStats `json:"cpu,omitempty"`
+	// Stats pertaining to memory (RAM) resources.
+	// +optional
+	Memory *MemoryStats `json:"memory,omitempty"`
+	// Metrics for Accelerators. Each Accelerator corresponds to one element in the array.
+	Accelerators []AcceleratorStats `json:"accelerators,omitempty"`
+	// Stats pertaining to container rootfs usage of filesystem resources.
+	// Rootfs.UsedBytes is the number of bytes used for the container write layer.
+	// +optional
+	Rootfs *FsStats `json:"rootfs,omitempty"`
+	// Stats pertaining to container logs usage of filesystem resources.
+	// Logs.UsedBytes is the number of bytes used for the container logs.
+	// +optional
+	Logs *FsStats `json:"logs,omitempty"`
+	// User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	UserDefinedMetrics []UserDefinedMetric `json:"userDefinedMetrics,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// PodReference contains enough information to locate the referenced pod.
+type PodReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	UID       string `json:"uid"`
+}
+
+// InterfaceStats contains resource value data about interface.
+type InterfaceStats struct {
+	// The name of the interface
+	Name string `json:"name"`
+	// Cumulative count of bytes received.
+	// +optional
+	RxBytes *uint64 `json:"rxBytes,omitempty"`
+	// Cumulative count of receive errors encountered.
+	// +optional
+	RxErrors *uint64 `json:"rxErrors,omitempty"`
+	// Cumulative count of bytes transmitted.
+	// +optional
+	TxBytes *uint64 `json:"txBytes,omitempty"`
+	// Cumulative count of transmit errors encountered.
+	// +optional
+	TxErrors *uint64 `json:"txErrors,omitempty"`
+}
+
+// NetworkStats contains data about network resources.
+type NetworkStats struct {
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+
+	// Stats for the default interface, if found
+	InterfaceStats `json:",inline"`
+
+	Interfaces []InterfaceStats `json:"interfaces,omitempty"`
+}
+
+// CPUStats contains data about CPU usage.
+type CPUStats struct {
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+	// Total CPU usage (sum of all cores) averaged over the sample window.
+	// The "core" unit can be interpreted as CPU core-nanoseconds per second.
+	// +optional
+	UsageNanoCores *uint64 `json:"usageNanoCores,omitempty"`
+	// Cumulative CPU usage (sum of all cores) since object creation.
+	// +optional
+	UsageCoreNanoSeconds *uint64 `json:"usageCoreNanoSeconds,omitempty"`
+}
+
+// MemoryStats contains data about memory usage.
+type MemoryStats struct {
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+	// Available memory for use.  This is defined as the memory limit - workingSetBytes.
+	// If memory limit is undefined, the available bytes is omitted.
+	// +optional
+	AvailableBytes *uint64 `json:"availableBytes,omitempty"`
+	// Total memory in use. This includes all memory regardless of when it was accessed.
+	// +optional
+	UsageBytes *uint64 `json:"usageBytes,omitempty"`
+	// The amount of working set memory. This includes recently accessed memory,
+	// dirty memory, and kernel memory. WorkingSetBytes is <= UsageBytes
+	// +optional
+	WorkingSetBytes *uint64 `json:"workingSetBytes,omitempty"`
+	// The amount of anonymous and swap cache memory (includes transparent
+	// hugepages).
+	// +optional
+	RSSBytes *uint64 `json:"rssBytes,omitempty"`
+	// Cumulative number of minor page faults.
+	// +optional
+	PageFaults *uint64 `json:"pageFaults,omitempty"`
+	// Cumulative number of major page faults.
+	// +optional
+	MajorPageFaults *uint64 `json:"majorPageFaults,omitempty"`
+}
+
+// AcceleratorStats contains stats for accelerators attached to the container.
+type AcceleratorStats struct {
+	// Make of the accelerator (nvidia, amd, google etc.)
+	Make string `json:"make"`
+
+	// Model of the accelerator (tesla-p100, tesla-k80 etc.)
+	Model string `json:"model"`
+
+	// ID of the accelerator.
+	ID string `json:"id"`
+
+	// Total accelerator memory.
+	// unit: bytes
+	MemoryTotal uint64 `json:"memoryTotal"`
+
+	// Total accelerator memory allocated.
+	// unit: bytes
+	MemoryUsed uint64 `json:"memoryUsed"`
+
+	// Percent of time over the past sample period (10s) during which
+	// the accelerator was actively processing.
+	DutyCycle uint64 `json:"dutyCycle"`
+}
+
+// VolumeStats contains data about Volume filesystem usage.
+type VolumeStats struct {
+	// Embedded FsStats
+	FsStats `json:",inline"`
+	// Name is the name given to the Volume
+	// +optional
+	Name string `json:"name,omitempty"`
+	// Reference to the PVC, if one exists
+	// +optional
+	PVCRef *PVCReference `json:"pvcRef,omitempty"`
+
+	// VolumeHealthStats contains data about volume health
+	// +optional
+	VolumeHealthStats *VolumeHealthStats `json:"volumeHealthStats,omitempty"`
+}
+
+// VolumeHealthStats contains data about volume health.
+type VolumeHealthStats struct {
+	// Normal volumes are available for use and operating optimally.
+	// An abnormal volume does not meet these criteria.
+	Abnormal bool `json:"abnormal"`
+}
+
+// PVCReference contains enough information to describe the referenced PVC.
+type PVCReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// FsStats contains data about filesystem usage.
+type FsStats struct {
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+	// AvailableBytes represents the storage space available (bytes) for the filesystem.
+	// +optional
+	AvailableBytes *uint64 `json:"availableBytes,omitempty"`
+	// CapacityBytes represents the total capacity (bytes) of the filesystems underlying storage.
+	// +optional
+	CapacityBytes *uint64 `json:"capacityBytes,omitempty"`
+	// UsedBytes represents the bytes used for a specific task on the filesystem.
+	// This may differ from the total bytes used on the filesystem and may not equal CapacityBytes - AvailableBytes.
+	// e.g. For ContainerStats.Rootfs this is the bytes used by the container rootfs on the filesystem.
+	// +optional
+	UsedBytes *uint64 `json:"usedBytes,omitempty"`
+	// InodesFree represents the free inodes in the filesystem.
+	// +optional
+	InodesFree *uint64 `json:"inodesFree,omitempty"`
+	// Inodes represents the total inodes in the filesystem.
+	// +optional
+	Inodes *uint64 `json:"inodes,omitempty"`
+	// InodesUsed represents the inodes used by the filesystem
+	// This may not equal Inodes - InodesFree because this filesystem may share inodes with other "filesystems"
+	// e.g. For ContainerStats.Rootfs, this is the inodes used only by that container, and does not count inodes used by other containers.
+	InodesUsed *uint64 `json:"inodesUsed,omitempty"`
+}
+
+// UserDefinedMetricType defines how the metric should be interpreted by the user.
+type UserDefinedMetricType string
+
+const (
+	// MetricGauge is an instantaneous value. May increase or decrease.
+	MetricGauge UserDefinedMetricType = "gauge"
+
+	// MetricCumulative is a counter-like value that is only expected to increase.
+	MetricCumulative UserDefinedMetricType = "cumulative"
+
+	// MetricDelta is a rate over a time period.
+	MetricDelta UserDefinedMetricType = "delta"
+)
+
+// UserDefinedMetricDescriptor contains metadata that describes a user defined metric.
+type UserDefinedMetricDescriptor struct {
+	// The name of the metric.
+	Name string `json:"name"`
+
+	// Type of the metric.
+	Type UserDefinedMetricType `json:"type"`
+
+	// Display Units for the stats.
+	Units string `json:"units"`
+
+	// Metadata labels associated with this metric.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// UserDefinedMetric represents a metric defined and generated by users.
+type UserDefinedMetric struct {
+	UserDefinedMetricDescriptor `json:",inline"`
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+	// Value of the metric. Float64s have 53 bit precision.
+	// We do not foresee any metrics exceeding that value.
+	Value float64 `json:"value"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -867,6 +867,7 @@ k8s.io/kubectl/pkg/validation
 # k8s.io/kubelet v0.26.0
 ## explicit; go 1.19
 k8s.io/kubelet/config/v1beta1
+k8s.io/kubelet/pkg/apis/stats/v1alpha1
 # k8s.io/utils v0.0.0-20230202215443-34013725500c
 ## explicit; go 1.18
 k8s.io/utils/buffer

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,10 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strconv"
+	"strings"
 
+	"golang.org/x/mod/semver"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -23,4 +26,14 @@ func Print() {
 // Get() returns the operator version
 func Get() string {
 	return Version
+}
+
+// Major returns only the Major portion of the operator version semver
+func Major() (int, error) {
+	semverParsableVersion := Get()
+	if version := Get(); !strings.HasPrefix(version, "v") {
+		semverParsableVersion = "v" + version
+	}
+	majorVersion := strings.TrimPrefix(semver.Major(semverParsableVersion), "v")
+	return strconv.Atoi(majorVersion)
 }


### PR DESCRIPTION
Manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1794