### PR TITLE
[release-4.15] OCPBUGS-31704: Stop checking CloudControllerOwner

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	config "github.com/openshift/api/config/v1"
-	openshiftClient "github.com/openshift/client-go/config/clientset/versioned"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -112,16 +111,8 @@ func NewConfigMapReconciler(mgr manager.Manager, clusterConfig cluster.Config, w
 	if err != nil {
 		return nil, err
 	}
-	oc, err := openshiftClient.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return nil, fmt.Errorf("unable to create openshift client-go client: %w", err)
-	}
-	ccmEnabled, err := cluster.IsCloudControllerOwnedByCCM(oc)
-	if err != nil {
-		return nil, fmt.Errorf("error determining if CCM owns cloud controller: %w", err)
-	}
 	svcData, err := services.GenerateManifest(argsFromIgnition, clusterConfig.Network().VXLANPort(),
-		clusterConfig.Platform(), ccmEnabled, ctrl.Log.V(1).Enabled())
+		clusterConfig.Platform(), ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, fmt.Errorf("error generating expected Windows service state: %w", err)
 	}

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -25,10 +25,6 @@ const (
 	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
 	// 1.20.x are supported for baseK8sVersion 1.20)
 	baseK8sVersion = "v1.28"
-	// cloudControllerOwnershipConditionType defines the Condition type for Cloud Controllers ownership
-	cloudControllerOwnershipConditionType = "CloudControllerOwner"
-	// clusterCloudControllerManagerOperatorName is the registered name of Cluster Cloud Controller Manager Operator
-	clusterCloudControllerManagerOperatorName = "cloud-controller-manager"
 	// MachineAPINamespace is the name of the namespace in which machine objects and userData secret is created.
 	MachineAPINamespace = "openshift-machine-api"
 )
@@ -325,28 +321,6 @@ func GetDNS(subnet string) (string, error) {
 		return "", err
 	}
 	return clusterDNS.String(), nil
-}
-
-// IsCloudControllerOwnedByCCM checks if Cloud Controllers are managed by Cloud Controller Manager (CCM)
-// instead of Kube Controller Manager.
-// For more information: https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/out-of-tree-provider-support.md
-func IsCloudControllerOwnedByCCM(oclient configclient.Interface) (bool, error) {
-	co, err := oclient.ConfigV1().ClusterOperators().Get(context.TODO(), clusterCloudControllerManagerOperatorName, meta.GetOptions{})
-	if err != nil {
-		return false, fmt.Errorf("unable to get cluster operator resource: %w", err)
-	}
-
-	// If there is no condition, we assume that CCM doesn't own the Cloud Controllers
-	ownedByCCM := false
-	if co.Status.Conditions != nil {
-		for _, cond := range co.Status.Conditions {
-			if cond.Type == cloudControllerOwnershipConditionType {
-				ownedByCCM = cond.Status == oconfig.ConditionTrue
-			}
-		}
-	}
-
-	return ownedByCCM, nil
 }
 
 // IsProxyEnabled returns whether a global egress proxy is active in the cluster

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -27,7 +27,7 @@ const (
 // GenerateManifest returns the expected state of the Windows service configmap. If debug is true, debug logging
 // will be enabled for services that support it.
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort string, platform config.PlatformType,
-	ccmEnabled, debug bool) (*servicescm.Data, error) {
+	debug bool) (*servicescm.Data, error) {
 	kubeletConfiguration, err := getKubeletServiceConfiguration(kubeletArgsFromIgnition, debug, platform)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine kubelet service configuration spec: %w", err)
@@ -47,7 +47,7 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 		kubeProxyConfiguration(debug),
 		csiProxyConfiguration(debug),
 	}
-	if platform == config.AzurePlatformType && ccmEnabled {
+	if platform == config.AzurePlatformType {
 		*services = append(*services, azureCloudNodeManagerConfiguration())
 	}
 	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -26,7 +26,6 @@ import (
 	cloudproviderapi "k8s.io/cloud-provider/api"
 
 	"github.com/openshift/windows-machine-config-operator/controllers"
-	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/condition"
 	"github.com/openshift/windows-machine-config-operator/pkg/crypto"
 	"github.com/openshift/windows-machine-config-operator/pkg/csr"
@@ -580,15 +579,11 @@ func (tc *testContext) testExpectedServicesRunning(t *testing.T) {
 // expectedWindowsServices returns a map of the names of the WMCO owned Windows services, with a value indicating if it
 // should or should not be running on the instance.
 func (tc *testContext) expectedWindowsServices(alwaysRequiredSvcs []string) (map[string]bool, error) {
-	ownedByCCM, err := cluster.IsCloudControllerOwnedByCCM(tc.client.Config)
-	if err != nil {
-		return nil, err
-	}
 	serviceMap := make(map[string]bool)
 	for _, svc := range alwaysRequiredSvcs {
 		serviceMap[svc] = true
 	}
-	if ownedByCCM && tc.CloudProvider.GetType() == config.AzurePlatformType {
+	if tc.CloudProvider.GetType() == config.AzurePlatformType {
 		serviceMap[windows.AzureCloudNodeManagerServiceName] = true
 	} else {
 		serviceMap[windows.AzureCloudNodeManagerServiceName] = false


### PR DESCRIPTION
Backport of https://github.com/openshift/windows-machine-config-operator/pull/2117

This commit reacts to
https://github.com/openshift/cluster-cloud-controller-manager-operator/commit/65c07a6e44bfa1b0cdfadc264d3341c093ffd914

There is no longer a CloudControllerOwner condition on the CCM clusteroperator, as external cloud controllers are now fully default. WMCO will no longer check for this condition, and the logic depending on it should now always be done.