### PR TITLE
WINC-751: Upgrade sdk-operator to 1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=windows-machine-config-operator crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=windows-machine-config-operator crd webhook paths="{./cmd/..., ./controllers/..., ./pkg/...}" output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Must be run when adding or changing a CRD.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="{./cmd/..., ./controllers/..., ./pkg/...}"
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/Makefile
+++ b/Makefile
@@ -134,25 +134,37 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+##@ Build Dependencies
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v4.5.5
+CONTROLLER_TOOLS_VERSION ?= v0.10.0
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
-KUSTOMIZE = $(shell pwd)/bin/kustomize
-kustomize: ## Download kustomize locally if necessary.
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
-# go-install-tool will 'go install' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-install-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,16 @@ OPM = $(shell which opm)
 endif
 endif
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
+# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(WMCO_VERSION) $(BUNDLE_METADATA_OPTS)
+
+# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
+# You can enable this value if you would like to use SHA Based Digests
+# To enable set flag to true
+USE_IMAGE_DIGESTS ?= false
+ifeq ($(USE_IMAGE_DIGESTS), true)
+    BUNDLE_GEN_FLAGS += --use-image-digests
+endif
 CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(WMCO_VERSION) ifneq ($(origin CATALOG_BASE_IMG), undefined) FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG) endif
 .PHONY: catalog-build
 catalog-build: opm
@@ -182,7 +192,7 @@ catalog-build: opm
 bundle: manifests kustomize
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle --overwrite=false -q --version $(WMCO_VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
 	sed -i 's/windows-machine-config-operator\.v.\.0\.0/windows-machine-config-operator.v$(WMCO_VERSION)/g' ./bundle/windows-machine-config-operator.package.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ build-daemon:
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run cmd/operator/main.go
 
+ifndef IGNORE-NOT-FOUND
+  IGNORE-NOT-FOUND = false
+endif
 ##@ Deployment
 
 .PHONY: install
@@ -116,7 +119,7 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | oc delete -f -
+	$(KUSTOMIZE) build config/crd | oc delete --ignore-not-found=$(IGNORE-NOT-FOUND) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
@@ -125,7 +128,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | oc delete -f -
+	$(KUSTOMIZE) build config/default | oc delete --ignore-not-found=$(IGNORE-NOT-FOUND) -f -
 
 .PHONY: controller-gen
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,8 +36,8 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=windows-machine-config-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=preview,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v2.0.0+git
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Copy files to locations specified by labels.

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
       Containers"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
@@ -218,6 +218,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -383,6 +383,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
               labels:
                 name: windows-machine-config-operator
             spec:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,8 +6,8 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: windows-machine-config-operator
   operators.operatorframework.io.bundle.channels.v1: preview,stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.builder: operator-sdk-v2.0.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   com.redhat.openshift.versions: "=v4.14"
   # Annotations for testing.

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -39,7 +39,10 @@ import (
 // Pod permissions used to get OwnerReference corresponding to the current pod. This is required to ensure that
 // the operator pod is the leader in the given namespace. This will not be required if the leader election is done
 // by the manager, instead of the "leader" library
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// ServiceAccount permissions used to watch operator on secrets.
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
 
 var (
 	scheme   = runtime.NewScheme()

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,10 +11,12 @@ namespace: openshift-windows-machine-config-operator
 namePrefix: ""
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- includeSelectors: true
+#  pairs:
+#    someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         name: windows-machine-config-operator
     spec:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -71,6 +70,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -30,7 +30,7 @@ If you already have a configured cluster, move on to [Build](#build)
 ## Build
 
 ### Prerequisites
-- [Install operator-sdk version 1.15.0 on your machine](https://sdk.operatorframework.io/docs/installation/).
+- [Install operator-sdk version 1.32.0 on your machine](https://sdk.operatorframework.io/docs/installation/).
 
 To manually build, see the subheading
 [below](#build-the-operator-image). To build and deploy automatically using the OLM hack script, jump ahead to

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -144,7 +144,7 @@ get_operator_sdk() {
 
   DOWNLOAD_DIR=/tmp/operator-sdk
   # TODO: Make this download the same version we have in go dependencies in gomod
-  wget --no-verbose -O $DOWNLOAD_DIR https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64 -o operator-sdk && chmod +x /tmp/operator-sdk || return
+  wget --no-verbose -O $DOWNLOAD_DIR https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_linux_amd64 -o operator-sdk && chmod +x /tmp/operator-sdk || return
   echo $DOWNLOAD_DIR
 }
 

--- a/hack/pre-release.sh
+++ b/hack/pre-release.sh
@@ -11,7 +11,7 @@ CVP=false
 BASEIMAGE=false
 DISTGIT=false
 GITLAB=false
-OPERATOR_SDK_VERSION=v1.15.0
+OPERATOR_SDK_VERSION=v1.32.0
 
 # codes for printing and resetting pink text
 PINK='\033[95m'
@@ -227,7 +227,7 @@ github_update() {
 
   # remove make bundle artifacts
   sed -i 's/REPLACE_IMAGE:latest/REPLACE_IMAGE/' bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
-  sed -i 's/operator-sdk-v1.14.0+git/operator-sdk-v1.15.0+git/' bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+  sed -i "s/operator-sdk-v1.14.0+git/operator-sdk-$OPERATOR_SDK_VERSION+git/" bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
 
   commit_message="[$base_branch] Update version to $updated_version
 


### PR DESCRIPTION
Updates the OSDK version to latest v1.32.0.

- Added updates required for Golang/v3 based operators following https://sdk.operatorframework.io/docs/upgrading-sdk-version/ starting from version 1.16.0 to latest 1.32.0.

- Updates the OSDK version in our pre-release.sh script and the hacking script.

- Skipped anything that did not apply to our operator (helm/ansible/non-Go-v3 based operators)