### PR TITLE
[build] Silence go compliance shim output

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,10 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,6 +1,10 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -7,6 +7,10 @@ FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-open
 LABEL stage=build
 WORKDIR /build/
 
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,6 +1,10 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
 LABEL stage=build
 
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 WORKDIR /build/windows-machine-config-operator/
 
 # Copy files and directories needed to build the WMCO binary


### PR DESCRIPTION
This removes the go compliance shim output like:
```
2023-10-18T03:16:31.947886521Z Go compliance shim [28] [][]: Forcing GOTOOLCHAIN=local
2023-10-18T03:16:31.950822867Z Go compliance shim [28] [][]: assessment: CGO_ENABLED=1
2023-10-18T03:16:31.958796677Z Go compliance shim [28] [][]: assessment: dynamic linking
2023-10-18T03:16:31.961102618Z Go compliance shim [28] [][]: skipping forced compliance due to GOOS=windows
2023-10-18T03:16:31.986646448Z Go compliance shim [28] [][]: EXEMPT: 1
2023-10-18T03:16:31.988808927Z 
2023-10-18T03:16:31.988808927Z 
2023-10-18T03:16:31.988916101Z Go compliance shim [28] [][]: final command line arguments: "build" "-v" "-mod" "vendor" "-gcflags" "" "-ldflags" "-B 0x80ad4265bd6983364e1614c7463ea2a0efe93137 		" "-o" "/build/windows-machine-config-operator/ovn-kubernetes/go-controller/_output/go/bin/windows/hybrid-overlay-node.exe" "./hybrid-overlay/cmd/hybrid-overlay-node" 
2023-10-18T03:16:31.989129497Z 
2023-10-18T03:16:31.989189345Z Go compliance shim [28] [][]: invoking real go binary
```