### PR TITLE
[release-4.15] Revert "Change sourceVIP used for kube-proxy"

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -132,7 +132,7 @@ func main() {
 	}
 
 	if err := payload.PopulateNetworkConfScript(clusterConfig.Network().GetServiceCIDR(), windows.OVNKubeOverlayNetwork,
-		windows.HNSPSModule, windows.CNIDir, windows.CniConfDir+"\\cni.conf"); err != nil {
+		windows.HNSPSModule, windows.CniConfDir+"\\cni.conf"); err != nil {
 		setupLog.Error(err, "unable to generate CNI config script")
 		os.Exit(1)
 	}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -46,10 +46,10 @@ const (
 	HybridOverlayLogDir = logDir + "\\hybrid-overlay"
 	// wicdLogDir is the remote wicd log directory
 	wicdLogDir = logDir + "\\wicd"
-	// CNIDir is the directory for storing CNI binaries
-	CNIDir = K8sDir + "\\cni"
+	// cniDir is the directory for storing CNI binaries
+	cniDir = K8sDir + "\\cni"
 	// CniConfDir is the directory for storing CNI configuration
-	CniConfDir = CNIDir + "\\config"
+	CniConfDir = cniDir + "\\config"
 	// ContainerdDir is the directory for storing Containerd binary
 	ContainerdDir = K8sDir + "\\containerd"
 	// ContainerdPath is the location of the containerd exe
@@ -151,7 +151,7 @@ var (
 	// RequiredDirectories is a list of directories to be created by WMCO
 	RequiredDirectories = []string{
 		remoteDir,
-		CNIDir,
+		cniDir,
 		CniConfDir,
 		logDir,
 		KubeletLogDir,
@@ -188,9 +188,9 @@ func getFilesToTransfer(platform *config.PlatformType) map[string]string {
 		payload.HybridOverlayPath:              K8sDir,
 		payload.HNSPSModule:                    remoteDir,
 		payload.WindowsExporterPath:            K8sDir,
-		payload.WinBridgeCNIPlugin:             CNIDir,
-		payload.HostLocalCNIPlugin:             CNIDir,
-		payload.WinOverlayCNIPlugin:            CNIDir,
+		payload.WinBridgeCNIPlugin:             cniDir,
+		payload.HostLocalCNIPlugin:             cniDir,
+		payload.WinOverlayCNIPlugin:            cniDir,
 		payload.KubeProxyPath:                  K8sDir,
 		payload.KubeletPath:                    K8sDir,
 		payload.KubeLogRunnerPath:              K8sDir,


### PR DESCRIPTION
This reverts commit ab9a1690d1de5bc34ed37106abcbff262473df3b.

We have been given new information that this is not required, the method that was used before was valid.