### PR TITLE
WINC-1291: Use all existing CAs for TLS auth when pulling images

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -500,17 +500,17 @@ func (r *ConfigMapReconciler) reconcileProxyCerts(ctx context.Context, trustedCA
 	if err := r.ensureProxyCertsCMIsValid(ctx, trustedCA.GetLabels()[InjectionRequestLabel]); err != nil {
 		return err
 	}
-	return r.ensureTrustedCABundleInNodes(ctx, trustedCA.Data)
+	return r.ensureTrustedCABundleInNodes(ctx)
 }
 
 // ensureTrustedCABundleInNodes copies over the trust CA bundle onto each Windows instance in the cluster
-func (r *ConfigMapReconciler) ensureTrustedCABundleInNodes(ctx context.Context, caData map[string]string) error {
+func (r *ConfigMapReconciler) ensureTrustedCABundleInNodes(ctx context.Context) error {
 	winNodes := &core.NodeList{}
 	if err := r.client.List(ctx, winNodes, client.MatchingLabels{core.LabelOSStable: "windows"}); err != nil {
 		return fmt.Errorf("error listing nodes: %w", err)
 	}
 	for _, node := range winNodes.Items {
-		if err := r.ensureTrustedCABundleInNode(ctx, caData, node); err != nil {
+		if err := r.ensureTrustedCABundleInNode(ctx, node); err != nil {
 			return fmt.Errorf("error ensuring trusted CA bundle is up-to-date on node %s: %w", node.Name, err)
 		}
 	}
@@ -518,7 +518,7 @@ func (r *ConfigMapReconciler) ensureTrustedCABundleInNodes(ctx context.Context, 
 }
 
 // ensureTrustedCABundleInNodes places the trusted CA bundle data into a file on the given node
-func (r *ConfigMapReconciler) ensureTrustedCABundleInNode(ctx context.Context, caData map[string]string, node core.Node) error {
+func (r *ConfigMapReconciler) ensureTrustedCABundleInNode(ctx context.Context, node core.Node) error {
 	winInstance, err := r.instanceFromNode(&node)
 	if err != nil {
 		return err
@@ -528,7 +528,7 @@ func (r *ConfigMapReconciler) ensureTrustedCABundleInNode(ctx context.Context, c
 	if err != nil {
 		return fmt.Errorf("failed to create new nodeconfig: %w", err)
 	}
-	return nc.UpdateTrustedCABundleFile(caData)
+	return nc.SyncTrustedCABundle()
 }
 
 // ensureProxyCertsCMIsValid ensures the trusted CA ConfigMap has the expected injection request. Patches the object if not.

--- a/controllers/controllerconfig_controller.go
+++ b/controllers/controllerconfig_controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
+	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig"
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/signer"
 )
@@ -101,16 +102,15 @@ func (r *ControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ControllerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	mccName := "machine-config-controller"
 	mccPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetName() == mccName
+			return e.Object.GetName() == nodeconfig.MccName
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetName() == mccName
+			return e.ObjectNew.GetName() == nodeconfig.MccName
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return e.Object.GetName() == mccName
+			return e.Object.GetName() == nodeconfig.MccName
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
 // imagePathSeparator separates the repo name, namespaces, and image name in an OCI-compliant image name
@@ -229,8 +231,7 @@ func (ms *mirrorSet) generateConfig(secretsConfig credentialprovider.DockerConfi
 		result += hostCapabilities
 		result += "\r\n"
 
-		// TODO: Remove this when we support TLS auth using CA certs - https://issues.redhat.com/browse/WINC-1291
-		result += "  skip_verify = true"
+		result += fmt.Sprintf("  ca = \"%s\"", strings.ReplaceAll(windows.TrustedCABundlePath, "\\", "\\\\"))
 		result += "\r\n"
 
 		// Extract the mirror repo's authorization credentials, if one exists

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -252,7 +252,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "basic one tag mirror",
@@ -263,7 +263,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "one digest mirror never contact source",
@@ -274,7 +274,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "tags mirror never contact source",
@@ -285,7 +285,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "multiple mirrors",
@@ -298,7 +298,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 		{
 			name: "multiple mirrors never contact source",
@@ -311,7 +311,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 	}
 

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -252,7 +252,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "basic one tag mirror",
@@ -263,7 +263,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  skip_verify = true\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "one digest mirror never contact source",
@@ -274,7 +274,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "tags mirror never contact source",
@@ -285,7 +285,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  skip_verify = true\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n",
 		},
 		{
 			name: "multiple mirrors",
@@ -298,7 +298,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  skip_verify = true\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 		{
 			name: "multiple mirrors never contact source",
@@ -311,7 +311,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  skip_verify = true\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  skip_verify = true\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\Temp\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 	}
 

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -138,7 +138,7 @@ const (
 	// wicdKubeconfigPath is the path of the kubeconfig used by WICD
 	wicdKubeconfigPath = K8sDir + "\\wicd-kubeconfig"
 	// TrustedCABundlePath is the location of the trusted CA bundle file
-	TrustedCABundlePath = remoteDir + "\\ca-bundle.crt"
+	TrustedCABundlePath = K8sDir + "\\ca-bundle.crt"
 	// GetHostnameFQDNCommand is the PowerShell command to get the FQDN hostname of the Windows instance
 	GetHostnameFQDNCommand = "$output = Invoke-Expression 'ipconfig /all'; " +
 		"$hostNameLine = ($output -split '`n') | Where-Object { $_ -match 'Host Name' }; " +


### PR DESCRIPTION
This PR adds support for using TLS certs for mirror registries by watching MCO's controllerconfig which holds the ImageRegistryBundleUserData and ImageRegistryBundleData.
These certs are combined into a bundle file and transferred to the trusted bundle store location on Windows nodes. 
If proxy is enabled, these certs are combined with the proxy certs.

