### PR TITLE
Align machineset.sh with 4.17 updates for securityGroups and subnet in AWS

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -123,12 +123,12 @@ $(get_spec $infraID $az $provider $byoh)
             - filters:
                 - name: tag:Name
                   values:
-                    - ${infraID}-worker-sg
+                    - ${infraID}-node
           subnet:
             filters:
               - name: tag:Name
                 values:
-                  - ${infraID}-private-${az}
+                  - ${infraID}-subnet-private-${az}
           tags:
             - name: kubernetes.io/cluster/${infraID}
               value: owned


### PR DESCRIPTION
This commit updates the machineset.sh script to follow the 4.17 naming convention for securityGroups and subnet in AWS.