### PR TITLE
[bundle] remove scorecard from bundle.Dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -40,11 +40,6 @@ LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
-# Labels for testing.
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
-COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
removes scorecard from bundle.Dockerfile which was preventing bundles from being built.