### PR TITLE
AWS userdata with persistent routes

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -524,15 +524,6 @@ func (nc *nodeConfig) Deconfigure() error {
 	if err := nc.Windows.Deconfigure(nc.wmcoNamespace, wicdKC); err != nil {
 		return fmt.Errorf("error deconfiguring instance: %w", err)
 	}
-
-	// Windows Server 2022 VMs on AWS have a non-persistent route to the metadata endpoint. This is lost when the HNS
-	// networks are deleted. Explicitly restore them to allow the same VM to be configured as a node again.
-	if nc.platformType == configv1.AWSPlatformType {
-		if err := nc.Windows.RestoreAWSRoutes(); err != nil {
-			return err
-		}
-	}
-
 	// Wait for reboot annotation removal. This prevents deleting the node until the node no longer needs reboot.
 	if err := metadata.WaitForRebootAnnotationRemoval(context.TODO(), nc.client, nc.node.Name); err != nil {
 		return err

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -238,8 +238,6 @@ type Windows interface {
 	// RunWICDCleanup ensures the WICD service is stopped and runs the cleanup command that ensures all WICD-managed
 	// services are also stopped
 	RunWICDCleanup(string, string) error
-	// RestoreAWSRoutes restores the default routes on AWS VMs. This function should not be called on non-AWS VMs
-	RestoreAWSRoutes() error
 }
 
 // windows implements the Windows interface
@@ -506,35 +504,6 @@ func (vm *windows) ConfigureWICD(watchNamespace, wicdKubeconfigContents string) 
 		return fmt.Errorf("error ensuring %s Windows service has started running: %w", WicdServiceName, err)
 	}
 	vm.log.Info("configured", "service", WicdServiceName, "args", wicdServiceArgs)
-	return nil
-}
-
-func (vm *windows) RestoreAWSRoutes() error {
-	ec2LaunchV2ServiceName := "\"Amazon EC2Launch\""
-	serviceExists, err := vm.serviceExists(ec2LaunchV2ServiceName)
-	if err != nil {
-		return fmt.Errorf("error checking if %s service exists: %w", ec2LaunchV2ServiceName, err)
-	}
-	// We don't want ensureServiceIsRunning to create the service if it does not exist, so we return without an error.
-	// Returning an error does not make sense as we could have an AMI configured without the EC2Launch service present
-	// and the route created using some other customer specific method which is unknown to us.
-	if !serviceExists {
-		vm.log.Info("missing", "service", ec2LaunchV2ServiceName)
-		return nil
-	}
-	ec2Launch, err := newService("C:\\Program Files\\Amazon\\EC2Launch\\service\\EC2LaunchService.exe",
-		ec2LaunchV2ServiceName, "", nil, nil, 0)
-	if err != nil {
-		return err
-	}
-	if err = vm.ensureServiceIsRunning(ec2Launch); err != nil {
-		return err
-	}
-	// The EC2Launch service stops running once it has completed its tasks like creating routes. So we wait until it
-	// has stopped running before proceeding.
-	if err = vm.waitStopped(ec2LaunchV2ServiceName); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	config "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,10 +87,6 @@ func (tc *testContext) testBYOHRemoval(t *testing.T) {
 			envVarsRemoved, err := tc.checkEnvVarsRemoved(addr)
 			require.NoError(t, err, "error determining if ENV vars are removed")
 			assert.True(t, envVarsRemoved, "ENV vars not removed")
-
-			t.Run("AWS metadata endpoint", func(t *testing.T) {
-				tc.checkAWSMetadataEndpointRouteIsRestored(t, addr)
-			})
 		})
 	}
 }
@@ -147,17 +142,6 @@ func (tc *testContext) checkEnvVarsRemoved(address string) (bool, error) {
 		}
 	}
 	return true, nil
-}
-
-// checkAWSMetadataEndpointRouteIsRestored returns true if the metadata endpoint route is present on the Windows
-// instance
-func (tc *testContext) checkAWSMetadataEndpointRouteIsRestored(t *testing.T, address string) {
-	if tc.CloudProvider.GetType() != config.AWSPlatformType {
-		t.Skipf("Skipping for %s", tc.CloudProvider.GetType())
-	}
-	out, err := tc.runPowerShellSSHJob("check-routes", "Get-NetRoute", address)
-	require.NoError(t, err, "error checking routes")
-	assert.True(t, strings.Contains(out, "169.254.169.254"), "metadata endpoint route is not restored")
 }
 
 // waitForWindowsNodeRemoval returns when there are zero Windows nodes of the given type, machine or byoh, in the cluster


### PR DESCRIPTION
Add a special command to the AWS userdata to add persistent routes for the metadata endpoint. This will allow the same VM to be configured, deconfigured, and reconfigured without losing access to the metadata endpoint.