### PR TITLE
[release-4.12] Revert extra private key secret creation

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -165,11 +165,6 @@ func (tc *testContext) testMachineConfiguration(t *testing.T) {
 
 	machines, err := tc.waitForWindowsMachines(int(gc.numberOfMachineNodes), "Provisioned", false)
 	require.NoError(t, err, "error waiting for Windows Machines to be provisioned")
-	if tc.CloudProvider.GetType() == config.AzurePlatformType {
-		// Replace the known private key with a randomly generated one.
-		err = tc.createPrivateKeySecret(false)
-		require.NoError(t, err, "error replacing private key secret")
-	}
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, false, false)
 	assert.NoError(t, err, "Windows node creation failed")
 	tc.machineLogCollection(machines.Items)


### PR DESCRIPTION


The `azure-e2e-operator` job is being failing [1] due to a timing problem while testing the private key secret change during the creation test suite. The later was fixed in 09c2bfb4589cefe4d3cb7b646bd369ee272f1613 by introducing a  wait after changing the private key secret on Azure to check all machines provisioned with the outdated windows-user-data were deleted. 

In 69e56dff8b68e68edb78a909f7f51ee6c0c9ab1d the private key secret change test was incorrectly  re-introduced making the timing problem resurface. This change removes the re-introduced code that triggers the private key secret change to fix the timing problem shown in the azure-e2e-operator job.

The following jobs shows successful runs of the azure-e2e-operator job as validation of the changes introduced here.
- [release-4.12-azure-e2e-operator #1745196721991847936](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_windows-machine-config-operator/2002/pull-ci-openshift-windows-machine-config-operator-release-4.12-azure-e2e-operator/1745196721991847936)
- [release-4.12-azure-e2e-operator #1745264177334718464](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_windows-machine-config-operator/2002/pull-ci-openshift-windows-machine-config-operator-release-4.12-azure-e2e-operator/1745264177334718464)

[1] Screenshot of the test results as of 204-01-12 of the azure-e2e-operator job for release-4.12 branch
![image](https://github.com/openshift/windows-machine-config-operator/assets/75598896/13e7b5d1-76d9-4d43-97eb-70bb3054290a)

Source: https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-windows-machine-config-operator-release-4.12-azure-e2e-operator

Blocks:
- https://github.com/openshift/windows-machine-config-operator/pull/1994
- https://github.com/openshift/windows-machine-config-operator/pull/2012
- https://github.com/openshift/windows-machine-config-operator/pull/1932