### PR TITLE
OCPBUGS-36305: Document graceful Node reboot and add workaround for issue in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ by the chosen storage driver's provider. A list of drivers can be found [here](h
 [Horizontal](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-autoscaling.html) and
 [Vertical](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-vertical-autoscaler.html) Pod
 autoscaling support are not available for Windows workloads.
+
 ### Other limitations
 WMCO / Windows nodes does not work with the following products:
 * [odo](https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/understanding-odo.html)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -48,6 +48,18 @@ Once the SSH bastion has been setup, you can use either method to access the Win
   ```
 * You can now RDP into the Windows node at *localhost:2020* using an RDP client
 
+## Rebooting a Windows node
+
+In general, the operator minimize disruptions and avoid node reboots whenever possible. Certain operations and
+updates at the system level still require a traditional reboot process to ensure changes are applied correctly
+and securely.
+
+To reboot a Windows node, please follow the Openshift documentation on [Rebooting a node gracefully](https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-rebooting.html#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting)
+to cordon, drain and reboot with the following command in PowerShell:
+```powershell
+  Restart-Computer -Force
+```
+
 ## How to collect Kubernetes node logs
 Kubernetes node log files are in *C:\var\logs*. To view all the directories under *C:\var\logs*, execute:
 ```shell script

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,7 +50,7 @@ Once the SSH bastion has been setup, you can use either method to access the Win
 
 ## Rebooting a Windows node
 
-In general, the operator minimize disruptions and avoid node reboots whenever possible. Certain operations and
+In general, the operator tries to minimize disruptions and avoids node reboots whenever possible. Certain operations and
 updates at the system level still require a traditional reboot process to ensure changes are applied correctly
 and securely.
 
@@ -59,6 +59,22 @@ to cordon, drain and reboot with the following command in PowerShell:
 ```powershell
   Restart-Computer -Force
 ```
+
+### Node reboot limitation in AWS
+
+In AWS, Windows nodes are not able to become ready after [performing a graceful reboot](#rebooting-a-windows-node)
+due to an inconsistency with the EC2 instance metadata routes and the HNS networks.
+
+The cluster administrator must SSH into the instance and add the route after rebooting with the following command:
+```cmd
+  route add 169.254.169.254 mask 255.255.255.255 <gateway_ip>
+```
+where `169.254.169.254` and `255.255.255.255` are the address and network mask of the EC2 instance metadata endpoint,
+respectively. The `<gateway_ip>` must be replaced by the corresponding IP address of the gateway in Windows instance
+and can be found by running the following command:
+```cmd
+  ipconfig | findstr /C:"Default Gateway"
+``` 
 
 ## How to collect Kubernetes node logs
 Kubernetes node log files are in *C:\var\logs*. To view all the directories under *C:\var\logs*, execute:


### PR DESCRIPTION
This PR documents the process of gratefully rebooting a Windows node
by adding references to the official OCP guidelines along with the specific
PowerShell command.

In addition, it provides a workaround to an AWS limitation where the EC2 instance metadata endpoint becomes unavailable, preventing the node from reaching the ready state. 
