### PR TITLE
OCPBUGS-21606,OCPBUGS-2887: Fix network config script

### DIFF
--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -140,7 +140,7 @@ $cni_template=$cni_template.Replace("provider_address",$provider_address)
 # Compare CNI config with existing file, and replace if necessary
 $existing_config=""
 if(Test-Path -Path CNI_CONFIG_PATH) {
-    $existing_config= Get-Content -Path "CNI_CONFIG_PATH"
+` + "    $existing_config=((Get-Content -Path \"CNI_CONFIG_PATH\" -Raw) -Replace \"`r\",\"\")" + `
 }
 if($existing_config -ne $cni_template){
     Set-Content -Path "CNI_CONFIG_PATH" -Value $cni_template -NoNewline

--- a/pkg/nodeconfig/payload/payload_test.go
+++ b/pkg/nodeconfig/payload/payload_test.go
@@ -74,7 +74,7 @@ $cni_template=$cni_template.Replace("provider_address",$provider_address)
 # Compare CNI config with existing file, and replace if necessary
 $existing_config=""
 if(Test-Path -Path c:\k\cni.conf) {
-    $existing_config= Get-Content -Path "c:\k\cni.conf"
+` + "    $existing_config=((Get-Content -Path \"c:\\k\\cni.conf\" -Raw) -Replace \"`r\",\"\")" + `
 }
 if($existing_config -ne $cni_template){
     Set-Content -Path "c:\k\cni.conf" -Value $cni_template -NoNewline


### PR DESCRIPTION
The network configuration script contained bad logic to determine if the cni config had the correct contents. The 'expected' config does not contain carriage returns, while the actual created config file does. Because the script did not account for this, the script would always determine that the cni configuration needed to be recreated with the correct contents. This can cause issues with containerd, which needs to reload the configuration everytime this happens.