### PR TITLE
OCPBUGS-36305: Add reboot docs and clean HNS networks before rebooting in AWS

### DIFF
--- a/controllers/controllerconfig_controller.go
+++ b/controllers/controllerconfig_controller.go
@@ -66,6 +66,7 @@ func NewControllerConfigReconciler(mgr manager.Manager, clusterConfig cluster.Co
 			clusterServiceCIDR: clusterConfig.Network().GetServiceCIDR(),
 			watchNamespace:     watchNamespace,
 			recorder:           mgr.GetEventRecorderFor(ControllerConfigController),
+			platform:           clusterConfig.Platform(),
 		},
 	}, nil
 }

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -64,6 +64,7 @@ func NewNodeReconciler(mgr manager.Manager, clusterConfig cluster.Config, watchN
 			clusterServiceCIDR: clusterConfig.Network().GetServiceCIDR(),
 			watchNamespace:     watchNamespace,
 			recorder:           mgr.GetEventRecorderFor(NodeController),
+			platform:           clusterConfig.Platform(),
 		},
 	}, nil
 }

--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -70,6 +70,7 @@ func NewRegistryReconciler(mgr manager.Manager, clusterConfig cluster.Config,
 			clusterServiceCIDR: clusterConfig.Network().GetServiceCIDR(),
 			watchNamespace:     watchNamespace,
 			recorder:           mgr.GetEventRecorderFor(RegistryController),
+			platform:           clusterConfig.Platform(),
 		},
 	}, nil
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -48,6 +48,19 @@ Once the SSH bastion has been setup, you can use either method to access the Win
   ```
 * You can now RDP into the Windows node at *localhost:2020* using an RDP client
 
+## Rebooting a Windows node
+
+In general, the operator minimize disruptions and avoid node reboots whenever possible. Certain operations and 
+updates at the system level still require a traditional reboot process to ensure changes are applied correctly
+and securely.
+
+To restart a Windows node configured with WMCO, add the special reboot annotation and wait for the operator to
+evict any existing pods, cordon the node and safely reboot the instance. 
+ ```shell script
+ oc annotate nodes <node_name> windowsmachineconfig.openshift.io/reboot-required=true
+ ```
+where `<node_name>` is the name of the Windows node to be rebooted.
+
 ## How to collect Kubernetes node logs
 Kubernetes node log files are in *C:\var\logs*. To view all the directories under *C:\var\logs*, execute:
 ```shell script

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -271,7 +271,13 @@ func (nc *nodeConfig) SafeReboot(ctx context.Context) error {
 	if err := drain.RunNodeDrain(drainer, nc.node.Name); err != nil {
 		return fmt.Errorf("unable to drain node %s: %w", nc.node.Name, err)
 	}
-
+	// Windows Server 2022 VMs on AWS have a non-persistent route to the metadata endpoint. Explicitly restore them
+	// to allow the same VM to be configured as a node again.
+	if nc.platformType == configv1.AWSPlatformType {
+		if err := nc.Windows.RestoreAWSRoutes(); err != nil {
+			return err
+		}
+	}
 	if err := nc.Windows.RebootAndReinitialize(); err != nil {
 		return err
 	}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -611,6 +611,9 @@ func (vm *windows) RestoreAWSRoutes() error {
 	if err != nil {
 		return err
 	}
+	if err := vm.ensureHNSNetworksAreRemoved(); err != nil {
+		return fmt.Errorf("unable to ensure HNS networks are removed: %w", err)
+	}
 	if err = vm.ensureServiceIsRunning(ec2Launch); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR introduces documentation to reboot a Windows node configured by WMCO properly. 

Direct access to the underlying Windows VM to trigger a restart is not recommended, the existing node annotation must be used, instead. 

In addition, this PR introduces a fix for AWS as a particular case where the EC2 Agent fails to configure the metadata endpoint when the HNS are fully configured with the virtual network interfaces.

