### PR TITLE
WINC-1305: Move kube-proxy submodule build from tags (v1.30.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,7 @@
 [submodule "kube-proxy"]
 	path = kube-proxy
 	url = https://github.com/openshift/kubernetes
-	branch = sdn-4.16-kubernetes-1.29.0
+	branch = master
 [submodule "containerd"]
 	path = containerd
 	url = https://github.com/openshift/containerd

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WMCO_VERSION ?= 10.17.0
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
 KUBELET_GIT_VERSION=v1.30.1+44fc19f
-KUBE-PROXY_GIT_VERSION=v1.29.0+9cdc488
+KUBE-PROXY_GIT_VERSION=v1.30.0
 CONTAINERD_GIT_VERSION=v1.7.17
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")


### PR DESCRIPTION
Switches to maintain kube-proxy repo by tag off of o/k's master branch.

With SDN no longer carrying kube-proxy patches, we no longer need to
have our submodule track a specific branch -- we can directly checkout
the tag we need without waiting for branch creation.

If we need upstream fixes later, we just update the submodule version
in our build an hack scripts to get the desired tag (e.g. `v1.30.2`).

Ran `./hack/update_submodules.sh -m kube-proxy -r master master`
