### PR TITLE
WINC-703: [config] adds controller manager resource limits

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -418,7 +418,13 @@ spec:
                 image: REPLACE_IMAGE
                 imagePullPolicy: IfNotPresent
                 name: manager
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 600Mi
+                  requests:
+                    cpu: 20m
+                    memory: 300Mi
               dnsPolicy: ClusterFirstWithHostNet
               hostNetwork: true
               nodeSelector:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,13 @@ spec:
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent
+        resources:
+         limits:
+            cpu: 200m
+            memory: 600Mi
+         requests:
+            cpu: 20m
+            memory: 300Mi
         env:
           - name: WATCH_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Adds resource limits for containers, taken from MCO's resource limits.

Testing done on a 4.14 GCP cluster with 10 windows worker node, and a  4.14 platform none cluster, with one windows worker node. 

ran make bundle