### PR TITLE
OCPBUGS-30995: Bypass ExecutionPolicy running commands

### DIFF
--- a/pkg/daemon/powershell/powershell.go
+++ b/pkg/daemon/powershell/powershell.go
@@ -15,7 +15,7 @@ type commandRunner struct{}
 
 // Run runs the command with the PowerShell on PATH
 func (r *commandRunner) Run(cmd string) (string, error) {
-	out, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
+	out, err := exec.Command("powershell", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", cmd).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("error running command with output %s: %w", string(out), err)
 	}


### PR DESCRIPTION
Aligns how WICD runs powershell commands with WMCO. Prevents commands from failing to run when ExecutionPolicy is set to restricted, which may be default depending on the VM image used.