### PR TITLE
Collect node logs on e2e failure

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -101,7 +101,8 @@ func (tc *testContext) testWindowsNodeCreation(t *testing.T) {
 // these logs can will be written to the artifact directory
 func (tc *testContext) nodelessLogCollection(name, address string) error {
 	// recurse through all files in /var/log and print the file name and file contents
-	cmd := "Get-ChildItem -Path /var/log -Recurse | ForEach-Object {Write-Output $_.FullName; Get-Content $_.FullName}"
+	// also collect any relevant configuration files
+	cmd := "Get-ChildItem -Path /var/log -Recurse | ForEach-Object {Write-Output $_.FullName; Get-Content $_.FullName}; Get-Item -Path /k/cni/config/cni.conf | ForEach-Object {Write-Output $_.FullName; Get-Content $_.FullName};"
 	_, err := tc.runPowerShellSSHJob("print-logs-"+name, cmd, address)
 	return err
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -214,6 +214,15 @@ func TestUpgrade(t *testing.T) {
 	err = tc.scaleMachineApprover(1)
 	require.NoError(t, err)
 
+	// Attempt to collect all Node logs if tests fail
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		log.Printf("test failed, attempting to gather Node logs")
+		tc.collectWindowsInstanceLogs()
+	})
+
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfMachineNodes), true, false)
 	assert.NoError(t, err, "timed out waiting for Windows Machine nodes")
 	err = tc.waitForConfiguredWindowsNodes(int32(numberOfBYOHNodes), true, true)

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/windows-machine-config-operator/controllers"
+	"github.com/openshift/windows-machine-config-operator/test/e2e/clusterinfo"
 )
 
 var (
@@ -36,6 +39,15 @@ func TestWMCO(t *testing.T) {
 	// label, so we ensure that it gets applied and the WMCO deployment is restarted.
 	require.NoError(t, tc.ensureMonitoringIsEnabled(), "error ensuring monitoring is enabled")
 
+	// Attempt to collect all Node logs if tests fail
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		log.Printf("test failed, attempting to gather Node logs")
+		tc.collectWindowsInstanceLogs()
+	})
+
 	// test that the operator can deploy without the secret already created, we can later use a secret created by the
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
@@ -61,4 +73,28 @@ func testOperatorDeployed(t *testing.T) {
 		"windows-machine-config-operator", meta.GetOptions{})
 	require.NoError(t, err, "could not get WMCO deployment")
 	require.NotZerof(t, deployment.Status.AvailableReplicas, "WMCO deployment has no available replicas: %v", deployment)
+}
+
+// collectWindowsInstanceLogs collects the node logs from each Windows Machine in the cluster.
+func (tc *testContext) collectWindowsInstanceLogs() {
+	winMachines, err := tc.client.Machine.Machines(clusterinfo.MachineAPINamespace).List(context.TODO(), meta.ListOptions{
+		LabelSelector: controllers.MachineOSLabel + "=Windows",
+	})
+	if err != nil {
+		log.Printf("unable to list Windows Machines, log collection failed")
+		return
+	}
+	for _, machine := range winMachines.Items {
+		addr, err := controllers.GetAddress(machine.Status.Addresses)
+		if err != nil {
+			log.Printf("unable to get address for %s: %s", machine.GetName(), err)
+			continue
+		}
+		err = tc.nodelessLogCollection(machine.GetName(), addr)
+		if err != nil {
+			log.Printf("unable to collect logs from %s: %s", machine.GetName(), err)
+			continue
+		}
+	}
+
 }


### PR DESCRIPTION
Collects service logs and the cni config on failures in the e2e tests