### PR TITLE
[build] Set go toolchain to local

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,10 @@ LABEL stage=build
 ENV GO_COMPLIANCE_INFO=0
 ENV GO_COMPLIANCE_DEBUG=0
 
+# Set go toolchain to local, this prevents it from
+# downloading the latest version
+ENV GOTOOLCHAIN=local
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -5,6 +5,10 @@ LABEL stage=build
 ENV GO_COMPLIANCE_INFO=0
 ENV GO_COMPLIANCE_DEBUG=0
 
+# Set go toolchain to local, this prevents it from
+# downloading the latest version
+ENV GOTOOLCHAIN=local
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -11,6 +11,10 @@ WORKDIR /build/
 ENV GO_COMPLIANCE_INFO=0
 ENV GO_COMPLIANCE_DEBUG=0
 
+# Set go toolchain to local, this prevents it from
+# downloading the latest version
+ENV GOTOOLCHAIN=local
+
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix
 

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -5,6 +5,10 @@ LABEL stage=build
 ENV GO_COMPLIANCE_INFO=0
 ENV GO_COMPLIANCE_DEBUG=0
 
+# Set go toolchain to local, this prevents it from
+# downloading the latest version
+ENV GOTOOLCHAIN=local
+
 WORKDIR /build/windows-machine-config-operator/
 
 # Copy files and directories needed to build the WMCO binary


### PR DESCRIPTION
This PR sets the value of ENV var GOTOOLCHAIN to local. The default value is auto if not set.
Making this change prevents it from downloading the latest version of toolchain which is incompatible
with Cachito still running on go1.19.
This change is made to maintain parity between the github and midtstream Dockerfiles.