### PR TITLE
OCPBUGS-36643: Handle reverse lookup error correctly

### DIFF
--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -193,9 +193,8 @@ func (a *Approver) validateNodeName(nodeName string) (bool, error) {
 	// check if the node name matches the lookup of any of the instance addresses
 	hasEntry, err := matchesDNS(nodeName, windowsInstances)
 	if err != nil {
-		return false, fmt.Errorf("unable to map node name to the addresses of Windows instances: %w", err)
-	}
-	if hasEntry {
+		a.log.Info("error occurred with reverse DNS lookup, falling back to hostname validation", "error", err)
+	} else if hasEntry {
 		return true, nil
 	}
 	return a.validateWithHostName(nodeName, windowsInstances)


### PR DESCRIPTION
This fixes an issue where if reverse lookup fails due to an error, such as reverse lookup services being down, WMCO would not fall back to using the VM hostname to determine if a CSR should be approved.