### PR TITLE
[release-4.13] OCPBUGS-34669: changes needed for validating webhook

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -97,8 +97,8 @@ func azureCloudNodeManagerConfiguration() servicescm.Service {
 
 // hybridOverlayConfiguration returns the Service definition for hybrid-overlay
 func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service {
-	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --k8s-kubeconfig %s --windows-service "+
-		"--logfile "+"%s\\hybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath,
+	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --bootstrap-kubeconfig=%s --cert-dir=%s --cert-duration=24h "+
+		"--windows-service --logfile "+"%s\\hybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath, windows.CniConfDir,
 		windows.HybridOverlayLogDir)
 	if len(vxlanPort) > 0 {
 		hybridOverlayServiceCmd = fmt.Sprintf("%s --hybrid-overlay-vxlan-port %s", hybridOverlayServiceCmd, vxlanPort)


### PR DESCRIPTION
clean cherry-pick of: b3b68b4 


with changes coming from backporting a validating webhook in ovn-kubernetes (https://github.com/openshift/ovn-kubernetes/pull/2053) this backport is needed in order to fully implement the webhook and make the required CNO changes https://github.com/openshift/cluster-network-operator/pull/2261


did not do an automated cherry-pick of PR https://github.com/openshift/windows-machine-config-operator/pull/1850 because there is an additional update to the ovn-kube submodule that was not needed. 