### PR TITLE
[hack] Change imagePullPolicy for olm.sh

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -224,6 +224,7 @@ run_WMCO() {
   fi
 
   transform_csv REPLACE_IMAGE $OPERATOR_IMAGE
+  transform_csv "imagePullPolicy: IfNotPresent" "imagePullPolicy: Always"
 
   # Validate the operator bundle manifests
   $OSDK bundle validate $MANIFEST_LOC
@@ -279,10 +280,10 @@ cleanup_WMCO() {
 
   # Cleanup the operator and revert changes made to the csv
   if ! OSDK_WMCO_management cleanup $OSDK; then
-      transform_csv $OPERATOR_IMAGE REPLACE_IMAGE
+      revert_csv
       error-exit "operator cleanup failed"
   fi
-  transform_csv $OPERATOR_IMAGE REPLACE_IMAGE
+  revert_csv
 
   # Remove the declared namespace
   oc delete ns $WMCO_DEPLOY_NAMESPACE
@@ -297,7 +298,13 @@ transform_csv() {
     echo incorrect parameter count for replace_csv_value $#
     return 1
   fi
-  sed -i "s|"$1"|"$2"|g" $MANIFEST_LOC/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+  sed -i "s|$1|$2|g" $MANIFEST_LOC/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+}
+
+# Revert the CSV back to it's original form
+revert_csv() {
+    transform_csv $OPERATOR_IMAGE REPLACE_IMAGE
+    transform_csv "imagePullPolicy: Always" "imagePullPolicy: IfNotPresent"
 }
 
 # creates the `windows-instances` ConfigMap


### PR DESCRIPTION
Change the `imagePullPolicy` for `olm.sh run` to `Always`. This is needed to ensure that the latest image is always pulled. Revert to `IfNotPresent` on `olm.sh cleanup`. 
Remove the extra quotes from the sed command which was mangling the strings.