### PR TITLE
[e2e] Use DNS address in instances CM on vSphere

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -127,7 +127,7 @@ func (tc *testContext) createWindowsInstanceConfigMap(machines *mapi.MachineList
 		Data: make(map[string]string),
 	}
 	for _, machine := range machines.Items {
-		addr, err := controllers.GetAddress(machine.Status.Addresses)
+		addr, err := tc.getAddress(machine.Status.Addresses)
 		if err != nil {
 			return fmt.Errorf("unable to get usable address: %w", err)
 		}

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -72,7 +72,7 @@ func (tc *testContext) testBYOHRemoval(t *testing.T) {
 	// For each node that was deleted, check that all the expected services and proxy configuration have been removed
 	for _, node := range byohNodes {
 		t.Run(node.GetName(), func(t *testing.T) {
-			addr, err := controllers.GetAddress(node.Status.Addresses)
+			addr, err := tc.getAddress(node.Status.Addresses)
 			require.NoError(t, err, "unable to get node address")
 			svcs, err := tc.getWinServices(addr)
 			require.NoError(t, err, "error getting service map")


### PR DESCRIPTION
On vSphere only, force the windows-instances ConfigMap to use instance's DNS
address due to reverse DNS lookup issues in internal infrastructure.
This way the node name will match the hostname, preventing CSR approval issues.