### PR TITLE
Improve predicate filtering for WindowsMachine controllers

### DIFF
--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -110,18 +110,18 @@ func (r *WindowsMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// We need the create event to account for Machines that are in provisioned state but were created
 		// before WMCO started running
 		CreateFunc: func(e event.CreateEvent) bool {
-			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())
+			return isWindowsMachine(e.Object.GetLabels()) && r.isValidMachine(e.Object)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return r.isValidMachine(e.ObjectNew) && isWindowsMachine(e.ObjectNew.GetLabels())
+			return isWindowsMachine(e.ObjectNew.GetLabels()) && r.isValidMachine(e.ObjectNew)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return r.isValidMachine(e.Object) && isWindowsMachine(e.Object.GetLabels())
+			return isWindowsMachine(e.Object.GetLabels()) && r.isValidMachine(e.Object)
 		},
 		// process delete event
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			// for Windows machines only
-			return isWindowsMachine(e.Object.GetLabels())
+			// for Windows machines only and avoid processing delete event for machines with ignore label
+			return isWindowsMachine(e.Object.GetLabels()) && e.Object.GetLabels()[IgnoreLabel] != "true"
 		},
 	}
 


### PR DESCRIPTION
This change updates the predicate filters in the Windows Machine controller to first check for machines
with the Windows label so that the machine validations target only Windows machines. In addition, updates the delete event filter in the Windows Machine predicate to honor the ignore label.

Before, WMCO reacted to Linux machines joining the cluster, for example:
```
DEBUG	controller.windowsmachine	Machine has no phase associated with it	{"name": "jvaldes-c57lx-worker-0-7tlm5"}
DEBUG	controller.windowsmachine	Machine has no phase associated with it	{"name": "jvaldes-c57lx-worker-0-7tlm5"}
DEBUG	controller.windowsmachine	invalid Machine	{"name": "jvaldes-c57lx-worker-0-7tlm5", "error": "no IP addresses defined"}
DEBUG	controller.windowsmachine	invalid Machine	{"name": "jvaldes-c57lx-worker-0-7tlm5", "error": "no IP addresses defined"}
DEBUG	controller.windowsmachine	invalid Machine	{"name": "jvaldes-c57lx-worker-0-7tlm5", "error": "no internal IP address associated"}

```
