### PR TITLE
[build] Use 4.16 index

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.17"
+LABEL com.redhat.openshift.versions="=v4.16"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  com.redhat.openshift.versions: "=v4.17"
+  com.redhat.openshift.versions: "=v4.16"
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
Required until 4.17 redhat-operators index is created