### PR TITLE
WINC-1163: Bump kube-proxy submodule to sdn-4.16-kubernetes-1.29.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 [submodule "kube-proxy"]
 	path = kube-proxy
 	url = https://github.com/openshift/kubernetes
-	branch = sdn-4.15-kubernetes-1.28.3
+	branch = sdn-4.16-kubernetes-1.29.0
 [submodule "containerd"]
 	path = containerd
 	url = https://github.com/openshift/containerd

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WMCO_VERSION ?= 10.16.0
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.29.0+1de6a14
-KUBE-PROXY_GIT_VERSION=v1.28.3+402e202
+KUBE-PROXY_GIT_VERSION=v1.29.0+948d02f
 CONTAINERD_GIT_VERSION=v1.7.9
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")


### PR DESCRIPTION
Ran:

```
./hack/update_submodules.sh -m kube-proxy -r sdn-4.16-kubernetes-1.29.0 master

```