### PR TITLE
[vsphere_ci] Add metrics port rule to packer script

### DIFF
--- a/docs/vsphere_ci/scripts/install-firewall-rules.ps1
+++ b/docs/vsphere_ci/scripts/install-firewall-rules.ps1
@@ -5,6 +5,8 @@
 
 # create firewall rule to allow Container Logs on port 10250
 New-NetFirewallRule -DisplayName "ContainerLogsPort" -LocalPort 10250 -Enabled True -Direction Inbound -Protocol TCP -Action Allow -EdgeTraversalPolicy Allow
+# create new firewall rule to allow incoming connections on port 9182 for node and pod metrics collection to function
+New-NetFirewallRule -DisplayName "WindowsExporter" -LocalPort 9182 -Enabled True -Direction Inbound -Protocol TCP -Action Allow -EdgeTraversalPolicy Allow
 
 # success
 exit 0


### PR DESCRIPTION
Update the firewall rules packer script to explicity allow incoming traffic for the Windows Exporter metrics server running on Windows nodes.

Follow-up to https://github.com/openshift/windows-machine-config-operator/pull/2006