### PR TITLE
WINC-1271: Remove unused CNI config field

### DIFF
--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -91,8 +91,7 @@ $cni_template=@'
         "dns":true
     },
     "ipam":{
-        "type":"host-local",
-        "subnet":"ovn_host_subnet"
+        "type":"host-local"
     },
     "policies":[
     {
@@ -134,8 +133,6 @@ $cni_template=@'
 
 # Generate CNI Config
 $hns_network=Get-HnsNetwork  | where { $_.Name -eq 'HNS_NETWORK'}
-$subnet=$hns_network.Subnets.AddressPrefix
-$cni_template=$cni_template.Replace("ovn_host_subnet",$subnet)
 $provider_address=$hns_network.ManagementIP
 $cni_template=$cni_template.Replace("provider_address",$provider_address)
 

--- a/pkg/nodeconfig/payload/payload_test.go
+++ b/pkg/nodeconfig/payload/payload_test.go
@@ -24,7 +24,6 @@ $cni_template=@'
     },
     "ipam":{
         "type":"host-local",
-        "subnet":"ovn_host_subnet"
     },
     "policies":[
     {
@@ -66,8 +65,6 @@ $cni_template=@'
 
 # Generate CNI Config
 $hns_network=Get-HnsNetwork  | where { $_.Name -eq 'OVNKubernetesHNSNetwork'}
-$subnet=$hns_network.Subnets.AddressPrefix
-$cni_template=$cni_template.Replace("ovn_host_subnet",$subnet)
 $provider_address=$hns_network.ManagementIP
 $cni_template=$cni_template.Replace("provider_address",$provider_address)
 


### PR DESCRIPTION
Removes the subnet field in the IPAM configuration, as it is outside the spec, and not used.
