### PR TITLE
[release-4.12] WINC-950: Test WMCO version upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,14 @@ run-ci-e2e-byoh-test:
 run-ci-e2e-upgrade-test:
 	hack/run-ci-e2e-test.sh -t upgrade
 
+.PHONY: upgrade-test-setup
+upgrade-test-setup:
+	hack/run-ci-e2e-test.sh -t upgrade-setup -s
+
+.PHONY: upgrade-test
+upgrade-test:
+	hack/run-ci-e2e-test.sh -t upgrade-test
+
 .PHONY: clean
 clean:
 	rm -rf ${OUTPUT_DIR}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -20,12 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
-	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
-	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
@@ -51,6 +48,8 @@ func creationTestSuite(t *testing.T) {
 		// No point in running the other tests if creation failed
 		return
 	}
+	t.Run("Nodes ready and schedulable", tc.testNodesBecomeReadyAndSchedulable)
+	t.Run("Node annotations", tc.testNodeAnnotations)
 	t.Run("Node Metadata", tc.testNodeMetadata)
 	t.Run("Services ConfigMap validation", tc.testServicesConfigMap)
 	t.Run("Services running", tc.testExpectedServicesRunning)
@@ -166,7 +165,12 @@ func (tc *testContext) testMachineConfiguration(t *testing.T) {
 
 	machines, err := tc.waitForWindowsMachines(int(gc.numberOfMachineNodes), "Provisioned", false)
 	require.NoError(t, err, "error waiting for Windows Machines to be provisioned")
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	if tc.CloudProvider.GetType() == config.AzurePlatformType {
+		// Replace the known private key with a randomly generated one.
+		err = tc.createPrivateKeySecret(false)
+		require.NoError(t, err, "error replacing private key secret")
+	}
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "Windows node creation failed")
 	tc.machineLogCollection(machines.Items)
 }
@@ -255,7 +259,7 @@ func (tc *testContext) testBYOHConfiguration(t *testing.T) {
 	}
 	// Wait for Windows worker node to become available
 	t.Run("VM is configured by ConfigMap controller", func(t *testing.T) {
-		err := tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+		err := tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 		assert.NoError(t, err, "Windows node creation failed")
 	})
 	// Make a best effort attempt to collect logs from each BYOH instance
@@ -486,39 +490,15 @@ func (tc *testContext) waitForWindowsMachines(machineCount int, phase string, ig
 	return machines, err
 }
 
-// waitForWindowsNode waits until there exists nodeCount Windows nodes with the correct set of annotations.
-// if expectError = true, the function will wait for duration of 10 minutes if we are deleting all nodes i.e. 0 nodesCount
-// else 5 minutes for the nodes as the error would be thrown immediately, else we will wait for the duration given by
-// nodeCreationTime variable which is 20 minutes increasing the overall wait time in test suite
-func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVersion bool, isBYOH bool) error {
-	annotations := []string{nodeconfig.HybridOverlaySubnet, nodeconfig.HybridOverlayMac, metadata.VersionAnnotation,
-		nodeconfig.PubKeyHashAnnotation, controllers.UsernameAnnotation}
-
-	var creationTime time.Duration
+// waitForConfiguredWindowsNodes waits until there exists nodeCount Windows nodes that have reported they have been
+// configured by WICD. Specifically the signal for this is the version annotation is applied to the node by WICD, with
+// a value matching the desired version annotation.
+func (tc *testContext) waitForConfiguredWindowsNodes(nodeCount int32, checkVersion, isBYOH bool) error {
 	startTime := time.Now()
-	if expectError {
-		if nodeCount == 0 {
-			creationTime = time.Minute * 10
-		} else {
-			// The time we expect to wait, if the ignore label is
-			// not used while creating nodes.
-			creationTime = time.Minute * 5
-		}
-	} else {
-		creationTime = nodeCreationTime
-	}
-
-	privKey, pubKey, err := tc.getExpectedKeyPair()
-	if err != nil {
-		return fmt.Errorf("error getting the expected public/private key pair: %w", err)
-	}
-	pubKeyAnnotation := nodeconfig.CreatePubKeyHashAnnotation(pubKey)
 
 	// We are waiting 20 minutes for each windows VM to be shown up in the cluster. The value comes from
-	// nodeCreationTime variable.  If we are testing a scale down from n nodes to 0, then we should
-	// not take the number of nodes into account. If we are testing node creation without applying the ignore label, we
-	// should throw error within 5 mins.
-	err = wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*creationTime, func() (done bool, err error) {
+	// nodeCreationTime variable.
+	err := wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*nodeCreationTime, func() (done bool, err error) {
 		nodes, err := tc.listFullyConfiguredWindowsNodes(isBYOH)
 		if err != nil {
 			log.Printf("failed to get list of configured Windows nodes: %s", err)
@@ -526,40 +506,6 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVe
 		}
 
 		for _, node := range nodes {
-			// check node status
-			readyCondition := false
-			for _, condition := range node.Status.Conditions {
-				if condition.Type == v1.NodeReady {
-					readyCondition = true
-				}
-				if readyCondition && condition.Status != v1.ConditionTrue {
-					log.Printf("node %v is expected to be in Ready state", node.Name)
-					return false, nil
-				}
-			}
-			if !readyCondition {
-				log.Printf("expected node Status to have condition type Ready for node %v", node.Name)
-				return false, nil
-			}
-			// explicitly check for the external cloud provider taint for more helpful test logging
-			for _, taint := range node.Spec.Taints {
-				if taint.Key == cloudproviderapi.TaintExternalCloudProvider && taint.Effect == v1.TaintEffectNoSchedule {
-					log.Printf("expected node %s to not have the external cloud provider taint", node.GetName())
-					return false, nil
-				}
-			}
-			if node.Spec.Unschedulable {
-				log.Printf("expected node %s to be schedulable", node.Name)
-				return false, nil
-			}
-
-			for _, annotation := range annotations {
-				_, found := node.Annotations[annotation]
-				if !found {
-					log.Printf("node %s does not have annotation: %s", node.GetName(), annotation)
-					return false, nil
-				}
-			}
 			if checkVersion {
 				operatorVersion, err := getWMCOVersion()
 				if err != nil {
@@ -569,24 +515,6 @@ func (tc *testContext) waitForWindowsNodes(nodeCount int32, expectError, checkVe
 				if node.Annotations[metadata.VersionAnnotation] != operatorVersion {
 					log.Printf("node %s has mismatched version annotation %s. expected: %s", node.GetName(),
 						node.Annotations[metadata.VersionAnnotation], operatorVersion)
-					return false, nil
-				}
-			}
-			if node.Annotations[nodeconfig.PubKeyHashAnnotation] != pubKeyAnnotation {
-				log.Printf("node %s has mismatched pubkey annotation value %s expected: %s", node.GetName(),
-					node.Annotations[nodeconfig.PubKeyHashAnnotation], pubKeyAnnotation)
-				return false, nil
-			}
-			// Ensure username annotation is decipherable and correct. Skip if deconfiguring node
-			if !expectError {
-				username, err := crypto.DecryptFromJSONString(node.Annotations[controllers.UsernameAnnotation], privKey)
-				if err != nil {
-					log.Printf("error decrypting username annotation for node %s: %s", node.Name, err)
-					return false, nil
-				}
-				if username != tc.vmUsername() {
-					log.Printf("username %s does not match expected value %s for node %s:", username, tc.vmUsername(),
-						node.Name)
 					return false, nil
 				}
 			}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -29,9 +29,9 @@ import (
 func testNetwork(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "timed out waiting for Windows Machine nodes")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 	assert.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 
 	t.Run("East West Networking", tc.testEastWestNetworking)

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -53,10 +53,10 @@ func (tc *testContext) reconfigurationTest(t *testing.T) {
 	require.NoError(t, err)
 
 	// The Windows nodes should eventually be returned to the state we expect them to be in
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, true, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
 	assert.NoError(t, err, "error waiting for Windows Machine nodes to be reconfigured")
 
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	assert.NoError(t, err, "error waiting for Windows BYOH nodes to be reconfigured")
 
 	err = tc.validateUpgradeableCondition(metav1.ConditionTrue)
@@ -96,7 +96,7 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 
 	// wait for the node to be removed
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes-1, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes-1, true, true)
 	require.NoError(t, err, "error waiting for the removal of a node")
 
 	// update the ConfigMap again, re-adding the instance
@@ -115,7 +115,7 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	require.NoError(t, err, "error patching windows-instances ConfigMap data with add operation")
 
 	// wait for the node to be successfully re-added
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	assert.NoError(t, err, "error waiting for the Windows node to be re-added")
 
 	err = tc.validateUpgradeableCondition(metav1.ConditionTrue)

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -26,9 +26,9 @@ func testStorage(t *testing.T) {
 	if !tc.StorageSupport() {
 		t.Skip("storage is not supported on this platform")
 	}
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, false, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	require.NoError(t, err, "timed out waiting for Windows Machine nodes")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, false, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, false, true)
 	require.NoError(t, err, "timed out waiting for BYOH Windows nodes")
 	require.Greater(t, len(gc.allNodes()), 0, "test requires at least one Windows node to run")
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -46,11 +46,11 @@ func upgradeTestSuite(t *testing.T) {
 	require.NoError(t, err, "error configuring upgrade")
 
 	// get current Windows node state
-	// TODO: waitForWindowsNodes currently loads nodes into global context, so we need this (even though BYOH
+	// TODO: waitForConfiguredWindowsNodes currently loads nodes into global context, so we need this (even though BYOH
 	// 		 nodes are not being upgraded/tested here). Remove as part of https://issues.redhat.com/browse/WINC-620
-	err = tc.waitForWindowsNodes(gc.numberOfMachineNodes, false, true, false)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
 	require.NoError(t, err, "wrong number of Machine controller nodes found")
-	err = tc.waitForWindowsNodes(gc.numberOfBYOHNodes, false, true, true)
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	require.NoError(t, err, "wrong number of ConfigMap controller nodes found")
 
 	t.Run("Operator version upgrade", tc.testUpgradeVersion)


### PR DESCRIPTION
Manual backport of #1649 needed because one commit [cd47d34b0](https://github.com/openshift/windows-machine-config-operator/commit/cd47d34b0ae6a114ee3a752c1bfdca380fc3d156) went in out of order.