### PR TITLE
[metrics] Add metric kubelet_running_pods

### DIFF
--- a/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -45,3 +45,6 @@ spec:
     - expr: |
         label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
       record: container_memory_working_set_bytes
+    - expr: |
+        windows_container_available
+      record: kubelet_running_pods

--- a/config/windows-exporter/prometheusRule.yaml
+++ b/config/windows-exporter/prometheusRule.yaml
@@ -45,3 +45,6 @@ spec:
         - expr: |
             label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
           record: container_memory_working_set_bytes
+        - expr: |
+            windows_container_available
+          record: kubelet_running_pods


### PR DESCRIPTION
Adds the renaming required for windows exporter's
windows_container_available metric which transaltes to kubelet_running_pods metric to display the number of pods running on a node in the OpenShift console.