### PR TITLE
OCPBUGS-36395: [config] Increase controller manager resource limits

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -437,7 +437,7 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 600Mi
+                    memory: 1Gi
                   requests:
                     cpu: 20m
                     memory: 300Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,7 +41,7 @@ spec:
         resources:
          limits:
             cpu: 200m
-            memory: 600Mi
+            memory: 1Gi
          requests:
             cpu: 20m
             memory: 300Mi


### PR DESCRIPTION
Increase memory resource requests and limits as the current limits are proving to be insufficient in an upgrade scenario, tested in QE clusters.