### PR TITLE
[release-4.14] submodule update 10/04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WMCO_VERSION ?= 9.0.0
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
-KUBELET_GIT_VERSION=v1.27.6+6936c15
+KUBELET_GIT_VERSION=v1.27.6+9ef6de6
 KUBE-PROXY_GIT_VERSION=v1.27.1+70821f7
 CONTAINERD_GIT_VERSION=v1.7.6
 # CHANNELS define the bundle channels used in the bundle.


### PR DESCRIPTION
- [[submodule][kubelet] Update to 9ef6de6018e](https://github.com/openshift/windows-machine-config-operator/commit/c699046ff0eee7d4c6c019836bac020ab6a6847c) 
- [[build] Update kubelet version to v1.27.6+9ef6de6](https://github.com/openshift/windows-machine-config-operator/commit/025651a38420f8fd1f24c9a57db5bec57dccc803)