### PR TITLE
WINC-1158: Prep for 10.16.0 release

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.20-openshift-4.14
+  tag: rhel-9-release-golang-1.20-openshift-4.16

--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.20-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "ovn-kubernetes"]
 	path = ovn-kubernetes
 	url = https://github.com/openshift/ovn-kubernetes
-	branch = release-4.15
+	branch = release-4.16
 [submodule "containernetworking-plugins"]
 	path = containernetworking-plugins
 	url = https://github.com/openshift/containernetworking-plugins
-	branch = release-4.15
+	branch = release-4.16
 [submodule "promu"]
 	path = promu
 	url = https://github.com/openshift/prometheus-promu
@@ -15,7 +15,7 @@
 [submodule "kubelet"]
 	path = kubelet
 	url = https://github.com/openshift/kubernetes
-	branch = release-4.15
+	branch = release-4.16
 [submodule "kube-proxy"]
 	path = kube-proxy
 	url = https://github.com/openshift/kubernetes
@@ -23,16 +23,16 @@
 [submodule "containerd"]
 	path = containerd
 	url = https://github.com/openshift/containerd
-	branch = release-4.15
+	branch = release-4.16
 [submodule "hcsshim"]
 	path = hcsshim
 	url = https://github.com/openshift/hcsshim
-	branch = release-4.15
+	branch = release-4.16
 [submodule "cloud-provider-azure"]
 	path = cloud-provider-azure
 	url = https://github.com/openshift/cloud-provider-azure
-	branch = release-4.15
+	branch = release-4.16
 [submodule "csi-proxy"]
 	path = csi-proxy
 	url = https://github.com/openshift/csi-proxy
-	branch = release-4.15
+	branch = release-4.16

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 10.15.0
+WMCO_VERSION ?= 10.16.0
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as build
+
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -123,7 +123,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -123,7 +123,7 @@ RUN make build-daemon
 #├── windows_exporter.exe
 #└── windows-instance-config-daemon.exe
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.15 as build
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.16 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -36,10 +36,15 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=windows-machine-config-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=preview,stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=9.0.0 <10.15.0'
+    olm.skipRange: '>=10.15.0 <10.16.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -17,7 +17,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v10.15.0
+  name: windows-machine-config-operator.v10.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -25,8 +25,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.15/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.15/windows_containers/byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.16/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.16/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -36,8 +36,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
-    * OCP 4.15 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.15/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.16 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.16/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -47,7 +47,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.16/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -132,9 +132,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
-    - [Azure](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
-    - [GCP](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
+    - [AWS](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs
@@ -143,7 +143,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.15/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.16/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:
@@ -481,4 +481,4 @@ spec:
   minKubeVersion: 1.28.0
   provider:
     name: Red Hat
-  version: 10.15.0
+  version: 10.16.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  com.redhat.openshift.versions: "=v4.14"
+  com.redhat.openshift.versions: "=v4.15"
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v10.15.0
+  - currentCSV: windows-machine-config-operator.v10.16.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
-    olm.skipRange: '>=9.0.0 <10.15.0'
+    olm.skipRange: '>=10.15.0 <10.16.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -23,8 +23,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.15/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.15/windows_containers/byoh-windows-instance.html)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.openshift.com/container-platform/4.16/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.openshift.com/container-platform/4.16/windows_containers/byoh-windows-instance.html)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -34,8 +34,8 @@ spec:
 
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
-    * OCP 4.15 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.15/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
+    * OCP 4.16 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
+    * [WMCO prerequisites](https://docs.openshift.com/container-platform/4.16/windows_containers/understanding-windows-container-workloads.html#wmco-prerequisites__understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -45,7 +45,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.openshift.com/container-platform/4.16/installing/installing_azure/installing-azure-default.html#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -130,9 +130,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
-    - [Azure](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
-    - [GCP](https://docs.openshift.com/container-platform/4.15/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
+    - [AWS](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
+    - [Azure](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
+    - [GCP](https://docs.openshift.com/container-platform/4.16/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
 
     ### Limitations
     #### DeploymentConfigs
@@ -141,7 +141,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.15/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
+    Please read through the [troubleshooting document](https://docs.openshift.com/container-platform/4.16/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.20
+go 1.21
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.44.298 h1:5qTxdubgV7PptZJmp/2qDwD2JL187ePL7VOxsSh1i3g=
@@ -121,6 +122,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -237,6 +239,7 @@ github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTM
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/goccy/go-yaml v1.8.1/go.mod h1:wS4gNoLalDSJxo/SpngzPQ2BN4uuZVLCmbM4S3vd4+Y=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -304,6 +307,7 @@ github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
@@ -391,6 +395,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -467,6 +472,7 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
+github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -474,6 +480,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
 github.com/openshift/api v0.0.0-20231129203025-7f2a17ecdd0a h1:DQliVqAaLBNWhgTD8W3FFqEMrV8HhhlaMuRG6Lwv2rM=
 github.com/openshift/api v0.0.0-20231129203025-7f2a17ecdd0a/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/client-go v0.0.0-20231121143148-910ca30a1a9a h1:4FVrw8hz0Wb3izbf6JfOEK+pJTYpEvteRR73mCh2g/A=
@@ -544,6 +551,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -632,6 +640,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
@@ -891,6 +900,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.16.0 h1:GO788SKMRunPIBCXiQyo2AaexLstOrVhuAL5YwsckQM=
+golang.org/x/tools v0.16.0/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.20') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.21') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
This change bumps the operator and the OCP version according to WMCO 10.16.0 release.

Ran:
```
  make bundle
```