### PR TITLE
WINC-1184: Add support for 10.y.z version parsing in hack scripts

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -30,6 +30,11 @@ get_OCP_version() {
   # versions behind OCP Y version
   local DIFFERENCE=5
   local OCP_VER_MINOR=$(($DIFFERENCE+$WMCO_VER_MAJOR))
+  # starting on WMCO 10.y.z, the WMCO y-stream follows OCP y-stream
+  if [ "$WMCO_VER_MAJOR" -ge 10 ]; then
+    WMCO_VER_MINOR=$(echo $WMCO_VERSION | cut -d. -f2)
+    OCP_VER_MINOR=${WMCO_VER_MINOR}
+  fi
   echo $OCP_VER_MAJOR.$OCP_VER_MINOR
 }
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -25,7 +25,7 @@ get_OCP_version() {
   fi
   local WMCO_VERSION=$1
   local OCP_VER_MAJOR=4
-  local WMCO_VER_MAJOR=${WMCO_VERSION:0:1}
+  local WMCO_VER_MAJOR=$(echo $WMCO_VERSION | cut -d. -f1)
   # OCP 4.6 maps to WMCO 1.y.z making the WMCO major version always five
   # versions behind OCP Y version
   local DIFFERENCE=5


### PR DESCRIPTION
This change  updates the get_OCP_version func to parse the
WMCO major version following a semantic version pattern
to support major versions with more than one digit, for
example 10.15.0