### PR TITLE
[test] Job log collection as a single action

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -110,7 +110,10 @@ func (tc *testContext) testParallelUpgradesChecker(t *testing.T) {
 	failedPods, err := tc.client.K8s.CoreV1().Pods(tc.workloadNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "job-name=" + parallelUpgradesCheckerJobName, FieldSelector: "status.phase=Failed"})
 	require.NoError(t, err)
-	tc.writePodLogs("job-name=" + parallelUpgradesCheckerJobName)
+	_, err = tc.gatherPodLogs("job-name=" + parallelUpgradesCheckerJobName)
+	if err != nil {
+		log.Printf("unable to gather logs: %v", err)
+	}
 	require.Equal(t, 0, len(failedPods.Items), "parallel upgrades check failed",
 		"failed pod count", len(failedPods.Items))
 }


### PR DESCRIPTION
Collects job logs in one go, rather than using two API calls, one to gather the logs to print to a file, and one to return the logs to the caller.