### PR TITLE
WINC-1181: Add pod CPU and Memory metrics

### DIFF
--- a/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -39,3 +39,9 @@ spec:
     - expr: |
         windows_cpu_info
       record: node_cpu_info
+    - expr: |
+        sum(rate(windows_container_cpu_usage_seconds_total[5m]) * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+      record: pod:container_cpu_usage:sum
+    - expr: |
+        label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
+      record: container_memory_working_set_bytes

--- a/config/windows-exporter/prometheusRule.yaml
+++ b/config/windows-exporter/prometheusRule.yaml
@@ -39,3 +39,9 @@ spec:
         - expr: |
             windows_cpu_info
           record: node_cpu_info
+        - expr: |
+            sum(rate(windows_container_cpu_usage_seconds_total[5m]) * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+          record: pod:container_cpu_usage:sum
+        - expr: |
+            label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
+          record: container_memory_working_set_bytes

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -5,8 +5,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -153,16 +154,8 @@ func (tc *testContext) testWindowsPrometheusRules(t *testing.T) {
 	prometheusRoute, err := tc.client.Route.Routes(monitoringNamespace).Get(context.TODO(), "prometheus-k8s", metav1.GetOptions{})
 	require.NoError(t, err, "error getting route")
 
-	// get Authorization token
 	prometheusToken, err := tc.getPrometheusToken()
-	require.NoError(t, err, "Error getting Prometheus token")
-	// define authorization token required to call Prometheus API
-	var bearer = "Bearer " + prometheusToken
-	// InsecureSkipVerify is required to avoid errors due to bad certificate
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{Transport: tr}
+	require.NoError(t, err)
 
 	// Following tests carry out api calls to Prometheus server with all the queries defined in the Windows PrometheusRule
 	// object. The tests check if the query results have instances corresponding to configured Windows Nodes.
@@ -173,25 +166,8 @@ func (tc *testContext) testWindowsPrometheusRules(t *testing.T) {
 		}
 		for _, winRules := range rules.Rules {
 			t.Run("Query: "+winRules.Record, func(t *testing.T) {
-				// url consists of prometheus host, appended with a Record defined in the Windows PrometheusRuleObject
-				url := "https://" + prometheusRoute.Spec.Host + "/api/v1/query?query=" + winRules.Record
-				// create a Get request
-				req, err := http.NewRequest("GET", url, nil)
+				queryResult, err := makePrometheusQuery(prometheusRoute.Spec.Host, winRules.Record, prometheusToken)
 				require.NoError(t, err)
-				// add Authorization Header to get access Prometheus server
-				req.Header.Set("Authorization", bearer)
-
-				resp, err := client.Do(req)
-				require.NoError(t, err)
-				// Convert the request response as a data type.
-				body, _ := ioutil.ReadAll(resp.Body)
-				var promQuery = new(PrometheusQuery)
-				err = json.Unmarshal(body, &promQuery)
-				require.NoError(t, err)
-
-				// test if query status is successful
-				require.Equal(t, "success", promQuery.Status)
-				queryResult := promQuery.Data.Result
 
 				// test query result against every Windows node
 				for _, node := range gc.allNodes() {
@@ -280,4 +256,36 @@ func (tc *testContext) testNodeResourceUsage(t *testing.T) {
 			assert.Truef(t, nodeStorage > 0, "expected strictly positive storage value but got %d", nodeStorage)
 		})
 	}
+}
+
+// makePrometheusQuery runs the given query against the prometheus server at the given address
+func makePrometheusQuery(address, query, token string) ([]Result, error) {
+	escapedQuery := url.QueryEscape(query)
+	url := "https://" + address + "/api/v1/query?query=" + escapedQuery
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error forming GET request %s: %w", url, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	tr := &http.Transport{
+		// InsecureSkipVerify is required to avoid errors due to bad certificate
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making GET request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request returned status code %d", resp.StatusCode)
+	}
+	var promQuery *PrometheusQuery
+	body, _ := io.ReadAll(resp.Body)
+	if err = json.Unmarshal(body, &promQuery); err != nil {
+		return nil, fmt.Errorf("error unmarshalling response %s: %w", string(body), err)
+	}
+	if promQuery.Status != "success" {
+		return nil, fmt.Errorf("query had status %s, expected 'success'", promQuery.Status)
+	}
+	return promQuery.Data.Result, nil
 }


### PR DESCRIPTION
Adds recording rules which translates the windows exporter's CPU and memory metrics into the time series required for display in the OpenShift console.