### PR TITLE
[hack] Add Azure File CSI Driver Manifests

### DIFF
--- a/hack/manifests/csi/azure/01-example-driver-daemonset.yaml
+++ b/hack/manifests/csi/azure/01-example-driver-daemonset.yaml
@@ -1,0 +1,110 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: azure-file-csi-driver-node-windows
+  namespace: openshift-cluster-csi-drivers
+spec:
+  selector:
+    matchLabels:
+      app: azure-file-csi-driver-node-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: azure-file-csi-driver-node-windows
+    spec:
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: windows
+      serviceAccountName: azure-file-csi-driver-controller-sa
+      os:
+        name: windows
+      containers:
+        - name: node-driver-registrar
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.8.0
+          args:
+            - "--v=2"
+            - "--csi-address=$(CSI_ENDPOINT)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: CSI_ENDPOINT
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: DRIVER_REG_SOCK_PATH
+              value: 'C:\\var\\lib\\kubelet\\plugins\\file.csi.azure.com\\csi.sock'
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: "spec.nodeName"
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\file.csi.azure.com\\csi.sock
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 3
+        - name: azurefile
+          image: mcr.microsoft.com/k8s/csi/azurefile-csi:latest
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          env:
+            - name: CSI_ENDPOINT
+              value: 'unix://C:\\csi\\csi.sock'
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: "spec.nodeName"
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+            - name: plugin-dir
+              mountPath: /csi
+            - name: azure-config
+              mountPath: /k
+            - name: csi-proxy-filesystem-v1
+              mountPath: \\.\pipe\csi-proxy-filesystem-v1
+            - name: csi-proxy-smb-pipe-v1
+              mountPath: \\.\pipe\csi-proxy-smb-v1
+      volumes:
+        - name: csi-proxy-filesystem-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-filesystem-v1
+            type: ''
+        - name: csi-proxy-smb-pipe-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-smb-v1
+            type: ''
+        - name: registration-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins_registry\'
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet\plugins\file.csi.azure.com\'
+            type: DirectoryOrCreate
+        - name: kubelet-dir
+          hostPath:
+            path: 'C:\var\lib\kubelet'
+            type: Directory
+        - name: azure-config
+          hostPath:
+            path: 'C:\k\'
+            type: DirectoryOrCreate
+      tolerations:
+        - key: "os"
+          value: "Windows"
+          effect: "NoSchedule"

--- a/hack/manifests/csi/azure/02-example-namespace.yaml
+++ b/hack/manifests/csi/azure/02-example-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-storage-example
+  labels:
+    # Windows storage resources must be deployed in a privileged namespace with a disabled pod security admission label
+    # synchronization
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: privileged

--- a/hack/manifests/csi/azure/03-example-sc.yaml
+++ b/hack/manifests/csi/azure/03-example-sc.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: example-windows-sc
+  namespace: windows-storage-example
+provisioner: file.csi.azure.com

--- a/hack/manifests/csi/azure/04-example-pvc.yaml
+++ b/hack/manifests/csi/azure/04-example-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-windows-pvc
+  namespace: windows-storage-example
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: example-windows-sc
+  volumeMode: Filesystem

--- a/hack/manifests/csi/azure/05-example-deployment.yaml
+++ b/hack/manifests/csi/azure/05-example-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example-windows-pod
+  name: example-windows-pod
+  # must be in the same namespace as the PVC
+  namespace: windows-storage-example
+spec:
+  selector:
+    matchLabels:
+      app: example-windows-pod
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: example-windows-pod
+      name: example-windows-pod
+    spec:
+      os:
+        name: windows
+      tolerations:
+        - key: "os"
+          value: "Windows"
+          Effect: "NoSchedule"
+      containers:
+        - name: example-windows-container
+          image: mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
+          imagePullPolicy: IfNotPresent
+          command:
+            - pwsh.exe
+            - -command
+            - "$filepath='C:\\test\\csi\\timestamp.txt'; New-Item -Path $filepath -Force ;while (1) { Add-Content -Encoding Ascii $filepath $(Get-Date -Format u); sleep 10 }"
+          volumeMounts:
+            - name: test-volume
+              mountPath: "/test/"
+              readOnly: false
+      volumes:
+        - name: test-volume
+          persistentVolumeClaim:
+            claimName: example-windows-pvc
+      nodeSelector:
+        kubernetes.io/os: windows


### PR DESCRIPTION
This patch adds the required manifests, in its ideal order, to ensure that Windows workloads can be created with Azure File CSI storage.