### PR TITLE
[release-4.13] OCPBUGS-20259: Fix "WMCO does not wait for instance to reboot properly"

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -224,8 +224,8 @@ type Windows interface {
 	// should be used in scenarios where you want to execute a command that runs in the background. In these cases we
 	// have observed that Run() returns before the command completes and as a result killing the process.
 	Run(string, bool) (string, error)
-	// Reinitialize re-initializes the Windows VM's SSH client
-	Reinitialize() error
+	// RebootAndReinitialize reboots the instance and re-initializes the Windows SSH client
+	RebootAndReinitialize() error
 	// Bootstrap prepares the Windows instance and runs the WICD bootstrap command
 	Bootstrap(string, string, string) error
 	// ConfigureWICD ensures that the Windows Instance Config Daemon is running on the node
@@ -388,10 +388,17 @@ func (vm *windows) Run(cmd string, psCmd bool) (string, error) {
 	return out, nil
 }
 
-func (vm *windows) Reinitialize() error {
-	if err := vm.interact.init(); err != nil {
-		return fmt.Errorf("failed to reinitialize ssh client: %v", err)
+// RebootAndReinitialize restarts the Windows instance and re-initializes the SSH connection for further configuration
+func (vm *windows) RebootAndReinitialize() error {
+	vm.log.Info("rebooting instance")
+	if _, err := vm.Run("Restart-Computer -Force", true); err != nil {
+		return fmt.Errorf("error rebooting the Windows VM: %w", err)
 	}
+	// Reinitialize the SSH connection after the VM reboot
+	if err := vm.reinitialize(); err != nil {
+		return fmt.Errorf("error reinitializing SSH connection after VM reboot: %w", err)
+	}
+	vm.log.V(1).Info("successful reboot")
 	return nil
 }
 
@@ -574,7 +581,7 @@ func (vm *windows) ensureHostNameAndContainersFeature() error {
 	// Changing the host name or enabling the Containers feature requires a VM restart for
 	// the change to take effect.
 	if rebootNeeded {
-		if err := vm.rebootAndReinitialize(); err != nil {
+		if err := vm.RebootAndReinitialize(); err != nil {
 			return fmt.Errorf("error restarting the Windows instance and reinitializing SSH connection: %w", err)
 		}
 	}
@@ -900,12 +907,12 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 			// reinitialize and retry on failure to avoid connection reset SSH errors
 			if err := vm.removeHNSNetwork(network); err != nil {
 				vm.log.V(1).Error(err, "error removing %s HNS network", "network", network)
-				if err := vm.Reinitialize(); err != nil {
+				if err := vm.reinitialize(); err != nil {
 					return false, fmt.Errorf("error reinitializing VM after removing %s HNS network: %w", network, err)
 				}
 				return false, nil
 			}
-			if err := vm.Reinitialize(); err != nil {
+			if err := vm.reinitialize(); err != nil {
 				return false, fmt.Errorf("error reinitializing VM after removing %s HNS network: %w", network, err)
 			}
 			out, err := vm.Run(getHNSNetworkCmd(network), true)
@@ -953,14 +960,9 @@ func (vm *windows) isContainersFeatureEnabled() (bool, error) {
 	return strings.Contains(out, "Enabled"), nil
 }
 
-// rebootAndReinitialize restarts the Windows instance and re-initializes the SSH connection for further configuration
-func (vm *windows) rebootAndReinitialize() error {
-	if _, err := vm.Run("Restart-Computer -Force", true); err != nil {
-		return fmt.Errorf("error rebooting the Windows VM: %w", err)
-	}
-	// Reinitialize the SSH connection after the VM reboot
-	if err := vm.Reinitialize(); err != nil {
-		return fmt.Errorf("error reinitializing SSH connection after VM reboot: %w", err)
+func (vm *windows) reinitialize() error {
+	if err := vm.interact.init(); err != nil {
+		return fmt.Errorf("failed to reinitialize ssh client: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- [[windows] Refactor instance reboot method](https://github.com/openshift/windows-machine-config-operator/commit/2ae380001073f93e9926613e6f96666c1dc32955) 
- [Add SSH off-line check to reboot logic](https://github.com/openshift/windows-machine-config-operator/commit/e70aa4b96902c902b21d25335e40c12ea9af6dd2)

manual backport of https://github.com/openshift/windows-machine-config-operator/pull/1862