### PR TITLE
OCPBUGS-22680: Ensure WICD service account token

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -120,3 +120,17 @@ func processTags(platformType oconfig.PlatformType, userData string) string {
 	}
 	return userData
 }
+
+// GenerateServiceAccountTokenSecret returns a pointer to a secret with the given name and namespace with
+// ServiceAccountToken type and the given serviceAccountName as the annotation
+func GenerateServiceAccountTokenSecret(namespace, serviceAccountName string) *core.Secret {
+	return &core.Secret{
+		TypeMeta: meta.TypeMeta{},
+		ObjectMeta: meta.ObjectMeta{
+			Name:        serviceAccountName,
+			Namespace:   namespace,
+			Annotations: map[string]string{core.ServiceAccountNameKey: serviceAccountName},
+		},
+		Type: core.SecretTypeServiceAccountToken,
+	}
+}


### PR DESCRIPTION
This change updates the logic that looks for the WICD secret token to avoid relying on the naming convention and proposes a more robust approach by matching the secret type and the corresponding service account name.

Ensures the WICD service account token is present by creating one if not found so that the WICD kubeconfig can be created from the secret token.
