### PR TITLE
WINC-1221: WMCO generates hosts.toml file content

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -308,6 +308,22 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - imagedigestmirrorsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - imagetagmirrorsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - infrastructures
           verbs:
           - get

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	openshiftconfig "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
 	mcfg "github.com/openshift/api/machineconfiguration/v1"
 	operators "github.com/operator-framework/api/pkg/operators/v2"
@@ -54,6 +55,7 @@ func init() {
 	utilruntime.Must(mapi.AddToScheme(scheme))
 	utilruntime.Must(operators.AddToScheme(scheme))
 	utilruntime.Must(mcfg.Install(scheme))
+	utilruntime.Must(openshiftconfig.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -199,6 +201,16 @@ func main() {
 	}
 	if err = nodeReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Node controller")
+		os.Exit(1)
+	}
+
+	registryReconciler, err := controllers.NewRegistryReconciler(mgr, clusterConfig, watchNamespace)
+	if err != nil {
+		setupLog.Error(err, "unable to create registry reconciler")
+		os.Exit(1)
+	}
+	if err = registryReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create registry controller")
 		os.Exit(1)
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -150,6 +150,22 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - imagedigestmirrorsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - imagetagmirrorsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   verbs:
   - get

--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	config "github.com/openshift/api/config/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
+)
+
+//+kubebuilder:rbac:groups="config.openshift.io",resources=imagedigestmirrorsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="config.openshift.io",resources=imagetagmirrorsets,verbs=get;list;watch
+
+const (
+	// RegistryController is the name of this controller in logs and other outputs.
+	RegistryController = "registry"
+)
+
+// registryReconciler holds the info required to reconcile image registry settings on Windows nodes
+type registryReconciler struct {
+	instanceReconciler
+}
+
+// NewRegistryReconciler returns a pointer to a new registryReconciler
+func NewRegistryReconciler(mgr manager.Manager, clusterConfig cluster.Config,
+	watchNamespace string) (*registryReconciler, error) {
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("error creating kubernetes clientset: %w", err)
+	}
+
+	return &registryReconciler{
+		instanceReconciler: instanceReconciler{
+			client:             mgr.GetClient(),
+			log:                ctrl.Log.WithName("controllers").WithName(RegistryController),
+			k8sclientset:       clientset,
+			clusterServiceCIDR: clusterConfig.Network().GetServiceCIDR(),
+			watchNamespace:     watchNamespace,
+			recorder:           mgr.GetEventRecorderFor(RegistryController),
+		},
+	}, nil
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which reads that state of the cluster for objects
+// related to image registry config and aims to move the current state of the cluster closer to the desired state.
+func (r *registryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	r.log = r.log.WithValues(RegistryController, req.NamespacedName)
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *registryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&config.ImageDigestMirrorSet{}).
+		Watches(&config.ImageTagMirrorSet{}, &handler.EnqueueRequestForObject{}).
+		Complete(r)
+}

--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -79,6 +79,7 @@ func (r *registryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 
 	_ = registries.NewRegistryConfig(imageDigestMirrorSetList.Items, imageTagMirrorSetList.Items)
+	// TODO: transfer generated config files to Windows nodes as part of WINC-1222
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -1,0 +1,139 @@
+package registries
+
+import (
+	"sort"
+
+	config "github.com/openshift/api/config/v1"
+)
+
+// mirror represents a mirrored image repo entry in a registry configuration file
+type mirror struct {
+	host string
+	// resolveTags indicates to the container runtime if this mirror is allowed to resolve an image tag into a digest
+	resolveTags bool
+}
+
+// mirrorSet holds the mirror registry information for a single source image repo
+type mirrorSet struct {
+	// source is the image repo to be mirrored
+	source string
+	// mirrors represents mirrored repository locations to pull images from rather than the default source
+	mirrors []mirror
+	// mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors
+	mirrorSourcePolicy config.MirrorSourcePolicy
+}
+
+// registryConfig represents a system-wide image registry configuration
+type registryConfig struct {
+	sourceConfigs []mirrorSet
+}
+
+// NewRegistryConfig creates a new RegistryConfig object by extracting and merging the contents of the given mirror sets
+func NewRegistryConfig(idmsItems []config.ImageDigestMirrorSet, idtsItems []config.ImageTagMirrorSet) *registryConfig {
+	// Each member of the allMirrorSets collection represents the registry configuration for a specific source
+	var allMirrorSets []mirrorSet
+
+	for _, idms := range idmsItems {
+		for _, entry := range idms.Spec.ImageDigestMirrors {
+			set := &mirrorSet{
+				source:             entry.Source,
+				mirrorSourcePolicy: entry.MirrorSourcePolicy,
+			}
+			for _, image := range entry.Mirrors {
+				set.mirrors = append(set.mirrors, mirror{host: string(image), resolveTags: false})
+			}
+			allMirrorSets = append(allMirrorSets, *set)
+		}
+	}
+	for _, itms := range idtsItems {
+		for _, entry := range itms.Spec.ImageTagMirrors {
+			set := &mirrorSet{
+				source:             entry.Source,
+				mirrorSourcePolicy: entry.MirrorSourcePolicy,
+			}
+			for _, image := range entry.Mirrors {
+				set.mirrors = append(set.mirrors, mirror{host: string(image), resolveTags: true})
+			}
+			allMirrorSets = append(allMirrorSets, *set)
+		}
+	}
+
+	return &registryConfig{sourceConfigs: mergeMirrorSets(allMirrorSets)}
+}
+
+// mergeMirrorSets consolidates duplicate entries in the given slice (based on the source) since we do not want to
+// generate multiple config files for the same source image repo. Output is sorted to ensure it is deterministic.
+func mergeMirrorSets(baseMirrorSets []mirrorSet) []mirrorSet {
+	// Map to keep track of unique mirrorSets by source
+	uniqueMirrorSets := make(map[string]mirrorSet)
+
+	for _, ms := range baseMirrorSets {
+		if existingMS, ok := uniqueMirrorSets[ms.source]; ok {
+			// If the source already exists, merge its mirrors slices
+			existingMS.mirrors = mergeMirrors(existingMS.mirrors, ms.mirrors)
+			// If the existing source's mirrorSourcePolicy conflicts, NeverContactSource is preferred
+			if existingMS.mirrorSourcePolicy == config.AllowContactingSource {
+				existingMS.mirrorSourcePolicy = ms.mirrorSourcePolicy
+			}
+			// Update the map entry
+			uniqueMirrorSets[ms.source] = existingMS
+		} else {
+			// If it does not exist, add it to the map
+			uniqueMirrorSets[ms.source] = ms
+		}
+	}
+
+	// Convert the map back to a slice with no duplicates sources
+	var result []mirrorSet
+	for _, ms := range uniqueMirrorSets {
+		result = append(result, ms)
+	}
+
+	sortMirrorSets(result)
+	return result
+}
+
+// sortMirrorSets sorts the mirrorSets and each set of underlying mirrors aplhabetically. Modifies the parameter in place
+func sortMirrorSets(mirrorSets []mirrorSet) {
+	// Sort mirrors by host alphabetically within each mirrorSet
+	for i := range mirrorSets {
+		sort.Slice(mirrorSets[i].mirrors, func(j, k int) bool {
+			return mirrorSets[i].mirrors[j].host < mirrorSets[i].mirrors[k].host
+		})
+	}
+	// Sort mirrorSets by source alphabetically
+	sort.Slice(mirrorSets, func(i, j int) bool {
+		return mirrorSets[i].source < mirrorSets[j].source
+	})
+}
+
+// mergeMirrors consolidates duplicate mirrors in the given slice (based on the host) since we do not want to
+// generate multiple entries in a single config file for the same mirror repo
+func mergeMirrors(existingMirrors, newMirrors []mirror) []mirror {
+	// Map to keep track of unique mirrors by host
+	uniqueMirrors := make(map[string]mirror)
+
+	// Iterate over existing mirrors and add them to the map
+	for _, m := range existingMirrors {
+		uniqueMirrors[m.host] = m
+	}
+	// Iterate over new mirrors
+	for _, m := range newMirrors {
+		if existingM, ok := uniqueMirrors[m.host]; ok {
+			// If the mirror already exists, check the resolveTags field. Resolving by tag is preferred over by digest.
+			if !existingM.resolveTags && m.resolveTags {
+				uniqueMirrors[m.host] = m
+			}
+		} else {
+			// If the mirror does not exist, add it to the map
+			uniqueMirrors[m.host] = m
+		}
+	}
+
+	// Convert the map back to a slice with no duplicates mirrors
+	var result []mirror
+	for _, m := range uniqueMirrors {
+		result = append(result, m)
+	}
+	return result
+}

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -1,0 +1,235 @@
+package registries
+
+import (
+	"testing"
+
+	config "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMirrorSets(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input []mirrorSet
+		// expectedOutput's sources and mirror orders matter since result is expected to be sorted alphabetically
+		expectedOutput []mirrorSet
+	}{
+		{
+			name: "same source but different mirrors",
+			input: []mirrorSet{
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"example.io/example/ubi-minimal", false},
+						{"example.com/example/ubi-minimal", true},
+					},
+				},
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.net/image", false},
+						{"mirror.example.com/redhat", true},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"example.com/example/ubi-minimal", true},
+						{"example.io/example/ubi-minimal", false},
+						{"mirror.example.com/redhat", true},
+						{"mirror.example.net/image", false},
+					},
+				},
+			},
+		},
+		{
+			name: "same source, ensuring mirrorSourcePolicy is handled correctly",
+			input: []mirrorSet{
+				{
+					source:             "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrorSourcePolicy: config.NeverContactSource,
+				},
+				{
+					source:             "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+				{
+					source:             "quay.io/openshift-release-dev/ocp-release",
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+				{
+					source:             "quay.io/openshift-release-dev/ocp-release",
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source:             "quay.io/openshift-release-dev/ocp-release",
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+				{
+					source:             "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrorSourcePolicy: config.NeverContactSource,
+				},
+			},
+		},
+		{
+			name: "same source and duplicated mirrors, ensuring resolveTags is handled correctly",
+			input: []mirrorSet{
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.net/image", false},
+						{"mirror.example.com/redhat", false},
+					},
+				},
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.net/image", false},
+						{"mirror.example.com/redhat", true},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.com/redhat", true},
+						{"mirror.example.net/image", false},
+					},
+				},
+			},
+		},
+		{
+			name: "different sources",
+			input: []mirrorSet{
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.com/redhat", false},
+						{"mirror.example.net/image", false},
+					},
+				},
+				{
+					source: "quay.io/openshift-release-dev/ocp-release",
+					mirrors: []mirror{
+						{"mirror.registry.com:443/ocp/release", false},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source: "quay.io/openshift-release-dev/ocp-release",
+					mirrors: []mirror{
+						{"mirror.registry.com:443/ocp/release", false},
+					},
+				},
+				{
+					source: "registry.access.redhat.com/ubi9/ubi-minimal",
+					mirrors: []mirror{
+						{"mirror.example.com/redhat", false},
+						{"mirror.example.net/image", false},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := mergeMirrorSets(test.input)
+			assert.Equal(t, out, test.expectedOutput)
+		})
+	}
+}
+
+func TestMergeMirrors(t *testing.T) {
+	testCases := []struct {
+		name            string
+		mirrorsA        []mirror
+		mirrorsB        []mirror
+		expectedMirrors []mirror
+	}{
+		{
+			name:            "no mirrors",
+			mirrorsA:        []mirror{},
+			mirrorsB:        []mirror{},
+			expectedMirrors: []mirror{},
+		},
+		{
+			name: "one empty slice",
+			mirrorsA: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+			mirrorsB: []mirror{},
+			expectedMirrors: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+		},
+		{
+			name: "duplicate mirror",
+			mirrorsA: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+			mirrorsB: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+			expectedMirrors: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+		},
+		{
+			name: "duplicate host but different resolveTags",
+			mirrorsA: []mirror{
+				{host: "openshift.com", resolveTags: false},
+			},
+			mirrorsB: []mirror{
+				{host: "openshift.com", resolveTags: true},
+			},
+			expectedMirrors: []mirror{
+				{host: "openshift.com", resolveTags: true},
+			},
+		},
+		{
+			name: "different mirrors",
+			mirrorsA: []mirror{
+				{host: "redhat.com", resolveTags: false},
+			},
+			mirrorsB: []mirror{
+				{host: "openshift.com", resolveTags: true},
+			},
+			expectedMirrors: []mirror{
+				{host: "redhat.com", resolveTags: false},
+				{host: "openshift.com", resolveTags: true},
+			},
+		},
+		{
+			name: "multiple mirrors",
+			mirrorsA: []mirror{
+				{host: "redhat.com", resolveTags: false},
+				{host: "openshift.com", resolveTags: true},
+				{host: "example.test.io", resolveTags: true},
+			},
+			mirrorsB: []mirror{
+				{host: "openshift.com", resolveTags: true},
+				{host: "example.test.io", resolveTags: true},
+			},
+			expectedMirrors: []mirror{
+				{host: "redhat.com", resolveTags: false},
+				{host: "openshift.com", resolveTags: true},
+				{host: "example.test.io", resolveTags: true},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := mergeMirrors(test.mirrorsA, test.mirrorsB)
+			assert.Equal(t, len(out), len(test.expectedMirrors))
+			for _, m := range test.expectedMirrors {
+				assert.Contains(t, out, m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Goal:
WMCO to create config files compatible with containerd from cluster's mirror registry settings

Approach: 
- introducing a "registry controller" to WMCO which watches to ImageDigestMirrorSet and ImageTagMirrorSet resources
- The controller generates a set of `hosts.toml` containerd config files when cluster settings are updated