### PR TITLE
OCPBUGS-33319: use FQDN for hostname in vSphere 

### DIFF
--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -325,11 +325,7 @@ func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (strin
 		return "", fmt.Errorf("error instantiating Windows instance: %w", err)
 	}
 	// get the instance host name  by running hostname command on remote VM
-	hostName, err := win.Run("hostname", true)
-	if err != nil {
-		return "", fmt.Errorf("error getting the host name, with stdout %s: %w", hostName, err)
-	}
-	return hostName, nil
+	return win.GetHostname()
 }
 
 // matchesDNS returns true if the node name passed matches with the instance address of any of the instances present

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -278,8 +278,10 @@ func getHostnameCmd(platformType config.PlatformType) string {
 		return "Invoke-RestMethod -UseBasicParsing -Uri http://169.254.169.254/latest/meta-data/local-hostname"
 	case config.GCPPlatformType:
 		return windows.GcpGetHostnameScriptRemotePath
+	case config.VSpherePlatformType:
+		return windows.GetHostnameFQDNCommand
 	default:
-		// by default use the original hostname
+		// by default do not override the hostname, the cloud provider determines the name of the node
 		return ""
 	}
 }

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -28,6 +28,11 @@ func TestGetHostnameCmd(t *testing.T) {
 			platformType: config.GCPPlatformType,
 			expected:     "C:\\Temp\\gcp-get-hostname.ps1",
 		},
+		{
+			name:         "VSphere platform",
+			platformType: config.VSpherePlatformType,
+			expected:     "$output = Invoke-Expression 'ipconfig /all'; $hostNameLine = ($output -split '`n') | Where-Object { $_ -match 'Host Name' }; $dnsSuffixLine = ($output -split '`n') | Where-Object { $_ -match 'Primary Dns Suffix' }; $hostName = ($hostNameLine -split ':')[1].Trim(); $dnsSuffix = ($dnsSuffixLine -split ':')[1].Trim(); if (-not $dnsSuffix) { return $hostName }; $fqdn = $hostName + '.' + $dnsSuffix; return $fqdn",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This PR introduces a better processing of the hostname so that it returns the FQDN of the instance, including the domain if the windows instance is part of a Active Directory domain controller. The latter, fixes an inconsistency with the configuration workflow of the operator that was not taking into account the DNS suffix in vSphere resulting in the cloud provider implementation (vsphere-cloud-provider) to fail while looking up the VM in the datacenter by name. 

```
[node_controller.go:236] error syncing 'win-worker-1': failed to get provider ID for node win-worker-1 at cloudprovider: failed to get instance ID from cloud provider: No VM found, requeuing
```

Finally, it passed the FQDN of the VM to the kubelet configuration to override the hostname resulting in a consistent naming convention on the node object. 
