### PR TITLE
WINC-1310: Remove certain tests in old upgrade suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,7 @@ run-ci-e2e-byoh-test:
 	hack/run-ci-e2e-test.sh -t basic -m 0
 
 .PHONY: run-ci-e2e-upgrade-test
-run-ci-e2e-upgrade-test:
-	hack/run-ci-e2e-test.sh -t upgrade
+run-ci-e2e-upgrade-test: ;
 
 .PHONY: upgrade-test-setup
 upgrade-test-setup:

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -58,8 +58,8 @@ while getopts ":m:c:b:st:w:" opt; do
       ;;
     t ) # test to run. Defaults to all. Other options are basic and upgrade.
       TEST=$OPTARG
-      if [[ "$TEST" != "all" && "$TEST" != "basic" && "$TEST" != "upgrade" && "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
-        echo "Invalid -t option $TEST. Valid options are all, basic, upgrade, upgrade-setup, and upgrade-test"
+      if [[ "$TEST" != "all" && "$TEST" != "basic" && "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
+        echo "Invalid -t option $TEST. Valid options are all, basic, upgrade-setup, and upgrade-test"
         exit 1
       fi
       ;;
@@ -79,9 +79,7 @@ if [ -z "$KUBE_SSH_KEY_PATH" ]; then
     return 1
 fi
 
-if ! [[ "$OPENSHIFT_CI" == "true" &&  "$TEST" = "upgrade" ]]; then
-  OSDK=$(get_operator_sdk)
-fi
+OSDK=$(get_operator_sdk)
 
 SKIP_NODE_DELETION=${SKIP_NODE_DELETION:-"false"}
 
@@ -163,16 +161,8 @@ if [[ "$TEST" = "all" || "$TEST" = "basic" ]]; then
   go test ./test/e2e/... -run=TestWMCO/service_reconciliation -v -timeout=20m -args $GO_TEST_ARGS
   printf "\n####### Testing cluster-wide proxy #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/cluster-wide_proxy -v -timeout=20m -args $GO_TEST_ARGS
-fi
-
-if [[ "$TEST" = "all" || "$TEST" = "upgrade" ]]; then
-  # Run the upgrade tests and skip deletion of the Windows VMs
-  printf "\n####### Testing upgrade #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/upgrade -v -timeout=90m -args $GO_TEST_ARGS
-
-  # Run the reconfiguration test
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=90m -args $GO_TEST_ARGS
+  go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=40m -args $GO_TEST_ARGS
 fi
 
 if [[ "$TEST" = "upgrade-setup" ]]; then
@@ -195,11 +185,7 @@ fi
 if ! $SKIP_NODE_DELETION; then
   go test ./test/e2e/... -run=TestWMCO/destroy -v -timeout=60m -args $GO_TEST_ARGS
   # Get logs on success before cleanup
-  PRINT_UPGRADE=""
-  if [[ "$TEST" = "upgrade" ]]; then
-    PRINT_UPGRADE="upgrade and"
-  fi
-  printf "\n####### WMCO logs for %s deletion tests #######\n" "$PRINT_UPGRADE" >> "$ARTIFACT_DIR"/wmco.log
+  printf "\n####### WMCO logs for deletion tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
   get_WMCO_logs
   # Cleanup the operator resources
   if [ "$wmco_deployed_by_script" = "true" ]; then

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
@@ -19,48 +18,10 @@ import (
 func reconfigurationTestSuite(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
-	t.Run("Reconfigure instance", tc.reconfigurationTest)
 	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
 		t.Run("Re-add removed instance", tc.testReAddInstance)
 	}
 	t.Run("Change private key", testPrivateKeyChange)
-}
-
-// reconfigurationTest tests that the correct behavior occurs when a previously configured instance is configured
-// again. In practice, this exact scenario should not happen, however it simulates a similar scenario where an instance
-// was almost completely configured, an error occurred, and the instance is requeued. This is a scenario that should be
-// expected to be ran into often enough, for reasons such as network instability. For that reason this test is warranted.
-func (tc *testContext) reconfigurationTest(t *testing.T) {
-	machineNodes, err := tc.listFullyConfiguredWindowsNodes(false)
-	require.NoError(t, err)
-	byohNodes, err := tc.listFullyConfiguredWindowsNodes(true)
-	require.NoError(t, err)
-
-	// Remove the version annotation of one of each type of node
-	patchData, err := metadata.GenerateRemovePatch([]string{}, []string{metadata.VersionAnnotation})
-	require.NoError(t, err)
-	_, err = tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), machineNodes[0].Name, types.JSONPatchType,
-		patchData, metav1.PatchOptions{})
-	require.NoError(t, err)
-	// TODO: This is an unreliable check, which will fail if WICD reconciles the node before WMCO is aware of the
-	// version change. This check should be re-added as part of https://issues.redhat.com/browse/OCPBUGS-15886.
-	// Ensure operator communicates to OLM that upgrade is not safe when processing Machine nodes
-	// err = tc.validateUpgradeableCondition(metav1.ConditionFalse)
-	// require.NoError(t, err, "operator Upgradeable condition not in proper state")
-
-	_, err = tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), byohNodes[0].Name, types.JSONPatchType,
-		patchData, metav1.PatchOptions{})
-	require.NoError(t, err)
-
-	// The Windows nodes should eventually be returned to the state we expect them to be in
-	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
-	assert.NoError(t, err, "error waiting for Windows Machine nodes to be reconfigured")
-
-	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
-	assert.NoError(t, err, "error waiting for Windows BYOH nodes to be reconfigured")
-
-	err = tc.validateUpgradeableCondition(metav1.ConditionTrue)
-	require.NoError(t, err, "operator Upgradeable condition not in proper state")
 }
 
 // testReAddInstance tests the case where a Windows BYOH instance was removed from the cluster, and then re-added.

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -158,10 +158,10 @@ func testPrivateKeyChange(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
 
-	// This test cannot be run on vSphere because this random key is not part of the vSphere template image.
-	// Moreover this test is platform agnostic so is not needed to be run for every supported platform.
-	if tc.CloudProvider.GetType() == config.VSpherePlatformType {
-		t.Skipf("Skipping for %s", config.VSpherePlatformType)
+	// This test cannot be run on vSphere environments because this random key is not part of the vSphere template
+	// image. Moreover this test is platform agnostic so is not needed to be run for every supported platform.
+	if tc.CloudProvider.GetType() != config.AWSPlatformType {
+		t.Skipf("Skipping for %s", tc.CloudProvider.GetType())
 	}
 	// Load the state of nodes before the test begins, this is required to determine if new Machine nodes were created
 	require.NoError(t, tc.loadExistingNodes())

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -9,14 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
-	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 )
 
 const (
@@ -26,116 +23,9 @@ const (
 	deploymentTimeout = time.Minute * 1
 	// resourceName is the name of a resource in the watched namespace (e.g pod name, deployment name)
 	resourceName = "windows-machine-config-operator"
-	// windowsWorkloadTesterJob is the name of the job created to test Windows workloads
-	windowsWorkloadTesterJob = "windows-workload-tester"
-	// outdatedVersion is the 'previous' version in the simulated upgrade that the operator is being upgraded from
-	outdatedVersion = "old-version"
 	// parallelUpgradesCheckerJobName is a fixed name for the job that checks for the number of parallel upgrades
 	parallelUpgradesCheckerJobName = "parallel-upgrades-checker"
 )
-
-// upgradeTestSuite tests behaviour of the operator when an upgrade takes place.
-func upgradeTestSuite(t *testing.T) {
-	tc, err := NewTestContext()
-	require.NoError(t, err)
-
-	// test if Windows workloads are running by creating a Job that curls the workloads continuously.
-	cleanupWorkloadAndTester, err := tc.deployWindowsWorkloadAndTester()
-	require.NoError(t, err, "error deploying Windows workloads")
-	defer cleanupWorkloadAndTester()
-
-	// apply configuration steps before running the upgrade tests
-	err = tc.configureUpgradeTest()
-	require.NoError(t, err, "error configuring upgrade")
-
-	// get current Windows node state
-	// TODO: waitForConfiguredWindowsNodes currently loads nodes into global context, so we need this (even though BYOH
-	// 		 nodes are not being upgraded/tested here). Remove as part of https://issues.redhat.com/browse/WINC-620
-	err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
-	require.NoError(t, err, "wrong number of Machine controller nodes found")
-	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
-	require.NoError(t, err, "wrong number of ConfigMap controller nodes found")
-
-	t.Run("Operator version upgrade", tc.testUpgradeVersion)
-}
-
-// testUpgradeVersion tests the upgrade scenario of the operator. The node version annotation is changed when
-// the operator is shut-down. The function tests if the operator on restart deletes the machines and recreates
-// them on version annotation mismatch.
-func (tc *testContext) testUpgradeVersion(t *testing.T) {
-	// Test the node metadata and if the version annotation corresponds to the current operator version
-	tc.testNodeMetadata(t)
-	// Test if prometheus is reconfigured with ip addresses of newly configured nodes
-	tc.testPrometheus(t)
-
-	// Ensure outdated ConfigMap is not retrievable
-	t.Run("Outdated services ConfigMap removal", func(t *testing.T) {
-		err := tc.waitForServicesConfigMapDeletion(servicescm.NamePrefix + outdatedVersion)
-		assert.NoError(t, err, "failed to ensure outdated services ConfigMap is removed after operator upgrade")
-	})
-
-	// TODO: Fix matching label for jobs. See https://issues.redhat.com/browse/WINC-673
-	// Test if there was any downtime for Windows workloads by checking the failure on the Job pods.
-	pods, err := tc.client.K8s.CoreV1().Pods(tc.workloadNamespace).List(context.TODO(),
-		metav1.ListOptions{FieldSelector: "status.phase=Failed",
-			LabelSelector: "job-name=" + windowsWorkloadTesterJob + "-job"})
-
-	require.NoError(t, err)
-	require.Equal(t, 0, len(pods.Items), "Windows workloads inaccessible for significant amount of time during upgrade")
-
-}
-
-// configureUpgradeTest carries out steps required before running tests for upgrade scenario.
-// The steps include -
-// 1. Scale down the operator to 0.
-// 2. Change Windows node version annotation to an invalid value
-// 3. Create a services ConfigMap tied to an outdated operator version
-// 4. Scale up the operator to 1
-func (tc *testContext) configureUpgradeTest() error {
-	// Scale down the WMCO deployment to 0
-	if err := tc.scaleWMCODeployment(0); err != nil {
-		return err
-	}
-
-	// tamper version annotation on all nodes
-	machineNodes, err := tc.listFullyConfiguredWindowsNodes(false)
-	if err != nil {
-		return fmt.Errorf("error getting list of fully configured Machine nodes: %w", err)
-	}
-	byohNodes, err := tc.listFullyConfiguredWindowsNodes(true)
-	if err != nil {
-		return fmt.Errorf("error getting list of fully configured BYOH nodes: %w", err)
-	}
-
-	for _, node := range append(machineNodes, byohNodes...) {
-		patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, metadata.VersionAnnotation, outdatedVersion)
-		node, err := tc.client.K8s.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.MergePatchType,
-			[]byte(patchData), metav1.PatchOptions{})
-		if err != nil {
-			return err
-		}
-		log.Printf("Node Annotation changed to %v", node.Annotations[metadata.VersionAnnotation])
-	}
-
-	// Create outdated services ConfigMap
-	outdatedServicesCM := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      servicescm.NamePrefix + outdatedVersion,
-			Namespace: wmcoNamespace,
-		},
-		Data: map[string]string{"services": "[]", "files": "[]"},
-	}
-	if _, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Create(context.TODO(), outdatedServicesCM,
-		metav1.CreateOptions{}); err != nil {
-		return err
-	}
-
-	// Scale up the WMCO deployment to 1
-	if err := tc.scaleWMCODeployment(1); err != nil {
-		return err
-	}
-	return nil
-}
 
 // scaleWMCODeployment scales the WMCO operator to the given replicas. If the deployment is managed by OLM, updating the
 // replicas only scales the deployment to 0 or 1. If we want to scale the deployment to more than 1 replicas, we need to
@@ -171,37 +61,6 @@ func (tc *testContext) scaleWMCODeployment(desiredReplicas int32) error {
 	})
 
 	return err
-}
-
-// deployWindowsWorkloadAndTester tests if the Windows Webserver deployment is available.
-// This is achieved by creating a Job object that continuously curls the webserver every 5 seconds.
-// returns a tearDown func that must be executed to cleanup resources
-func (tc *testContext) deployWindowsWorkloadAndTester() (func(), error) {
-	// create a Windows Webserver deployment
-	deployment, err := tc.deployWindowsWebServer("win-webserver", nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating Windows Webserver deployment for upgrade test: %w", err)
-	}
-	// create a clusterIP service which can be used to reach the Windows webserver
-	intermediarySVC, err := tc.createService(deployment.Name, 80, v1.ServiceTypeClusterIP, *deployment.Spec.Selector)
-	if err != nil {
-		_ = tc.deleteDeployment(deployment.Name)
-		return nil, fmt.Errorf("error creating service for deployment %s: %w", deployment.Name, err)
-	}
-	// create a Job object that continuously curls the webserver every 5 seconds.
-	testerJob, err := tc.createLinuxCurlerJob(windowsWorkloadTesterJob, intermediarySVC.Spec.ClusterIP, true)
-	if err != nil {
-		_ = tc.deleteDeployment(deployment.Name)
-		_ = tc.deleteService(intermediarySVC.Name)
-		return nil, fmt.Errorf("error creating linux job %s: %w", windowsWorkloadTesterJob, err)
-	}
-	// return a cleanup func
-	return func() {
-		// ignore errors while deleting the objects
-		_ = tc.deleteDeployment(deployment.Name)
-		_ = tc.deleteService(intermediarySVC.Name)
-		_ = tc.deleteJob(testerJob.Name)
-	}, nil
 }
 
 // TestUpgrade tests that things are functioning properly after an upgrade

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -57,7 +57,6 @@ func TestWMCO(t *testing.T) {
 	t.Run("storage", testStorage)
 	t.Run("service reconciliation", testDependentServiceChanges)
 	t.Run("cluster-wide proxy", proxyTestSuite)
-	t.Run("upgrade", upgradeTestSuite)
 	// The reconfigurationTestSuite must be run directly before the deletionTestSuite. This is because we do not
 	// currently wait for nodes to fully reconcile after changing the private key back to the valid key. Any tests
 	// added/moved in between these two suites may fail.


### PR DESCRIPTION
Removes the old upgrade test, as it has been replaced by the newer upgrade test for a while now. The reconfigure test was moved to run on other cloud platforms as that was the only part of the test run that is not covered elsewhere.