### PR TITLE
WINC-673: Fix Windows Webserver tester jobs in upgrade test

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -196,6 +196,9 @@ func (tc *testContext) deployWindowsWorkloadAndTester() (func(), error) {
 	}
 	// return a cleanup func
 	return func() {
+		// collect webserver pods logs
+		tc.collectDeploymentLogs(deployment)
+		tc.writePodLogs("job-name=" + testerJob.Name)
 		// ignore errors while deleting the objects
 		_ = tc.deleteDeployment(deployment.Name)
 		_ = tc.deleteService(intermediarySVC.Name)


### PR DESCRIPTION
This change fixes the upgrade test suite so that
it checks the correct Linux job that curls the
service exposed by the Windows Webserver.

Before, the label selector was picking no pods and
the number of failed pod was always zero making this
test worthless. Now, the e2e upgrade test fails if the Windows
workloads were unavailable in an upgrade scenario.

In addition, adds the collection of the pod logs of the Windows
Webserver deployment and service curl job during
the cleanup in the upgrade test. Before, there was
no evidence in the artifact dir about such pods.

