### PR TITLE
Revert "[test] Enable upgrading from in-tree to CSI"

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -174,8 +174,6 @@ if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
 fi
 
 if [[ "$TEST" = "upgrade-setup" ]]; then
-  # TODO: Remove this after adding it to the appropriate release jobs
-  export UPGRADE_FROM_IN_TREE=true
   go test ./test/e2e/... -run=TestWMCO/create/Creation -v -timeout=90m -args $GO_TEST_ARGS
   go test ./test/e2e/... -run=TestWMCO/create/Nodes_ready_and_schedulable -v -timeout=90m -args $GO_TEST_ARGS
   # Run the storage test, skipping deletion of the created workload in order to test that it persists across the upgrade
@@ -184,8 +182,6 @@ if [[ "$TEST" = "upgrade-setup" ]]; then
 fi
 
 if [[ "$TEST" = "upgrade-test" ]]; then
-  # TODO: Remove this after adding it to the appropriate release jobs
-  export UPGRADE_FROM_IN_TREE=true
   go test ./test/e2e/... -run=TestUpgrade -v -timeout=20m -args $GO_TEST_ARGS
 fi
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -27,10 +27,7 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"kubelet/kubelet.log",
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
-	}
-	// TODO: Always collect csi-proxy log when no longer upgrading from in-tree to CSI for any platform
-	if !inTreeUpgrade {
-		mandatoryLogs = append(mandatoryLogs, "csi-proxy/csi-proxy.log")
+		"csi-proxy/csi-proxy.log",
 	}
 	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
 	for _, node := range gc.allNodes() {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,9 +27,6 @@ var (
 	numberOfBYOHNodes int
 	// privateKeyPath is the path of the private key file used to configure the Windows node
 	privateKeyPath string
-	// inTreeUpgrade indicates if tests should be ran to test upgrading from an in-tree storage solution to CSI.
-	// This will cause in tree storage volumes and related resources to be deployed where appropriate, instead of CSI.
-	inTreeUpgrade bool
 	// skipWorkloadDeletion indicates that worklaods should not be deleted when tests complete
 	skipWorkloadDeletion bool
 	// wmcoNamespace is the namespace WMCO is deployed to
@@ -169,9 +166,6 @@ func TestMain(m *testing.M) {
 			return nil
 		})
 	flag.Parse()
-	if val := os.Getenv("UPGRADE_FROM_IN_TREE"); val == "true" {
-		inTreeUpgrade = true
-	}
 
 	os.Exit(m.Run())
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
-	"github.com/openshift/windows-machine-config-operator/test/e2e/providers/vsphere"
 )
 
 const (
@@ -217,17 +216,6 @@ func TestUpgrade(t *testing.T) {
 	t.Run("Node annotations", tc.testNodeAnnotations)
 	t.Run("Node Metadata", tc.testNodeMetadata)
 
-	if inTreeUpgrade {
-		// Deploy the CSI drivers and wait for a CSI node to be created
-		// This is a requirement for storage workloads to go back to ready
-		vsphereProvider, ok := tc.CloudProvider.(*vsphere.Provider)
-		require.True(t, ok, "in tree upgrade must be ran on vSphere")
-		require.NoError(t, vsphereProvider.EnsureWindowsCSIDrivers(tc.client.K8s))
-		log.Printf("waiting for csinodes to reflect driver deployment")
-		err = tc.waitForCSINodesWithDrivers(gc.allNodes())
-		require.NoError(t, err)
-	}
-
 	// test that any workloads deployed on the node have not been broken by the upgrade
 	t.Run("Workloads ready", tc.testWorkloadsAvailable)
 	t.Run("Node Logs", tc.testNodeLogs)
@@ -252,33 +240,4 @@ func (tc *testContext) testWorkloadsAvailable(t *testing.T) {
 			return true, nil
 		})
 	assert.NoError(t, err)
-}
-
-// waitForCSINodes waits for a CSINode to exist for each node with a driver loaded, indicating CSI functionality has
-// been enabled for the given node.
-func (tc *testContext) waitForCSINodesWithDrivers(nodes []v1.Node) error {
-	return wait.PollImmediate(retry.Interval, 10*time.Minute, func() (bool, error) {
-		csinodes, err := tc.client.K8s.StorageV1().CSINodes().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			log.Printf("error listing CSINodes: %s", err)
-			return false, nil
-		}
-		for _, node := range nodes {
-			var ready bool
-			for _, csinode := range csinodes.Items {
-				if csinode.GetName() == node.GetName() {
-					if len(csinode.Spec.Drivers) != 1 {
-						log.Printf("CSINode for %s is missing driver", node.GetName())
-						break
-					}
-					ready = true
-					break
-				}
-			}
-			if !ready {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
 }


### PR DESCRIPTION
This reverts commit 378aa320ce74f0e3385c3e1bca54a22d65d2f352.

This needs to be done as in-tree storage is not usable on 4.14.
All upgrades will be from CSI -> CSI. 