### PR TITLE
[controllers] Introduce err check when merging CA configmaps

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -153,6 +153,10 @@ func (r *instanceReconciler) reconcileKubeletClientCA(ctx context.Context, bundl
 	// matches the signer subject.
 	kubeAPIServerServingCABytes, err := certificates.MergeCAsConfigMaps(initialCAConfigMap, bundleCAConfigMap,
 		"kube-apiserver-to-kubelet-signer")
+	if err != nil {
+		return fmt.Errorf("error merging the initial %s and current %s CA ConfigMaps %w", initialCAConfigMap,
+			bundleCAConfigMap, err)
+	}
 
 	// fetch all Windows nodes (Machine and BYOH instances)
 	winNodes := &core.NodeList{}


### PR DESCRIPTION
reconcileKubeletClientCA() handles reconciling the kube-apiserver certificate rotation by merging the initial and current CA configmaps for the kube API server signer, however, there is currently no error-check after the call to mergeCAsConfigMaps(). This commit adds an error-check after mergeCAsConfigMaps() is called to make certain no unknown failures are able to slip through.