### PR TITLE
WINC-1199: Fix VM creation automation in new vCenter

### DIFF
--- a/docs/vsphere_ci/README.md
+++ b/docs/vsphere_ci/README.md
@@ -9,7 +9,7 @@ template to virtual machine, the `machine-api` can use this newly created virtua
 subsequent VM cloning. 
 
 The above golden image name is the one we use in the Machine Set's `providerSpec.template`. The following steps need 
-to be executed with a sshuttle opened to the vSphere bastion host.
+to be executed with the `twingate` VPN active.
 
 ## Installing Packer
 
@@ -92,6 +92,7 @@ adjust the following variables:
    must match with the password entered in the [autounattend.xml](answer-files/autounattend.xml) script
 - `<vsphere-cluster>` Name of the vSphere cluster
 - `<vsphere-datacenter>` Name of the vSphere datacenter
+- `<vsphere-network>` Name of the vSphere network
 - `<vsphere-datastore>` Name of the vSphere datastore
 - `<vsphere-server>` The vCenter server hostname, with no scheme (`https://`) nor path separators (`/`).
   For example: `vcenter.example.com`.

--- a/docs/vsphere_ci/vcenter_copy_template/README.md
+++ b/docs/vsphere_ci/vcenter_copy_template/README.md
@@ -1,0 +1,36 @@
+# Copying VMs to CI vCenters
+
+Tools to copy an existing VM images from one vCenter environment to another.
+Keep the images to transfer as VMs (powered-off state), not as templates.
+
+Note that this should only be done as a last resort.
+The ideal way is to use packer to build a golden image replica within each separate environment.
+If building via packer is not working, we should first try to fix the packer scripts before trying to copy over VMs.
+
+## Installing govc
+
+Install `govc` on the host where you will be building image. Download, unzip, and move the utility within your `$PATH`.
+e.g.
+
+```sh
+curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
+```
+
+## Prerequisite files
+
+Please ensure the following files are present in the location where you are running the cloning scripts from:
+
+- `source*` - vCenter config, one file for each environment
+- `options.json` - VM template config
+
+Fill out the config variables with your credentials and parameters for each environment. Note that some values may be different between the DEV/QE and CI vCenters -- example files are given: `sourcedevqe`, `sourceibm-ci`, `source-vcs8e`.
+
+## Scripts
+
+There are two scripts to run, each of which requires passing in a source file to populate govc config variables.
+
+- getem.sh
+- putem.sh
+
+You can run these from a jump VM (temporary host created in the target vSphere environment) or from your local machine,
+but the latter will be slower in the transfer.

--- a/docs/vsphere_ci/vcenter_copy_template/getem.sh
+++ b/docs/vsphere_ci/vcenter_copy_template/getem.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+	echo "Error: incorrect parameter count $#" >&2
+	exit 1
+fi
+
+# Pass in source file with govc creds/settings e.g. sourcedevqe
+source $1
+
+# Get all or a specific host
+govc ls /*/vm/windows-golden-images/windows-server-2022-template-ipv6-disabled > servers.txt
+#govc ls /*/vm/windows-golden-images/ > servers.txt
+
+# Get the list of servers from a file
+servers=$(cat servers.txt)
+
+# Ping each server and print the results
+for server in $servers; do
+	govc export.ovf -vm $server .
+done

--- a/docs/vsphere_ci/vcenter_copy_template/options.json
+++ b/docs/vsphere_ci/vcenter_copy_template/options.json
@@ -1,0 +1,13 @@
+{
+"DiskProvisioning": "flat",
+"IPAllocationPolicy": "dhcpPolicy",
+"IPProtocol": "IPv4",
+"NetworkMapping": [
+{ "Name": "VM Network", "Network": "VM Network" }
+],
+"MarkAsTemplate": false,
+"PowerOn": false,
+"InjectOvfEnv": false,
+"WaitForIP": false,
+"Name": null
+}

--- a/docs/vsphere_ci/vcenter_copy_template/putem.sh
+++ b/docs/vsphere_ci/vcenter_copy_template/putem.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+	echo "Error: incorrect parameter count $#" >&2
+	exit 1
+fi
+
+# Pass in source file with govc creds/settings e.g. sourcedevqe
+source $1
+
+# Specify the starting directory for the search
+search_dir="."
+
+# Find all files with extension .ovf
+for file in $(find $serch_dir -type f -name "*.ovf"); do
+	sed -i "s/vmware.cdrom.iso/vmware.cdrom.remotepassthrough/g" $file
+done
+
+# Specify the output file to store the line-by-line content
+output_file="ovf_files_content.txt"
+
+# Find all *.ovf files in the specified directory and its subdirectories
+find "$search_dir" -type f -name "*.ovf" -print0 | while IFS= read -r -d '' file; do
+	# For each found file, list its contents line by line into the output file
+	echo "$file" > "$output_file"
+	done
+echo "OVF file contents saved to $output_file"
+
+# Import each host one by one
+for server in $(cat $output_file); do
+	echo $server
+	govc import.ovf -ds=vsanDatastore -folder=windows-golden-images $server
+done

--- a/docs/vsphere_ci/vcenter_copy_template/sourcedevqe
+++ b/docs/vsphere_ci/vcenter_copy_template/sourcedevqe
@@ -1,0 +1,4 @@
+export GOVC_URL=https://vcenter.devqe.ibmc.devcluster.openshift.com
+export GOVC_USERNAME=xxxxxxx@devqe.ibmc.devcluster.openshift.com
+export GOVC_PASSWORD='xxxxxxx'
+export GOVC_INSECURE=true

--- a/docs/vsphere_ci/vcenter_copy_template/sourceibm-ci
+++ b/docs/vsphere_ci/vcenter_copy_template/sourceibm-ci
@@ -1,0 +1,4 @@
+export GOVC_URL=https://vcenter.ibmc.devcluster.openshift.com
+export GOVC_USERNAME=xxxxxxx@ibmc.devcluster.openshift.com
+export GOVC_PASSWORD='xxxxxxx'
+export GOVC_INSECURE=true

--- a/docs/vsphere_ci/vcenter_copy_template/sourcevcs8e
+++ b/docs/vsphere_ci/vcenter_copy_template/sourcevcs8e
@@ -1,0 +1,6 @@
+export GOVC_URL=https://vcs8e-vc.ocp2.dev.cluster.com
+export GOVC_USERNAME=xxxxxxx@vsphere.local
+export GOVC_PASSWORD='xxxxxxx'
+export GOVC_INSECURE=true
+export GOVC_DATACENTER=IBMCloud
+export GOVC_RESOURCE_POOL='QE Resource Pool'

--- a/docs/vsphere_ci/windows-server-2022.pkr.hcl
+++ b/docs/vsphere_ci/windows-server-2022.pkr.hcl
@@ -42,7 +42,7 @@ variable "vsphere-datacenter" {
 
 variable "vsphere-network" {
   type    = string
-  default = "/DEVQEdatacenter/network/devqe-segment-xxx"
+  default = "/DEVQEdatacenter/network/devqe-segment-222"
 }
 
 variable "vsphere-datastore" {

--- a/docs/vsphere_ci/windows-server-2022.pkr.hcl
+++ b/docs/vsphere_ci/windows-server-2022.pkr.hcl
@@ -1,7 +1,7 @@
 
 variable "os-iso-path" {
   type    = string
-  default = "[WorkloadDatastore] windows-iso-images/winsrv2022_sep_2021_x64_dvd.iso"
+  default = "[vsanDatastore] windows-iso-images/winsrv2022_sep_2021_x64_dvd.iso"
 }
 
 variable "vm-elevated-password" {
@@ -32,17 +32,22 @@ variable "vmtools-iso-path" {
 
 variable "vsphere-cluster" {
   type    = string
-  default = "Cluster-1"
+  default = "DEVQEcluster"
 }
 
 variable "vsphere-datacenter" {
   type    = string
-  default = "SDDC-Datacenter"
+  default = "DEVQEdatacenter"
+}
+
+variable "vsphere-network" {
+  type    = string
+  default = "/DEVQEdatacenter/network/devqe-segment-xxx"
 }
 
 variable "vsphere-datastore" {
   type    = string
-  default = "WorkloadDatastore"
+  default = "vsanDatastore"
 }
 
 variable "vsphere-password" {
@@ -78,7 +83,7 @@ source "vsphere-iso" "windows-server-2022" {
   insecure_connection  = "true"
   iso_paths            = ["${var.os-iso-path}", "${var.vmtools-iso-path}"]
   network_adapters {
-    network      = "dev-segment"
+    network      = "${var.vsphere-network}"
     network_card = "vmxnet3"
   }
   password         = "${var.vsphere-password}"


### PR DESCRIPTION
- Updates packer config to work on new DEV/QE environment
- Adds scripts and documentation to copy over VMs across vCenter environments, to be used only as a last resort to move existing VMs (created via packer or otherwise) to CI environments.