### PR TITLE
[hack] Fix get_operator_sdk hardcode path issue

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# defines the operator-sdk version used across the hack scripts, e.g. pre-release.sh
+export OPERATOR_SDK_VERSION=v1.32.0
+
 # Default is false unless test is running in COMMUNITY branch
 COMMUNITY=${COMMUNITY:-false}
 
@@ -142,10 +145,20 @@ get_operator_sdk() {
     return
   fi
 
-  DOWNLOAD_DIR=/tmp/operator-sdk
+  OPERATOR_SDK_DOWNLOAD_DIR=$(mktemp -d)
+  OPERATOR_SDK_DOWNLOAD_URL="https://github.com/operator-framework/operator-sdk/releases/download"
   # TODO: Make this download the same version we have in go dependencies in gomod
-  wget --no-verbose -O $DOWNLOAD_DIR https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_linux_amd64 -o operator-sdk && chmod +x /tmp/operator-sdk || return
-  echo $DOWNLOAD_DIR
+  wget --no-verbose "${OPERATOR_SDK_DOWNLOAD_URL}"/"${OPERATOR_SDK_VERSION}"/operator-sdk_linux_amd64 \
+    -O "${OPERATOR_SDK_DOWNLOAD_DIR}"/operator-sdk \
+    -o "${OPERATOR_SDK_DOWNLOAD_DIR}"/operator-sdk.log || {
+      echo "Failed to download operator-sdk version ${OPERATOR_SDK_VERSION}"
+      return
+  }
+  chmod +x "${OPERATOR_SDK_DOWNLOAD_DIR}"/operator-sdk || {
+    echo "Failed to make operator-sdk executable"
+    return
+  }
+  echo "${OPERATOR_SDK_DOWNLOAD_DIR}/operator-sdk"
 }
 
 get_packagemanifests_version() {

--- a/hack/pre-release.sh
+++ b/hack/pre-release.sh
@@ -11,7 +11,6 @@ CVP=false
 BASEIMAGE=false
 DISTGIT=false
 GITLAB=false
-OPERATOR_SDK_VERSION=v1.32.0
 
 # codes for printing and resetting pink text
 PINK='\033[95m'


### PR DESCRIPTION
This change updates the get_operator_sdk function in the hack script to use a temp dir instead of a hard-coded path that may not exist and improve error handling.

In addition, it generalizes the OPERATOR_SDK_VERSION environment variable to be re-used.