### PR TITLE
[e2e] bump generated key size

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -561,7 +561,7 @@ func generateCertificate() (string, error) {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -208,7 +208,7 @@ func (tc *testContext) waitForBYOHPrivateKeyUpdate() error {
 // generatePrivateKey generates a random RSA private key
 func generatePrivateKey() ([]byte, error) {
 	var keyData []byte
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, fmt.Errorf("error generating key: %w", err)
 	}


### PR DESCRIPTION
This change increases the size of the generated private keys in the e2e test suite so that it complies with the smaller size of keys in recent openssl version.

See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.3_release_notes/index


- https://github.com/openshift/oc/pull/1652