### PR TITLE
[release-4.13] build: Build Azure CCM with buildvcs=false

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,7 +52,7 @@ RUN make kube-proxy
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/
 COPY cloud-provider-azure/ .
-RUN GOOS=windows go build -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
+RUN GOOS=windows go build -buildvcs=false -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
 
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -52,7 +52,7 @@ RUN make kube-proxy
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/
 COPY cloud-provider-azure/ .
-RUN GOOS=windows go build -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
+RUN GOOS=windows go build -buildvcs=false -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
 
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -60,7 +60,7 @@ RUN make kube-proxy
 # Build azure-cloud-node-manager
 WORKDIR /build/windows-machine-config-operator/cloud-provider-azure/
 COPY cloud-provider-azure/ .
-RUN GOOS=windows go build -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
+RUN GOOS=windows go build -buildvcs=false -o azure-cloud-node-manager.exe ./cmd/cloud-node-manager
 
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/


### PR DESCRIPTION
This is to workaround:
error obtaining VCS status: exit status 128
    Use -buildvcs=false to disable VCS stamping.
which occurs due to the RHSA-2024:0407 fix which intentionally disabled the safe.directory that is required to allow non-root users to interact with the git repo.