### PR TITLE
[doc] Remove stale references to networking doc

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -12,8 +12,8 @@ oc logs -f deployment/windows-machine-config-operator -n openshift-windows-machi
 File a GitHub issue and attach the logs to the issue along with the *MachineSet* used.
 
 ## Windows Server 2019 LTSC (1809) nodes never become Ready
-Ensure that you have not configured the cluster with a
-[custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) as that is not a supported feature in 1809.
+Ensure that you have not [configured the cluster network](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html) with a
+custom VXLAN port, as that is not a supported feature in 1809.
 
 ## Accessing a Windows node
 Windows nodes cannot be accessed using `oc debug node` as that requires running a privileged pod on the node which is

--- a/docs/vsphere-golden-image.md
+++ b/docs/vsphere-golden-image.md
@@ -8,7 +8,7 @@ Currently, the Windows Machine Config Operator (WMCO) stable version supports:
 * Windows Server 2022 Long-Term Servicing Channel (must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d))
 
 *Please note that Windows Server 2019 is unsupported, as patch [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351)
-is not included. This is a requirement of the [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere) feature.*
+is not included. This is a requirement of the [hybrid OVN Kubernetes networking with a custom VXLAN port](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html) feature.*
 
 ## 2. Create the virtual machine
 

--- a/docs/vsphere-prerequisites.md
+++ b/docs/vsphere-prerequisites.md
@@ -3,7 +3,7 @@
 In order to successfully use the Windows Machine Config Operator (WMCO) on a vSphere Platform, 
 the following pre-requisites are required:
 
-* The vSphere cluster must be configured with [hybrid OVN Kubernetes networking with a custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vSphere)
+* The vSphere cluster must be configured with [hybrid OVN Kubernetes networking with a custom VXLAN port](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html)
   to work around the pod-to-pod connectivity between hosts [issue](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere)
 * Set up a [VM golden image with a compatible Windows Server version](vsphere-golden-image.md#1-select-a-compatible-windows-server-version).
 * Add a [DNS entry](#adding-a-dns-entry-in-vsphere-environment) for the internal API endpoint in the vSphere environment

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -37,7 +37,7 @@ these errors, only use the appropriate version according to the cloud provider i
 *Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
 
 ## Supported Networking
-[OVNKubernetes hybrid networking](setup-hybrid-OVNKubernetes-cluster.md) is the only supported networking configuration.
+[OVNKubernetes hybrid networking](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html) is the only supported networking configuration.
 The following tables outline the type of networking configuration and Windows Server versions to be used based on your 
 cloud provider. The network configuration must be completed during the installation of the cluster.
   
@@ -50,7 +50,7 @@ Note:
 | AWS            | Hybrid OVNKubernetes                                                                           |
 | Azure          | Hybrid OVNKubernetes                                                                           |
 | GCP            | Hybrid OVNKubernetes                                                                           |
-| VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](setup-hybrid-OVNKubernetes-cluster.md#vsphere) |
+| VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html) |
 | Nutanix        | Hybrid OVNKubernetes                                                                           |
 
 | Hybrid OVNKubernetes | Supported Windows Server version                                                                                                  |


### PR DESCRIPTION
Point to OpenShift docs instead of stale reference to an internal networking pre-req doc.
The internal doc was removed as part of
https://github.com/openshift/windows-machine-config-operator/pull/1513.