### PR TITLE
OCPBUGS-35936: Update WICD args to include CA bundle path

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -133,10 +133,15 @@ fi
 
 echo "Testing against Windows Server $WIN_VER"
 
+# MIRROR_REGISTRY_HOST holds the container mirror registry URL, its value will be set in CI
+MIRROR_REGISTRY_HOST=${MIRROR_REGISTRY_HOST:-}
+
 # The bool flags in golang does not respect key value pattern. They follow -flag=x pattern.
 # -flag x is allowed for non-boolean flags only(https://golang.org/pkg/flag/)
 
-GO_TEST_ARGS="$BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE --windows-server-version=$WIN_VER"
+GO_TEST_ARGS="$BYOH_NODE_COUNT_OPTION $MACHINE_NODE_COUNT_OPTION --private-key-path=$KUBE_SSH_KEY_PATH --wmco-namespace=$WMCO_DEPLOY_NAMESPACE --windows-server-version=$WIN_VER --mirror-registry=$MIRROR_REGISTRY_HOST"
+echo "Running tests with arguments: $GO_TEST_ARGS"
+
 # Test that the operator is running when the private key secret is not present
 printf "\n####### Testing operator deployed without private key secret #######\n" >> "$ARTIFACT_DIR"/wmco.log
 go test ./test/e2e/... -run=TestWMCO/operator_deployed_without_private_key_secret -v -args $GO_TEST_ARGS

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -13,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
 // imagePathSeparator separates the repo name, namespaces, and image name in an OCI-compliant image name
@@ -229,9 +227,6 @@ func (ms *mirrorSet) generateConfig(secretsConfig credentialprovider.DockerConfi
 			hostCapabilities = "  capabilities = [\"pull\"]"
 		}
 		result += hostCapabilities
-		result += "\r\n"
-
-		result += fmt.Sprintf("  ca = \"%s\"", strings.ReplaceAll(windows.TrustedCABundlePath, "\\", "\\\\"))
 		result += "\r\n"
 
 		// Extract the mirror repo's authorization credentials, if one exists

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -252,7 +252,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n",
 		},
 		{
 			name: "basic one tag mirror",
@@ -263,7 +263,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
 		},
 		{
 			name: "one digest mirror never contact source",
@@ -274,7 +274,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n",
 		},
 		{
 			name: "tags mirror never contact source",
@@ -285,7 +285,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n",
 		},
 		{
 			name: "multiple mirrors",
@@ -298,7 +298,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.AllowContactingSource,
 			},
-			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://registry.access.redhat.com/ubi9/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net/image\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  [host.\"https://mirror.example.net/image\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 		{
 			name: "multiple mirrors never contact source",
@@ -311,7 +311,7 @@ func TestGenerateConfig(t *testing.T) {
 				},
 				mirrorSourcePolicy: config.NeverContactSource,
 			},
-			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  ca = \"C:\\\\k\\\\ca-bundle.crt\"\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
+			expectedOutput: "server = \"https://example.io/example/ubi-minimal\"\r\n\r\n[host.\"https://example.io/example/ubi-minimal\"]\r\n  capabilities = [\"pull\"]\r\n\r\n[host.\"https://mirror.example.com/redhat\"]\r\n  capabilities = [\"pull\"]\r\n  [host.\"https://mirror.example.com/redhat\".header]\r\n    authorization = \"Basic dXNlcjpwYXNz\"\r\n\r\n[host.\"https://mirror.example.net\"]\r\n  capabilities = [\"pull\", \"resolve\"]\r\n  [host.\"https://mirror.example.net\".header]\r\n    authorization = \"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"\r\n",
 		},
 	}
 

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/openshift/windows-machine-config-operator/pkg/cluster"
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig/payload"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
@@ -560,9 +559,7 @@ func (vm *windows) ConfigureWICD(watchNamespace, wicdKubeconfigContents string) 
 	}
 	wicdServiceArgs := fmt.Sprintf("controller --windows-service --log-dir %s --kubeconfig %s --namespace %s",
 		wicdLogDir, wicdKubeconfigPath, watchNamespace)
-	if cluster.IsProxyEnabled() {
-		wicdServiceArgs = fmt.Sprintf("%s --ca-bundle %s", wicdServiceArgs, TrustedCABundlePath)
-	}
+	wicdServiceArgs = fmt.Sprintf("%s --ca-bundle %s", wicdServiceArgs, TrustedCABundlePath)
 	// if WICD crashes, attempt to restart WICD after 10, 30, and 60 seconds, and then every 2 minutes after that.
 	// reset this counter 5 min after a period with no crashes
 	recoveryActions := []recoveryAction{

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -35,6 +35,8 @@ var (
 	windowsServerVersion windows.ServerVersion
 	// gc is the global context across the test suites.
 	gc = globalContext{}
+	// mirrorRegistry is the container mirror registry URL
+	mirrorRegistry string
 )
 
 // globalContext holds the information that we want to use across the test suites.
@@ -85,6 +87,8 @@ type testContext struct {
 	// windowsServerVersion is the Windows Server version used in the e2e test suite.
 	// If unset or empty, Windows Server 2022 is assumed for Machine and container images.
 	windowsServerVersion windows.ServerVersion
+	// mirrorRegistry is the container mirror registry URL
+	mirrorRegistry string
 }
 
 // NewTestContext returns a new test context to be used by every test.
@@ -113,7 +117,7 @@ func NewTestContext() (*testContext, error) {
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{client: oc, timeout: retry.Timeout, retryInterval: retry.Interval,
 		CloudProvider: cloudProvider, workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels,
-		windowsServerVersion: windowsServerVersion, toolsImage: toolsImage}, nil
+		windowsServerVersion: windowsServerVersion, toolsImage: toolsImage, mirrorRegistry: mirrorRegistry}, nil
 }
 
 // vmUsername returns the name of the user which can be used to log into each Windows instance
@@ -165,6 +169,7 @@ func TestMain(m *testing.M) {
 			}
 			return nil
 		})
+	flag.StringVar(&mirrorRegistry, "mirror-registry", "", "mirror registry URL")
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -754,7 +754,7 @@ func (tc *testContext) createLinuxCurlerJob(jobSuffix, endpoint string, continuo
 
 // createLinuxJob creates a job which will run the provided command with a ubi8 image
 func (tc *testContext) createLinuxJob(name string, command []string) (*batchv1.Job, error) {
-	return tc.createJob(name, ubi8Image, command, nil, nil, &v1.PodOS{Name: v1.Linux})
+	return tc.createJob(name, ubi8Image, command, nil, nil, &v1.PodOS{Name: v1.Linux}, nil)
 }
 
 // createWinCurlerJob creates a Job to curl Windows server at given IP address
@@ -783,12 +783,12 @@ func (tc *testContext) createWindowsServerJob(name, pwshCommand string, affinity
 	windowsOS := &v1.PodOS{Name: v1.Windows}
 	windowsServerImage := tc.getWindowsServerContainerImage()
 	command := []string{powerShellExe, "-command", pwshCommand}
-	return tc.createJob(name, windowsServerImage, command, &rcName, affinity, windowsOS)
+	return tc.createJob(name, windowsServerImage, command, &rcName, affinity, windowsOS, nil)
 }
 
 // createJob creates a job on the cluster using the given parameters
 func (tc *testContext) createJob(name, image string, command []string, runtimeClassName *string, affinity *v1.Affinity,
-	os *v1.PodOS) (*batchv1.Job, error) {
+	os *v1.PodOS, pullSecret []v1.LocalObjectReference) (*batchv1.Job, error) {
 	jobsClient := tc.client.K8s.BatchV1().Jobs(tc.workloadNamespace)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -809,6 +809,7 @@ func (tc *testContext) createJob(name, image string, command []string, runtimeCl
 							Command:         command,
 						},
 					},
+					ImagePullSecrets: pullSecret,
 				},
 			},
 		},

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -34,6 +34,7 @@ func TestWMCO(t *testing.T) {
 	// Create the namespace test resources can be deployed in, as well as required resources within said namespace.
 	require.NoError(t, tc.ensureNamespace(tc.workloadNamespace, tc.workloadNamespaceLabels), "error creating test namespace")
 	require.NoError(t, tc.ensureTestRunnerRBAC(), "error creating test runner RBAC")
+	require.NoError(t, tc.createPullSecret(), "error creating pull secret in test namespace")
 
 	// When the upgrade test is run from CI, the namespace that gets created does not have the required monitoring
 	// label, so we ensure that it gets applied and the WMCO deployment is restarted.


### PR DESCRIPTION
Update WICD args to include CA bundle path irrespective of cluster proxy settings.