### PR TITLE
Improve logging for malformed RBAC reconciliation and use context for WICD rbac operations

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -182,6 +182,7 @@ func main() {
 			watchNamespace)
 		os.Exit(1)
 	}
+	setupLog.Info("operator", "namespace", watchNamespace)
 
 	// Setup all Controllers
 	winMachineReconciler, err := controllers.NewWindowsMachineReconciler(mgr, clusterConfig, watchNamespace)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -269,7 +269,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := configMapReconciler.EnsureWICDRBAC(); err != nil {
+	if err := configMapReconciler.EnsureWICDRBAC(ctx); err != nil {
 		setupLog.Error(err, "error ensuring WICD RBAC resources exist", "namespace", watchNamespace)
 		os.Exit(1)
 	}

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -615,7 +615,8 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
 			return fmt.Errorf("unable to delete RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
 		}
 		r.log.Info("Deleted malformed resource", "RoleBinding",
-			kubeTypes.NamespacedName{Namespace: r.watchNamespace, Name: existingRB.Name})
+			kubeTypes.NamespacedName{Namespace: r.watchNamespace, Name: existingRB.Name},
+			"RoleRef", existingRB.RoleRef.Name, "Subjects", existingRB.Subjects)
 	}
 	// create proper resource if it does not exist
 	_, err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Create(context.TODO(), expectedRB,
@@ -663,7 +664,8 @@ func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding() error {
 		if err != nil {
 			return err
 		}
-		r.log.Info("Deleted malformed resource", "ClusterRoleBinding", existingCRB.Name)
+		r.log.Info("Deleted malformed resource", "ClusterRoleBinding", existingCRB.Name,
+			"RoleRef", existingCRB.RoleRef.Name, "Subjects", existingCRB.Subjects)
 	}
 	// create proper resource if it does not exist
 	_, err = r.k8sclientset.RbacV1().ClusterRoleBindings().Create(context.TODO(), expectedCRB, meta.CreateOptions{})

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -572,17 +572,17 @@ func (r *ConfigMapReconciler) EnsureTrustedCAConfigMapExists() error {
 }
 
 // EnsureWICDRBAC ensures the WICD RBAC resources exist as expected
-func (r *ConfigMapReconciler) EnsureWICDRBAC() error {
-	if err := r.ensureWICDRoleBinding(); err != nil {
+func (r *ConfigMapReconciler) EnsureWICDRBAC(ctx context.Context) error {
+	if err := r.ensureWICDRoleBinding(ctx); err != nil {
 		return err
 	}
-	return r.ensureWICDClusterRoleBinding()
+	return r.ensureWICDClusterRoleBinding(ctx)
 }
 
 // ensureWICDRoleBinding ensures the WICD RoleBinding resource exists as expected.
 // Creates it if it doesn't exist, deletes and re-creates it if it exists with improper spec.
-func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
-	existingRB, err := r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Get(context.TODO(), wicdRBACResourceName,
+func (r *ConfigMapReconciler) ensureWICDRoleBinding(ctx context.Context) error {
+	existingRB, err := r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Get(ctx, wicdRBACResourceName,
 		meta.GetOptions{})
 	if err != nil && !k8sapierrors.IsNotFound(err) {
 		return fmt.Errorf("unable to get RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
@@ -609,7 +609,7 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
 			reflect.DeepEqual(existingRB.Subjects, expectedRB.Subjects) {
 			return nil
 		}
-		err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Delete(context.TODO(), wicdRBACResourceName,
+		err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Delete(ctx, wicdRBACResourceName,
 			meta.DeleteOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to delete RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
@@ -619,7 +619,7 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
 			"RoleRef", existingRB.RoleRef.Name, "Subjects", existingRB.Subjects)
 	}
 	// create proper resource if it does not exist
-	_, err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Create(context.TODO(), expectedRB,
+	_, err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Create(ctx, expectedRB,
 		meta.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
@@ -631,8 +631,8 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding() error {
 
 // ensureWICDClusterRoleBinding ensures the WICD ClusterRoleBinding resource exists as expected.
 // Creates it if it doesn't exist, deletes and re-creates it if it exists with improper spec.
-func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding() error {
-	existingCRB, err := r.k8sclientset.RbacV1().ClusterRoleBindings().Get(context.TODO(), wicdRBACResourceName,
+func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding(ctx context.Context) error {
+	existingCRB, err := r.k8sclientset.RbacV1().ClusterRoleBindings().Get(ctx, wicdRBACResourceName,
 		meta.GetOptions{})
 	if err != nil && !k8sapierrors.IsNotFound(err) {
 		return err
@@ -659,7 +659,7 @@ func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding() error {
 			reflect.DeepEqual(existingCRB.Subjects, expectedCRB.Subjects) {
 			return nil
 		}
-		err = r.k8sclientset.RbacV1().ClusterRoleBindings().Delete(context.TODO(), wicdRBACResourceName,
+		err = r.k8sclientset.RbacV1().ClusterRoleBindings().Delete(ctx, wicdRBACResourceName,
 			meta.DeleteOptions{})
 		if err != nil {
 			return err
@@ -668,7 +668,7 @@ func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding() error {
 			"RoleRef", existingCRB.RoleRef.Name, "Subjects", existingCRB.Subjects)
 	}
 	// create proper resource if it does not exist
-	_, err = r.k8sclientset.RbacV1().ClusterRoleBindings().Create(context.TODO(), expectedCRB, meta.CreateOptions{})
+	_, err = r.k8sclientset.RbacV1().ClusterRoleBindings().Create(ctx, expectedCRB, meta.CreateOptions{})
 	if err == nil {
 		r.log.Info("Created resource", "ClusterRoleBinding", expectedCRB.Name)
 	}


### PR DESCRIPTION
This PR use context for WICD rbac operations and adds a setup log to show the namespace where the operator is running and expands the details
on the malformed RBAC resources reconciliation. 

**before:**
```
2024-05-08T15:51:54Z	INFO	version	operator	{"version": "10.16.0-53d7bda"}
2024-05-08T15:51:54Z	INFO	version	go	{"version": "go1.21.3 linux/amd64"}
2024-05-08T15:51:54Z	INFO	leader	Trying to become the leader.
2024-05-08T15:51:54Z	DEBUG	leader	Found podname	{"Pod.Name": "windows-machine-config-operator-fcdbdb656-xvkkr"}
2024-05-08T15:51:54Z	DEBUG	leader	Found Pod	{"Pod.Namespace": "windows-operator-one", "Pod.Name": "windows-machine-config-operator-fcdbdb656-xvkkr"}
2024-05-08T15:51:54Z	INFO	leader	No pre-existing lock was found.
2024-05-08T15:51:54Z	INFO	leader	Became the leader.
2024-05-08T15:51:54Z	ERROR	controller.secret	Unable to retrieve private key, please ensure it is created	{"error": "the cache is not started, can not read objects"}
2024-05-08T15:51:54Z	DEBUG	ignition	parsed	{"machineconfig": "rendered-worker-22695463f786ddbf71889e3594a9e7b3", "using ignition version": "3.4.0"}
2024-05-08T15:51:54Z	DEBUG	ignition	processing kubelet-ca	{"ControllerConfig": "machine-config-controller"}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created	{"ConfigMap": {"name":"windows-services-10.16.0-53d7bda","namespace":"windows-operator-one"}}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created resource	{"RoleBinding": {"name":"windows-instance-config-daemon","namespace":"windows-operator-one"}}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Deleted malformed resource	{"ClusterRoleBinding": "windows-instance-config-daemon"}]}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created resource	{"ClusterRoleBinding": "windows-instance-config-daemon"}
2024-05-08T15:51:54Z	INFO	setup	starting manager
```



**after:**
```
2024-05-08T15:51:54Z	INFO	version	operator	{"version": "10.16.0-53d7bda"}
2024-05-08T15:51:54Z	INFO	version	go	{"version": "go1.21.3 linux/amd64"}
2024-05-08T15:51:54Z	INFO	leader	Trying to become the leader.
2024-05-08T15:51:54Z	DEBUG	leader	Found podname	{"Pod.Name": "windows-machine-config-operator-fcdbdb656-xvkkr"}
2024-05-08T15:51:54Z	DEBUG	leader	Found Pod	{"Pod.Namespace": "windows-operator-one", "Pod.Name": "windows-machine-config-operator-fcdbdb656-xvkkr"}
2024-05-08T15:51:54Z	INFO	leader	No pre-existing lock was found.
2024-05-08T15:51:54Z	INFO	leader	Became the leader.
2024-05-08T15:51:54Z	INFO	setup	operator	{"namespace": "windows-operator-one"}
2024-05-08T15:51:54Z	ERROR	controller.secret	Unable to retrieve private key, please ensure it is created	{"error": "the cache is not started, can not read objects"}
2024-05-08T15:51:54Z	DEBUG	ignition	parsed	{"machineconfig": "rendered-worker-22695463f786ddbf71889e3594a9e7b3", "using ignition version": "3.4.0"}
2024-05-08T15:51:54Z	DEBUG	ignition	processing kubelet-ca	{"ControllerConfig": "machine-config-controller"}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created	{"ConfigMap": {"name":"windows-services-10.16.0-53d7bda","namespace":"windows-operator-one"}}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created resource	{"RoleBinding": {"name":"windows-instance-config-daemon","namespace":"windows-operator-one"}}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Deleted malformed resource	{"ClusterRoleBinding": "windows-instance-config-daemon", "RoleRef": "windows-instance-config-daemon", "Subjects": [{"kind":"ServiceAccount","name":"windows-instance-config-daemon","namespace":"openshift-windows-machine-config-operator"}]}
2024-05-08T15:51:54Z	INFO	controllers.configmap	Created resource	{"ClusterRoleBinding": "windows-instance-config-daemon"}
2024-05-08T15:51:54Z	INFO	setup	starting manager
```


**proposed additions:**

 - new  setup log to show the namespace where the operator was installed
- extended controllers.configmap log to include the  RoleRef and Subjects of the malformed resource

```
...
2024-05-08T15:51:54Z	INFO	setup	operator	{"namespace": "windows-operator-one"}
...
2024-05-08T15:51:54Z	INFO	controllers.configmap	Deleted malformed resource	{"ClusterRoleBinding": "windows-instance-config-daemon", "RoleRef": "windows-instance-config-daemon", "Subjects": [{"kind":"ServiceAccount","name":"windows-instance-config-daemon","namespace":"openshift-windows-machine-config-operator"}]}
...
```

