### PR TITLE
OCPBUGS-19039: [nodeconfig] Enable draining nodes with emptydir data

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -498,7 +498,9 @@ func (nc *nodeConfig) newDrainHelper() *drain.Helper {
 		Force: true,
 		// Prevents erroring out in case a DaemonSet's pod is on the node
 		IgnoreAllDaemonSets: true,
-		Out:                 &OutWriter{nc.log},
+		// Prevents erroring out in case there is a workload with emptydir data
+		DeleteEmptyDirData: true,
+		Out:                &OutWriter{nc.log},
 	}
 }
 

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -220,6 +220,11 @@ func (tc *testContext) testWindowsNodeDeletion(t *testing.T) {
 	err = tc.waitUntilDaemonsetScaled(ds.GetName(), int(gc.numberOfMachineNodes+gc.numberOfBYOHNodes))
 	require.NoError(t, err, "error waiting for DaemonSet pods to become ready")
 
+	dp, err := tc.deployEmptyDirVolumeWorkload()
+	require.NoError(t, err, "error creating Deployment")
+	defer tc.client.K8s.AppsV1().Deployments(dp.GetNamespace()).Delete(context.TODO(), dp.GetName(),
+		meta.DeleteOptions{})
+
 	// set expected node count to zero, since all Windows Nodes should be deleted in the test
 	expectedNodeCount := int32(0)
 	// Get all the Machines created by the e2e tests
@@ -275,6 +280,25 @@ func (tc *testContext) testWindowsNodeDeletion(t *testing.T) {
 	// Cleanup wmco-test namespace created by us.
 	err = tc.deleteNamespace(tc.workloadNamespace)
 	require.NoError(t, err, "could not delete test namespace")
+}
+
+// Deploy an emptydir volume and wait until its pods have been made ready on each Windows node. emptydir
+// volumes should be able to be removed from a Node.
+func (tc *testContext) deployEmptyDirVolumeWorkload() (*apps.Deployment, error) {
+	winPodCommand := []string{powerShellExe, "-command", "while ($true) {Start-Sleep -Seconds 1}"}
+	volumeSource := core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{Medium: core.StorageMediumDefault}}
+	v, vm := getVolumeSpec("test-volume", volumeSource, "test-volume", "/test/")
+	volumes, volumeMounts := []core.Volume{v}, []core.VolumeMount{vm}
+
+	emptyDir, err := tc.createWindowsServerDeployment("windows-pod", winPodCommand, nil, volumes, volumeMounts)
+	if err != nil {
+		return nil, fmt.Errorf("could not create Windows deployment: %w", err)
+	}
+	err = tc.waitUntilDeploymentScaled(emptyDir.GetName())
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for emptydir volumes to become ready: %w", err)
+	}
+	return emptyDir, nil
 }
 
 // DeployNOOPDaemonSet deploys a DaemonSet which will deploy pods in a sleep loop across all Windows nodes

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -413,6 +413,16 @@ func (tc *testContext) deleteNamespace(name string) error {
 // deployWindowsWebServer creates a deployment with a single Windows Server pod, listening on port 80
 func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity,
 	pvcToMount *v1.PersistentVolumeClaimVolumeSource) (*appsv1.Deployment, error) {
+	var volumes []v1.Volume
+	var volumeMounts []v1.VolumeMount
+	if pvcToMount != nil {
+		volumeName := pvcToMount.ClaimName
+		volumeSource := v1.VolumeSource{PersistentVolumeClaim: pvcToMount}
+		mountName := pvcToMount.ClaimName
+		mountPath := "C:\\mnt\\storage"
+		v, vm := getVolumeSpec(volumeName, volumeSource, mountName, mountPath)
+		volumes, volumeMounts = append([]v1.Volume{}, v), append([]v1.VolumeMount{}, vm)
+	}
 	// This will run a Server on the container, which can be reached with a GET request
 	winServerCommand := []string{powerShellExe, "-command",
 		"$listener = New-Object System.Net.HttpListener; $listener.Prefixes.Add('http://*:80/'); $listener.Start(); " +
@@ -421,7 +431,7 @@ func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity
 			"$content='<html><body><H1>Windows Container Web Server</H1></body></html>'; " +
 			"$buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; " +
 			"$response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };"}
-	winServerDeployment, err := tc.createWindowsServerDeployment(name, winServerCommand, affinity, pvcToMount)
+	winServerDeployment, err := tc.createWindowsServerDeployment(name, winServerCommand, affinity, volumes, volumeMounts)
 	if err != nil {
 		return nil, fmt.Errorf("could not create Windows deployment: %w", err)
 	}
@@ -432,6 +442,20 @@ func (tc *testContext) deployWindowsWebServer(name string, affinity *v1.Affinity
 		return nil, fmt.Errorf("deployment was unable to scale: %w", err)
 	}
 	return winServerDeployment, nil
+}
+
+// getVolumeSpec returns a Volume and VolumeMount spec given the volume name, volume source, volume mount name and
+// mount path.
+func getVolumeSpec(volumeName string, volumeSource v1.VolumeSource, mountName string, mountPath string) (v1.Volume, v1.VolumeMount) {
+	volumes := v1.Volume{
+		Name:         volumeName,
+		VolumeSource: volumeSource,
+	}
+	volumeMounts := v1.VolumeMount{
+		Name:      mountName,
+		MountPath: mountPath,
+	}
+	return volumes, volumeMounts
 }
 
 // deleteDeployment deletes the deployment with the given name
@@ -473,26 +497,12 @@ func (tc *testContext) getWindowsServerContainerImage() string {
 // number of replicas will be set to 3 to allow for network testing across nodes. If pvcToMount is set, the pod will
 // mount the given pvc as a volume
 func (tc *testContext) createWindowsServerDeployment(name string, command []string, affinity *v1.Affinity,
-	pvcToMount *v1.PersistentVolumeClaimVolumeSource) (*appsv1.Deployment, error) {
+	volumes []v1.Volume, volumeMounts []v1.VolumeMount) (*appsv1.Deployment, error) {
 	deploymentsClient := tc.client.K8s.AppsV1().Deployments(tc.workloadNamespace)
 	replicaCount := int32(1)
 	// affinity being nil is a hint that the caller does not care which nodes the pods are deployed to
 	if affinity == nil {
 		replicaCount = int32(3)
-	}
-	var volumes []v1.Volume
-	var volumeMounts []v1.VolumeMount
-	if pvcToMount != nil {
-		volumes = append(volumes, v1.Volume{
-			Name: pvcToMount.ClaimName,
-			VolumeSource: v1.VolumeSource{
-				PersistentVolumeClaim: pvcToMount,
-			},
-		})
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      pvcToMount.ClaimName,
-			MountPath: "C:\\mnt\\storage",
-		})
 	}
 	windowsServerImage := tc.getWindowsServerContainerImage()
 	containerUserName := "ContainerAdministrator"


### PR DESCRIPTION
Draining a workload with emptydir data was causing an error due to a lack of the DeleteEmptyDirData field in the drain Helper struct. This change adds the field and sets it to true to resolve the error.

Fixes OCPBUGS-19039