### PR TITLE
WINC-1222: WMCO applies image mirroring settings to Windows instances

### DIFF
--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -21,13 +21,20 @@ import (
 	"fmt"
 
 	config "github.com/openshift/api/config/v1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/registries"
+	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
+	"github.com/openshift/windows-machine-config-operator/pkg/signer"
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
 //+kubebuilder:rbac:groups="config.openshift.io",resources=imagedigestmirrorsets,verbs=get;list;watch
@@ -68,19 +75,37 @@ func NewRegistryReconciler(mgr manager.Manager, clusterConfig cluster.Config,
 func (r *registryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	r.log = r.log.WithValues(RegistryController, req.NamespacedName)
 
-	// List all IDMS/ITMS resources
-	imageDigestMirrorSetList := &config.ImageDigestMirrorSetList{}
-	if err = r.client.List(ctx, imageDigestMirrorSetList); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error getting IDMS list: %w", err)
-	}
-	imageTagMirrorSetList := &config.ImageTagMirrorSetList{}
-	if err = r.client.List(ctx, imageTagMirrorSetList); err != nil {
-		return ctrl.Result{}, fmt.Errorf("error getting ITMS list: %w", err)
+	configFiles, err := registries.GenerateConfigFiles(ctx, r.client)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	_ = registries.NewRegistryConfig(imageDigestMirrorSetList.Items, imageTagMirrorSetList.Items)
-	// TODO: transfer generated config files to Windows nodes as part of WINC-1222
-
+	// Transfer the generated registry config folder to each Windows node, completely replacing any existing config
+	nodes := &core.NodeList{}
+	if err := r.client.List(ctx, nodes, client.MatchingLabels{core.LabelOSStable: "windows"}); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.signer, err = signer.Create(types.NamespacedName{Namespace: r.watchNamespace, Name: secrets.PrivateKeySecret},
+		r.client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to create signer from private key secret: %w", err)
+	}
+	for _, node := range nodes.Items {
+		winInstance, err := r.instanceFromNode(&node)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to create instance object from node: %w", err)
+		}
+		nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+			winInstance, r.signer, nil, nil, r.platform)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)
+		}
+		// TODO: If this flakes for any one node, we have to loop over all nodes again and re-transfer the directory to
+		// all nodes. We should fix this as part of https://issues.redhat.com/browse/WINC-1306
+		if err := nc.Windows.ReplaceDir(configFiles, windows.ContainerdConfigDir); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -153,6 +153,8 @@ if [[ "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
 fi
 
 if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
+  printf "\n####### Testing image mirroring #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  go test ./test/e2e/... -run=TestWMCO/image_mirroring -v -timeout=10m -args $GO_TEST_ARGS
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $GO_TEST_ARGS
   printf "\n####### Testing storage #######\n" >> "$ARTIFACT_DIR"/wmco.log

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeutil"
+	"github.com/openshift/windows-machine-config-operator/pkg/registries"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
@@ -150,6 +151,9 @@ func (nc *nodeConfig) Configure() error {
 	}
 
 	if err := nc.createBootstrapFiles(); err != nil {
+		return err
+	}
+	if err := nc.createRegistryConfigFiles(); err != nil {
 		return err
 	}
 	if cluster.IsProxyEnabled() {
@@ -368,6 +372,15 @@ func (nc *nodeConfig) write(pathToData map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// createRegistryConfigFiles creates all files on the node required for containerd to mirror images
+func (nc *nodeConfig) createRegistryConfigFiles() error {
+	configFiles, err := registries.GenerateConfigFiles(context.TODO(), nc.client)
+	if err != nil {
+		return err
+	}
+	return nc.Windows.ReplaceDir(configFiles, windows.ContainerdConfigDir)
 }
 
 // createFilesFromIgnition returns the contents and write locations on the instance for any file it can create from

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -140,19 +140,29 @@ func mergeMirrors(existingMirrors, newMirrors []mirror) []mirror {
 }
 
 // generateConfig is a serialization method that generates a valid TOML representation from a mirrorSet object.
-// Results in content usable as a containerd image registry configuration file.
+// Results in content usable as a containerd image registry configuration file. Returns empty string if no mirrors exist
 func (ms *mirrorSet) generateConfig() string {
-	result := ""
-
-	if ms.mirrorSourcePolicy == config.AllowContactingSource {
-		result += fmt.Sprintf("server = \"https://%s\"", ms.source)
-		result += "\r\n\r\n"
+	if len(ms.mirrors) == 0 {
+		return ""
 	}
 
+	result := ""
+
+	fallbackServer := ms.source
+	if ms.mirrorSourcePolicy == config.NeverContactSource {
+		// set the fallback server to the first mirror to ensure the source is never contacted, even if all mirrors fail
+		fallbackServer = ms.mirrors[0].host
+	}
+	result += fmt.Sprintf("server = \"https://%s\"", fallbackServer)
+	result += "\r\n\r\n"
+
+	// Each mirror should result in an entry followed by a set of settings for interacting with the mirror host
 	for _, m := range ms.mirrors {
 		result += fmt.Sprintf("[host.\"https://%s\"]", m.host)
 		result += "\r\n"
 
+		// Specify the operations the registry host may perform. IDMS mirrors can only be pulled by directly by digest,
+		// whereas ITMS mirrors have the additional resolve capability, which allows converting a tag name into a digest
 		var hostCapabilities string
 		if m.resolveTags {
 			hostCapabilities = "  capabilities = [\"pull\", \"resolve\"]"

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -1,11 +1,13 @@
 package registries
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 
 	config "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // imagePathSeparator separates the repo name, namespaces, and image name in an OCI-compliant image name
@@ -80,13 +82,9 @@ func extractHostname(fullImage string) string {
 	return parts[0]
 }
 
-// registryConfig represents a system-wide image registry configuration
-type registryConfig struct {
-	sourceConfigs []mirrorSet
-}
-
-// NewRegistryConfig creates a new RegistryConfig object by extracting and merging the contents of the given mirror sets
-func NewRegistryConfig(idmsItems []config.ImageDigestMirrorSet, idtsItems []config.ImageTagMirrorSet) *registryConfig {
+// getMergedMirrorSets extracts and merges the contents of the given mirror sets.
+// The resulting slice of mirrorSets represents a system-wide image registry configuration.
+func getMergedMirrorSets(idmsItems []config.ImageDigestMirrorSet, idtsItems []config.ImageTagMirrorSet) []mirrorSet {
 	// Each member of the allMirrorSets collection represents the registry configuration for a specific source
 	var allMirrorSets []mirrorSet
 
@@ -103,12 +101,16 @@ func NewRegistryConfig(idmsItems []config.ImageDigestMirrorSet, idtsItems []conf
 		}
 	}
 
-	return &registryConfig{sourceConfigs: mergeMirrorSets(allMirrorSets)}
+	return mergeMirrorSets(allMirrorSets)
 }
 
 // mergeMirrorSets consolidates duplicate entries in the given slice (based on the source) since we do not want to
 // generate multiple config files for the same source image repo. Output is sorted to ensure it is deterministic.
 func mergeMirrorSets(baseMirrorSets []mirrorSet) []mirrorSet {
+	if len(baseMirrorSets) == 0 {
+		return []mirrorSet{}
+	}
+
 	// Map to keep track of unique mirrorSets by source
 	uniqueMirrorSets := make(map[string]mirrorSet)
 
@@ -218,4 +220,28 @@ func (ms *mirrorSet) generateConfig() string {
 	}
 
 	return result
+}
+
+// GenerateConfigFiles uses cluster resources to generate the containerd mirror registry configuration files
+func GenerateConfigFiles(ctx context.Context, c client.Client) (map[string][]byte, error) {
+	// List IDMS/ITMS resources
+	imageDigestMirrorSetList := &config.ImageDigestMirrorSetList{}
+	if err := c.List(ctx, imageDigestMirrorSetList); err != nil {
+		return nil, fmt.Errorf("error getting IDMS list: %w", err)
+	}
+	imageTagMirrorSetList := &config.ImageTagMirrorSetList{}
+	if err := c.List(ctx, imageTagMirrorSetList); err != nil {
+		return nil, fmt.Errorf("error getting ITMS list: %w", err)
+	}
+
+	registryConf := getMergedMirrorSets(imageDigestMirrorSetList.Items, imageTagMirrorSetList.Items)
+
+	// configFiles is a map from file path on the Windows node to the file content
+	configFiles := make(map[string][]byte)
+	for _, ms := range registryConf {
+		// fileShortPath is the file path within containerd's config directory
+		fileShortPath := fmt.Sprintf("%s\\hosts.toml", ms.source)
+		configFiles[fileShortPath] = []byte(ms.generateConfig())
+	}
+	return configFiles, nil
 }

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -328,3 +328,82 @@ func TestMergeMirrors(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractMirrorURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		mirror   string
+		expected string
+	}{
+		{
+			name:     "Exact match",
+			source:   "example.com/path/to/resource",
+			mirror:   "example.com/path/to/resource",
+			expected: "",
+		},
+		{
+			name:     "Different domain",
+			source:   "example.com/path/to/resource",
+			mirror:   "example.org/path/to/resource",
+			expected: "example.org",
+		},
+		{
+			name:     "Last letter equal but no namespace match",
+			source:   "example.com/path/to/resource/x",
+			mirror:   "example.com/path/to/resourceax",
+			expected: "example.com/path/to/resourceax",
+		},
+		{
+			name:     "Different tags",
+			source:   "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022",
+			mirror:   "quay.io/powershell:23",
+			expected: "quay.io/powershell:23",
+		},
+		{
+			name:     "Different domain with tag",
+			source:   "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022",
+			mirror:   "quay.io/powershell:lts-nanoserver-ltsc2022",
+			expected: "quay.io",
+		},
+		{
+			name:     "1 leading namespace",
+			source:   "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022",
+			mirror:   "quay.io/random_namespace/powershell:lts-nanoserver-ltsc2022",
+			expected: "quay.io/random_namespace",
+		},
+		{
+			name:     "2 leading namespaces",
+			source:   "mcr.microsoft.com/windows/servercore:ltsc2022",
+			mirror:   "quay.io/mohashai/random_namespace/windows/servercore:ltsc2022",
+			expected: "quay.io/mohashai/random_namespace",
+		},
+		{
+			name:     "Matching higher level namespace",
+			source:   "foo1/fah/different/foo2",
+			mirror:   "foo1/fah/something/foo2",
+			expected: "foo1/fah/something",
+		},
+		{
+			name:     "Matching higher level namespace with longer source",
+			source:   "foo1/fah/hello/different/foo2",
+			mirror:   "foo1/fah/something/foo2",
+			expected: "foo1/fah/something",
+		},
+		{
+			name:     "Matching higher level namespace with longer mirror",
+			source:   "foo1/fah/different/foo2",
+			mirror:   "foo1/fah/hello/something/foo2",
+			expected: "foo1/fah/hello/something",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractMirrorURL(tt.source, tt.mirror)
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -14,11 +14,20 @@ func TestGenerateConfig(t *testing.T) {
 		expectedOutput string
 	}{
 		{
+			name: "empty mirrors",
+			input: mirrorSet{
+				source:             "registry.access.redhat.com/ubi9/ubi-minimal",
+				mirrors:            []mirror{},
+				mirrorSourcePolicy: config.AllowContactingSource,
+			},
+			expectedOutput: "",
+		},
+		{
 			name: "basic one digest mirror",
 			input: mirrorSet{
 				source: "registry.access.redhat.com/ubi9/ubi-minimal",
 				mirrors: []mirror{
-					{"example.io/example/ubi-minimal", false},
+					{host: "example.io/example/ubi-minimal", resolveTags: false},
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
@@ -29,7 +38,7 @@ func TestGenerateConfig(t *testing.T) {
 			input: mirrorSet{
 				source: "registry.access.redhat.com/ubi9/ubi-minimal",
 				mirrors: []mirror{
-					{"example.io/example/ubi-minimal", true},
+					{host: "example.io/example/ubi-minimal", resolveTags: true},
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
@@ -40,35 +49,48 @@ func TestGenerateConfig(t *testing.T) {
 			input: mirrorSet{
 				source: "registry.access.redhat.com/ubi9/ubi-minimal",
 				mirrors: []mirror{
-					{"example.io/example/ubi-minimal", false},
+					{host: "example.io/example/ubi-minimal", resolveTags: false},
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n",
 		},
 		{
-			name: "one tag mirror never contact source",
+			name: "tags mirror never contact source",
 			input: mirrorSet{
 				source: "registry.access.redhat.com/ubi9/ubi-minimal",
 				mirrors: []mirror{
-					{"example.io/example/ubi-minimal", true},
+					{host: "example.io/example/ubi-minimal", resolveTags: true},
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
 		},
 		{
 			name: "multiple mirrors",
 			input: mirrorSet{
 				source: "registry.access.redhat.com/ubi9/ubi-minimal",
 				mirrors: []mirror{
-					{"example.io/example/ubi-minimal", false},
-					{"mirror.example.com/redhat", false},
-					{"mirror.example.net/image", true},
+					{host: "example.io/example/ubi-minimal", resolveTags: false},
+					{host: "mirror.example.com/redhat", resolveTags: false},
+					{host: "mirror.example.net/image", resolveTags: true},
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
 			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
+		},
+		{
+			name: "multiple mirrors never contact source",
+			input: mirrorSet{
+				source: "registry.access.redhat.com/ubi9/ubi-minimal",
+				mirrors: []mirror{
+					{host: "example.io/example/ubi-minimal", resolveTags: false},
+					{host: "mirror.example.com/redhat", resolveTags: false},
+					{host: "mirror.example.net", resolveTags: true},
+				},
+				mirrorSourcePolicy: config.NeverContactSource,
+			},
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
 		},
 	}
 

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -7,6 +7,217 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetMergedMirrorSets(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputIDMS      []config.ImageDigestMirrorSet
+		inputITMS      []config.ImageTagMirrorSet
+		expectedOutput []mirrorSet
+	}{
+		{
+			name:           "No items",
+			inputIDMS:      []config.ImageDigestMirrorSet{},
+			inputITMS:      []config.ImageTagMirrorSet{},
+			expectedOutput: []mirrorSet{},
+		},
+		{
+			name: "One IDMS item",
+			inputIDMS: []config.ImageDigestMirrorSet{
+				{
+					Spec: config.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []config.ImageDigestMirrors{
+							{
+								Source:             "source1",
+								Mirrors:            []config.ImageMirror{"mirror1"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+						},
+					},
+				},
+			},
+			inputITMS: []config.ImageTagMirrorSet{},
+			expectedOutput: []mirrorSet{
+				{
+					source:             "source1",
+					mirrors:            []mirror{{host: "mirror1", resolveTags: false}},
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+			},
+		},
+		{
+			name:      "One ITMS item",
+			inputIDMS: []config.ImageDigestMirrorSet{},
+			inputITMS: []config.ImageTagMirrorSet{
+				{
+					Spec: config.ImageTagMirrorSetSpec{
+						ImageTagMirrors: []config.ImageTagMirrors{
+							{
+								Source:             "source2",
+								Mirrors:            []config.ImageMirror{"mirror2"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source:             "source2",
+					mirrors:            []mirror{{host: "mirror2", resolveTags: true}},
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+			},
+		},
+		{
+			name: "1 IDMS and 1 ITMS",
+			inputIDMS: []config.ImageDigestMirrorSet{
+				{
+					Spec: config.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []config.ImageDigestMirrors{
+							{
+								Source:             "source1",
+								Mirrors:            []config.ImageMirror{"mirror1"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+						},
+					},
+				},
+			},
+			inputITMS: []config.ImageTagMirrorSet{
+				{
+					Spec: config.ImageTagMirrorSetSpec{
+						ImageTagMirrors: []config.ImageTagMirrors{
+							{
+								Source:             "source2",
+								Mirrors:            []config.ImageMirror{"mirror2"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source:             "source1",
+					mirrors:            []mirror{{host: "mirror1", resolveTags: false}},
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+				{
+					source:             "source2",
+					mirrors:            []mirror{{host: "mirror2", resolveTags: true}},
+					mirrorSourcePolicy: config.AllowContactingSource,
+				},
+			},
+		},
+		{
+			name: "Mix of overlapping IDMS and 1 ITMS",
+			inputIDMS: []config.ImageDigestMirrorSet{
+				{
+					Spec: config.ImageDigestMirrorSetSpec{
+						ImageDigestMirrors: []config.ImageDigestMirrors{
+							{
+								Source:             "vmc.ci.openshift.org/ci-op/pipeline",
+								Mirrors:            []config.ImageMirror{"devcluster.openshift.com:5000/pipeline"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+						},
+					},
+				},
+			},
+			inputITMS: []config.ImageTagMirrorSet{
+				{
+					Spec: config.ImageTagMirrorSetSpec{
+						ImageTagMirrors: []config.ImageTagMirrors{
+							{
+								Source:             "mcr.microsoft.com/oss/kubernetes/pause",
+								Mirrors:            []config.ImageMirror{"quay.io/testuser/oss/kubernetes/pause"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+							{
+								Source:             "mcr.microsoft.com/powershell",
+								Mirrors:            []config.ImageMirror{"quay.io/testuser/testnamespace/powershell"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+							{
+								Source:             "registry.k8s.io/sig-storage/csi-provisioner",
+								Mirrors:            []config.ImageMirror{"devcluster.openshift.com:5000/sig-storage/csi-provisioner"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+							{
+								Source:             "registry.access.redhat.com/ubi9/ubi-minimal",
+								Mirrors:            []config.ImageMirror{"devcluster.openshift.com:5000/ubi9/ubi-minimal"},
+								MirrorSourcePolicy: config.AllowContactingSource,
+							},
+							{
+								Source:             "registry.access.redhat.com/ubi8/ubi-minimal",
+								Mirrors:            []config.ImageMirror{"random.io/ubi8/ubi-minimal"},
+								MirrorSourcePolicy: config.NeverContactSource,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: []mirrorSet{
+				{
+					source: "mcr.microsoft.com",
+					mirrors: []mirror{
+						{
+							host:        "quay.io/testuser",
+							resolveTags: true,
+						},
+						{
+							host:        "quay.io/testuser/testnamespace",
+							resolveTags: true,
+						},
+					},
+					mirrorSourcePolicy: "AllowContactingSource"},
+				{
+					source: "registry.access.redhat.com",
+					mirrors: []mirror{
+						{
+							host:        "devcluster.openshift.com:5000",
+							resolveTags: true,
+						},
+						{
+							host:        "random.io",
+							resolveTags: true,
+						},
+					},
+					mirrorSourcePolicy: "NeverContactSource",
+				},
+				{
+					source: "registry.k8s.io",
+					mirrors: []mirror{
+						{
+							host:        "devcluster.openshift.com:5000",
+							resolveTags: true,
+						},
+					},
+					mirrorSourcePolicy: "AllowContactingSource",
+				},
+				{
+					source: "vmc.ci.openshift.org",
+					mirrors: []mirror{
+						{
+							host:        "devcluster.openshift.com:5000",
+							resolveTags: false,
+						},
+					},
+					mirrorSourcePolicy: "AllowContactingSource",
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := getMergedMirrorSets(test.inputIDMS, test.inputITMS)
+			assert.Equal(t, test.expectedOutput, out)
+			//assert.True(t, reflect.DeepEqual(out, test.expectedOutput))
+		})
+	}
+}
+
 func TestGenerateConfig(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -109,6 +320,11 @@ func TestMergeMirrorSets(t *testing.T) {
 		// expectedOutput's sources and mirror orders matter since result is expected to be sorted alphabetically
 		expectedOutput []mirrorSet
 	}{
+		{
+			name:           "empty mirrorset",
+			input:          []mirrorSet{},
+			expectedOutput: []mirrorSet{},
+		},
 		{
 			name: "same source but different mirrors",
 			input: []mirrorSet{

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -58,8 +58,8 @@ const (
 	ContainerdPath = ContainerdDir + "\\containerd.exe"
 	// ContainerdConfPath is the location of containerd config file
 	ContainerdConfPath = ContainerdDir + "\\containerd_conf.toml"
-	// containerdConfigDir is the remote directory for containerd registry config
-	containerdConfigDir = ContainerdDir + "\\registries"
+	// ContainerdConfigDir is the remote directory for containerd registry config
+	ContainerdConfigDir = ContainerdDir + "\\registries"
 	// containerdLogDir is the remote containerd log directory
 	containerdLogDir = logDir + "\\containerd"
 	// ContainerdLogPath is the location of the containerd log file
@@ -165,7 +165,7 @@ var (
 		HybridOverlayLogDir,
 		ContainerdDir,
 		containerdLogDir,
-		containerdConfigDir,
+		ContainerdConfigDir,
 		podManifestDirectory,
 		K8sDir,
 	}
@@ -238,6 +238,9 @@ type Windows interface {
 	// FileExists returns true if a specific file exists at the given path and checksum on the Windows VM. Set an
 	// empty checksum (checksum == "") to disable checksum check.
 	FileExists(string, string) (bool, error)
+	// ReplaceDir transfers the given files to their given paths within the remote directory the Windows instance.
+	// The destination dir will only contain the given files after this function is called, clearing existing content.
+	ReplaceDir(map[string][]byte, string) error
 	// Run executes the given command remotely on the Windows VM over a ssh connection and returns the combined output
 	// of stdout and stderr. If the bool is set, it implies that the cmd is to be execute in PowerShell. This function
 	// should be used in scenarios where you want to execute a command that runs in the background. In these cases we
@@ -335,7 +338,18 @@ func (vm *windows) EnsureFileContent(contents []byte, filename string, remoteDir
 		return nil
 	}
 	vm.log.V(1).Info("copy", "file content", filename, "remote dir", remoteDir)
-	if err := vm.interact.transfer(bytes.NewReader(contents), filename, remoteDir); err != nil {
+
+	c, err := vm.interact.createSFTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create SFTP client: %w", err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			vm.log.Error(err, "error closing SFTP connection")
+		}
+	}()
+
+	if err := vm.interact.transfer(c, bytes.NewReader(contents), filename, remoteDir); err != nil {
 		return fmt.Errorf("unable to copy %s content to remote dir %s: %w", filename, remoteDir, err)
 	}
 	return nil
@@ -362,7 +376,18 @@ func (vm *windows) EnsureFile(file *payload.FileInfo, remoteDir string) error {
 		}
 	}()
 	vm.log.V(1).Info("copy", "local file", file.Path, "remote dir", remoteDir)
-	if err := vm.interact.transfer(f, filepath.Base(file.Path), remoteDir); err != nil {
+
+	c, err := vm.interact.createSFTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create SFTP client: %w", err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			vm.log.Error(err, "error closing SFTP connection")
+		}
+	}()
+
+	if err := vm.interact.transfer(c, f, filepath.Base(file.Path), remoteDir); err != nil {
 		return fmt.Errorf("unable to transfer %s to remote dir %s: %w", file.Path, remoteDir, err)
 	}
 	return nil
@@ -389,6 +414,32 @@ func (vm *windows) FileExists(path, checksum string) (bool, error) {
 	}
 	// file exist with diff content
 	return false, nil
+}
+
+func (vm *windows) ReplaceDir(files map[string][]byte, remoteDir string) error {
+	vm.log.V(1).Info("overwriting", "remote destination dir", remoteDir, "number of files", len(files))
+
+	if out, err := vm.Run(rmDirCmd(remoteDir), true); err != nil {
+		return fmt.Errorf("unable to remove directory %s, out: %s, err: %s", remoteDir, out, err)
+	}
+	if out, err := vm.Run(mkdirCmd(remoteDir), false); err != nil {
+		return fmt.Errorf("unable to create remote directory %s, out: %s: %w", remoteDir, out, err)
+	}
+
+	sftpClient, err := vm.interact.createSFTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create SFTP client: %w", err)
+	}
+	defer func() {
+		if err := sftpClient.Close(); err != nil {
+			vm.log.Error(err, "error closing SFTP connection")
+		}
+	}()
+
+	if err = vm.interact.transferFiles(sftpClient, files, remoteDir); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (vm *windows) Run(cmd string, psCmd bool) (string, error) {

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -33,6 +33,7 @@ const remotePowerShellCmdPrefix = "powershell.exe -NonInteractive -ExecutionPoli
 func deletionTestSuite(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
+	t.Run("Mirror settings cleared from nodes", tc.testMirrorSettingsCleared)
 	t.Run("Deletion", tc.testWindowsNodeDeletion)
 }
 

--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -1,0 +1,188 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	config "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/windows-machine-config-operator/controllers"
+	"github.com/openshift/windows-machine-config-operator/pkg/retry"
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
+)
+
+const (
+	testMirrorSetName               = "e2e-powershell-mirror"
+	upstreamPowershellImageLocation = "mcr.microsoft.com/powershell"
+	badPowershellImageLocation      = "test.registry.io/powershell"
+)
+
+// numBaseRegistryConfigFiles represents the number of registry config files that exist before this test suite's steps run
+var numBaseRegistryConfigFiles int
+
+func testImageMirroring(t *testing.T) {
+	tc, err := NewTestContext()
+	require.NoError(t, err)
+
+	require.NoError(t, tc.loadExistingNodes(), "error getting the current Windows nodes in the cluster")
+
+	require.NoError(t, tc.setNumBaseRegistryConfigFiles(), "error getting base number of registry config files")
+
+	if !t.Run("Mirror settings applied to nodes", tc.testMirrorSettingsApplied) {
+		// No point in running the rest of the tests if settings aren't applied
+		return
+	}
+}
+
+// setNumBaseRegistryConfigFiles updates the numBaseRegistryConfigFiles variable
+func (tc *testContext) setNumBaseRegistryConfigFiles() error {
+	winNodes := gc.allNodes()
+	if len(winNodes) == 0 {
+		return fmt.Errorf("test requires at least one Windows node to run")
+	}
+	addr, err := controllers.GetAddress(winNodes[0].Status.Addresses)
+	if err != nil {
+		return fmt.Errorf("unable to get node address: %w", err)
+	}
+	numBaseRegistryConfigFiles, err = tc.countItemsInDir(windows.ContainerdConfigDir, addr)
+	if err != nil {
+		return fmt.Errorf("error counting items in dir %s on node %s: %w", windows.ContainerdConfigDir, addr, err)
+	}
+	return nil
+}
+
+// testMirrorSettingsApplied tests that the containerd registry configuration directory is populated
+func (tc *testContext) testMirrorSettingsApplied(t *testing.T) {
+	// enables this test suite to run independently of the creation tests
+	itms, err := tc.ensureMirrorSetExists()
+	require.NoErrorf(t, err, "error ensuring mirror set %s exists", testMirrorSetName)
+	// expected one config file per source entry
+	expectedNumConfigFiles := len(itms.Spec.ImageTagMirrors) + numBaseRegistryConfigFiles
+
+	for _, node := range gc.allNodes() {
+		t.Run(node.Name, func(t *testing.T) {
+			addr, err := controllers.GetAddress(node.Status.Addresses)
+			require.NoError(t, err, "unable to get node address")
+
+			// retry to give time for registry controller to transfer generated config to all nodes
+			err = wait.PollUntilContextTimeout(context.TODO(), retry.Interval, 5*time.Minute, true,
+				func(ctx context.Context) (done bool, err error) {
+					count, err := tc.countItemsInDir(windows.ContainerdConfigDir, addr)
+					require.NoErrorf(t, err, "error counting items in dir %s on node %s", windows.ContainerdConfigDir, addr)
+					return count == expectedNumConfigFiles, nil
+				})
+			assert.NoError(t, err, "error waiting for mirror settings to be applied")
+		})
+	}
+}
+
+// testMirrorSettingsCleared tests that the containerd registry config directory does not contain any config settings
+func (tc *testContext) testMirrorSettingsCleared(t *testing.T) {
+	require.NoError(t, tc.safeDeleteMirrorSet())
+
+	for _, node := range gc.allNodes() {
+		t.Run(node.Name, func(t *testing.T) {
+			addr, err := controllers.GetAddress(node.Status.Addresses)
+			require.NoError(t, err, "unable to get node address")
+
+			// retry to give time for registry controller to clear settings from all nodes
+			err = wait.PollUntilContextTimeout(context.TODO(), retry.Interval, 5*time.Minute, true,
+				func(ctx context.Context) (done bool, err error) {
+					count, err := tc.countItemsInDir(windows.ContainerdConfigDir, addr)
+					require.NoErrorf(t, err, "error counting items in dir %s on node %s", windows.ContainerdConfigDir, addr)
+					return count == numBaseRegistryConfigFiles, nil
+				})
+			assert.NoError(t, err, "error waiting for mirror settings to be cleared")
+		})
+	}
+}
+
+// safeDeleteMirrorSet deletes the test suite's ITMS resource if it exists, and waits for deletion to complete
+func (tc *testContext) safeDeleteMirrorSet() error {
+	// Check if mirror set exists, do nothing if it already doesn't exist
+	_, err := tc.client.Config.ConfigV1().ImageTagMirrorSets().Get(context.TODO(), testMirrorSetName, meta.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	err = tc.client.Config.ConfigV1().ImageTagMirrorSets().Delete(context.TODO(), testMirrorSetName, meta.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("error deleting %s: %w", testMirrorSetName, err)
+	}
+	return tc.waitForMirrorSetDeletion()
+}
+
+// waitForMirrorSetDeletion waits for a test ITMS to deleted. Returns an error if it is still present at the time limit.
+func (tc *testContext) waitForMirrorSetDeletion() error {
+	err := wait.PollUntilContextTimeout(context.TODO(), retry.Interval, retry.ResourceChangeTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := tc.client.Config.ConfigV1().ImageTagMirrorSets().Get(context.TODO(), testMirrorSetName, meta.GetOptions{})
+			if err == nil {
+				// Retry if the resource is found
+				return false, nil
+			}
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("error retrieving ITMS: %s: %w", testMirrorSetName, err)
+		})
+	if err != nil {
+		return fmt.Errorf("error waiting for ITMS deletion %s: %w", testMirrorSetName, err)
+	}
+	return nil
+}
+
+// countItemsInDir runs a job on the given instance address to count the number of items in the given directory
+func (tc *testContext) countItemsInDir(remoteDir, address string) (int, error) {
+	countDirsCommand := fmt.Sprintf("(Get-ChildItem -Path %s).Count", remoteDir)
+	out, err := tc.runPowerShellSSHJob("check-registry-config-files", countDirsCommand, address)
+	if err != nil {
+		return 0, fmt.Errorf("error running SSH job: %w", err)
+	}
+	// Final line should contain a single number representing the number of dirs and files found in the remote dir
+	count, err := strconv.Atoi(finalLine(out))
+	if err != nil {
+		return 0, fmt.Errorf("job result is not an integer: %w", err)
+	}
+	return count, nil
+}
+
+// ensureMirrorSetExists creates the test mirror set if it does not exist
+func (tc *testContext) ensureMirrorSetExists() (*config.ImageTagMirrorSet, error) {
+	itms, err := tc.client.Config.ConfigV1().ImageTagMirrorSets().Get(context.TODO(), testMirrorSetName, meta.GetOptions{})
+	if err == nil {
+		return itms, nil
+	}
+	if errors.IsNotFound(err) {
+		return tc.createMirrorSet()
+	}
+	return nil, fmt.Errorf("error creating mirror set: %w", err)
+}
+
+// createMirrorSet creates a cluster resource to mirror an image reference from an invalid source to the real location
+func (tc *testContext) createMirrorSet() (*config.ImageTagMirrorSet, error) {
+	itms := &config.ImageTagMirrorSet{
+		ObjectMeta: meta.ObjectMeta{
+			Name: testMirrorSetName,
+		},
+		Spec: config.ImageTagMirrorSetSpec{
+			ImageTagMirrors: []config.ImageTagMirrors{{
+				Source:             badPowershellImageLocation,
+				Mirrors:            []config.ImageMirror{upstreamPowershellImageLocation},
+				MirrorSourcePolicy: config.AllowContactingSource,
+			}},
+		},
+	}
+	// Create the ImageTagMirrorSet in the cluster
+	return tc.client.Config.ConfigV1().ImageTagMirrorSets().Create(context.TODO(), itms, meta.CreateOptions{})
+}

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -52,6 +52,7 @@ func TestWMCO(t *testing.T) {
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
+	t.Run("image mirroring", testImageMirroring)
 	t.Run("network", testNetwork)
 	t.Run("storage", testStorage)
 	t.Run("service reconciliation", testDependentServiceChanges)


### PR DESCRIPTION
- [WINC-1222](https://issues.redhat.com//browse/WINC-1222): WMCO applies image mirroring settings to Windows instances
- [WINC-1294](https://issues.redhat.com//browse/WINC-1294): Support token-based auth for mirror registries

This PR transfers containerd registry config files generated by WMCO to
each Windows instance based on the cluster's global image mirroring settings,
allowing containerd to pull Windows images from user-defined mirror locations.

The containerd daemon picks up the registry config without requiring restart.

Containerd also becomes auth-aware in order to support pulling images from secure registries.
We add a header field to each host listed in hosts.tomls with the repo's auth token.
The token for each mirror is taken from cluster's global pull secret.