### PR TITLE
[test] Increase upgrade test timeout

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -184,7 +184,7 @@ fi
 
 if [[ "$TEST" = "upgrade-test" ]]; then
   trap deleteParallelUpgradeCheckerResources EXIT
-  go test ./test/e2e/... -run=TestUpgrade -v -timeout=20m -args $GO_TEST_ARGS
+  go test ./test/e2e/... -run=TestUpgrade -v -timeout=30m -args $GO_TEST_ARGS
 fi
 
 


### PR DESCRIPTION
Increases the timeout for the upgrade test, as we have been seeing panics due to the timeout being hit. Panics make log collection much harder.