### PR TITLE
[release-4.12] submodule update 02/12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.25.16 // indirect
 	k8s.io/cli-runtime v0.25.16 // indirect
 	k8s.io/component-base v0.25.16 // indirect
-	k8s.io/kube-openapi v0.0.0-20240126223410-2919ad4fcfec // indirect
+	k8s.io/kube-openapi v0.0.0-20240209001042-7a0d5b415232 // indirect
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -846,7 +846,7 @@ k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
-# k8s.io/kube-openapi v0.0.0-20240126223410-2919ad4fcfec => k8s.io/kube-openapi v0.0.0-20220928191237-829ce0c27909
+# k8s.io/kube-openapi v0.0.0-20240209001042-7a0d5b415232 => k8s.io/kube-openapi v0.0.0-20220928191237-829ce0c27909
 ## explicit; go 1.18
 k8s.io/kube-openapi/pkg/builder3/util
 k8s.io/kube-openapi/pkg/common


### PR DESCRIPTION
[[submodule][ovn-kubernetes] Update to cc7638a92](https://github.com/openshift/windows-machine-config-operator/commit/9d23fffeee4bf3b13e7a6429b831c5dec6b72b32) 

[[vendor] Use v1.25.16+6df2177 k8s and OpenShift libraries](https://github.com/openshift/windows-machine-config-operator/commit/559e5ca4727173c30aa41506b7421257dd9e9716)