### PR TITLE
OCPBUGS-28575: Fix issue with PS type mismatch

### DIFF
--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -140,7 +140,10 @@ $cni_template=$cni_template.Replace("provider_address",$provider_address)
 # Compare CNI config with existing file, and replace if necessary
 $existing_config=""
 if(Test-Path -Path CNI_CONFIG_PATH) {
-` + "    $existing_config=((Get-Content -Path \"CNI_CONFIG_PATH\" -Raw) -Replace \"`r\",\"\")" + `
+    $config_file_content=(Get-Content -Path CNI_CONFIG_PATH -Raw)
+    if($config_file_content -ne $null) {
+` + "        $existing_config=$config_file_content.Replace(\"`r\",\"\")" + `
+    }
 }
 if($existing_config -ne $cni_template){
     Set-Content -Path "CNI_CONFIG_PATH" -Value $cni_template -NoNewline

--- a/pkg/nodeconfig/payload/payload_test.go
+++ b/pkg/nodeconfig/payload/payload_test.go
@@ -74,7 +74,10 @@ $cni_template=$cni_template.Replace("provider_address",$provider_address)
 # Compare CNI config with existing file, and replace if necessary
 $existing_config=""
 if(Test-Path -Path c:\k\cni.conf) {
-` + "    $existing_config=((Get-Content -Path \"c:\\k\\cni.conf\" -Raw) -Replace \"`r\",\"\")" + `
+    $config_file_content=(Get-Content -Path c:\k\cni.conf -Raw)
+    if($config_file_content -ne $null) {
+` + "        $existing_config=$config_file_content.Replace(\"`r\",\"\")" + `
+    }
 }
 if($existing_config -ne $cni_template){
     Set-Content -Path "c:\k\cni.conf" -Value $cni_template -NoNewline


### PR DESCRIPTION
This commit fixes an issue which would be seen when the cni config file was created with no content. When using the -replace operator with $null, an empty object array was returned. This caused comparison issues with the expected config as it was comparing an array with a string.