### PR TITLE
WINC-1220: Set config_path for containerd registry settings

### DIFF
--- a/pkg/internal/containerd_conf.toml
+++ b/pkg/internal/containerd_conf.toml
@@ -134,7 +134,7 @@ version = 2
       key_model = "node"
 
     [plugins."io.containerd.grpc.v1.cri".registry]
-      config_path = ""
+      config_path = "C:\\k\\containerd\\registries"
 
       [plugins."io.containerd.grpc.v1.cri".registry.auths]
 

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -58,6 +58,8 @@ const (
 	ContainerdPath = ContainerdDir + "\\containerd.exe"
 	// ContainerdConfPath is the location of containerd config file
 	ContainerdConfPath = ContainerdDir + "\\containerd_conf.toml"
+	// containerdConfigDir is the remote directory for containerd registry config
+	containerdConfigDir = ContainerdDir + "\\registries"
 	// containerdLogDir is the remote containerd log directory
 	containerdLogDir = logDir + "\\containerd"
 	// ContainerdLogPath is the location of the containerd log file
@@ -165,6 +167,7 @@ var (
 		HybridOverlayLogDir,
 		ContainerdDir,
 		containerdLogDir,
+		containerdConfigDir,
 		podManifestDirectory,
 		K8sDir,
 	}


### PR DESCRIPTION
This PR adjusts the containerd base config to pick up CRI plugin config so we can customize runtime settings like image registry configuration. The new directory is added to the set created and deleted by WMCO.