### PR TITLE
OCPBUGS-27775: [release-4.12] Introduce olm.skipRange to 7.2.1

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
+    olm.skipRange: '>=6.0.0 <7.2.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     certified: "false"
     createdAt: REPLACE_DATE
     description: An operator that enables Windows container workloads on OCP
+    olm.skipRange: '>=6.0.0 <7.2.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows


### PR DESCRIPTION
This change adds the olm.skipRange attribute to the ClusterServiceVersion manifest to specify a range of versions that should be skipped during upgrades so that the upgrade path skips intermediate versions that may contain issues fixed in the latest patch and minor releases.

Ran:
```
  make bundle
```