### PR TITLE
OCPBUGS-19943: Fix hybrid-overlay parameters required for certificate management

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -102,8 +102,8 @@ func azureCloudNodeManagerConfiguration() servicescm.Service {
 
 // hybridOverlayConfiguration returns the Service definition for hybrid-overlay
 func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service {
-	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --k8s-kubeconfig %s --windows-service "+
-		"--logfile "+"%s\\hybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath,
+	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --bootstrap-kubeconfig=%s --cert-dir=%s --cert-duration=24h "+
+		"--windows-service --logfile "+"%s\\hybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath, windows.CniConfDir,
 		windows.HybridOverlayLogDir)
 	if len(vxlanPort) > 0 {
 		hybridOverlayServiceCmd = fmt.Sprintf("%s --hybrid-overlay-vxlan-port %s", hybridOverlayServiceCmd, vxlanPort)


### PR DESCRIPTION
First commit bumps ovn-kubernetes submodule.
Second commit adjusts hybrid-overlay parameters required to use a per-node certificate. 