### PR TITLE
WINC-1180: Use record created for container_network metrics

### DIFF
--- a/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -45,3 +45,9 @@ spec:
     - expr: |
         label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
       record: container_memory_working_set_bytes
+    - expr: |
+        sum(irate(windows_container_network_receive_bytes_total[5m]) * on(container_id) group_left(namespace, pod, interface) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+      record: pod_interface_network:container_network_receive_bytes:irate5m
+    - expr: |
+        sum(irate(windows_container_network_transmit_bytes_total[5m]) * on(container_id) group_left(namespace, pod, interface) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+      record: pod_interface_network:container_network_transmit_bytes_total:irate5m

--- a/config/windows-exporter/prometheusRule.yaml
+++ b/config/windows-exporter/prometheusRule.yaml
@@ -45,3 +45,9 @@ spec:
         - expr: |
             label_replace(windows_container_memory_usage_private_working_set_bytes * on(container_id) group_left(namespace, pod, container) kube_pod_container_info{container_id!=""},"container","","","")
           record: container_memory_working_set_bytes
+        - expr: |
+            sum(irate(windows_container_network_receive_bytes_total[5m]) * on(container_id) group_left(namespace, pod, interface) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+          record: pod_interface_network:container_network_receive_bytes:irate5m
+        - expr: |
+            sum(irate(windows_container_network_transmit_bytes_total[5m]) * on(container_id) group_left(namespace, pod, interface) kube_pod_container_info{container_id!=""}) by (pod,namespace)
+          record: pod_interface_network:container_network_transmit_bytes_total:irate5m

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -275,6 +275,8 @@ func (tc *testContext) testPodMetrics(t *testing.T, podName string) {
 		fmt.Sprintf("pod:container_cpu_usage:sum{pod='%s',namespace='%s'}", podName, tc.workloadNamespace),
 		fmt.Sprintf("sum(container_memory_working_set_bytes{pod='%s',namespace='%s',container='',}) BY (pod, namespace)",
 			podName, tc.workloadNamespace),
+		fmt.Sprintf("pod_interface_network:container_network_receive_bytes:irate5m{pod='%s',namespace='%s'}", podName, tc.workloadNamespace),
+		fmt.Sprintf("pod_interface_network:container_network_transmit_bytes_total:irate5m{pod='%s',namespace='%s'}", podName, tc.workloadNamespace),
 	}
 	for i, query := range queries {
 		t.Run("query "+strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
This commit creates a new Prometheus monitoring rule that uses the newly created record for container_metrics introduced for CMO and console.
Ref:
https://github.com/openshift/console/pull/13759
https://github.com/openshift/cluster-monitoring-operator/pull/2314
![Screenshot from 2024-04-26 15-37-02](https://github.com/openshift/windows-machine-config-operator/assets/35242579/fe920c10-1ebe-4aba-a852-9cbdcdb0efbd)
![image](https://github.com/openshift/windows-machine-config-operator/assets/35242579/33409d71-ac34-418f-9a2b-6a490a60828e)
![Screenshot from 2024-04-26 14-28-16](https://github.com/openshift/windows-machine-config-operator/assets/35242579/fe14a8f9-339d-4f5e-9dbf-fb21805bf26e)
