### PR TITLE
Update registry for the csi node driver image

### DIFF
--- a/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
+++ b/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: vmware-vsphere-csi-driver-node-sa
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -102,7 +102,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.9.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -267,7 +267,7 @@ func (p *Provider) ensureWindowsCSIDaemonSet(client client.Interface) error {
 					Containers: []core.Container{
 						{
 							Name:  "node-driver-registrar",
-							Image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0",
+							Image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0",
 							Args:  []string{"--v=5", "--csi-address=$(ADDRESS)", "-kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
 							Env: []core.EnvVar{
 								{

--- a/test/e2e/smb/smb.go
+++ b/test/e2e/smb/smb.go
@@ -419,7 +419,7 @@ func ensureWindowsCSIDaemonset(c client.Interface) error {
 					Containers: []core.Container{
 						{
 							Name:  "node-driver-registrar",
-							Image: "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.7.0",
+							Image: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0",
 							Args:  []string{"--v=5", "--csi-address=$(ADDRESS)", "-kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"},
 							Env: []core.EnvVar{
 								{


### PR DESCRIPTION
This PR updates the DaemonSet container image to use the new
image registry for the csi node driver.

See https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement