### PR TITLE
[e2e] Increase retry interval for mirror test

### DIFF
--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -77,7 +77,7 @@ func (tc *testContext) testMirrorSettingsApplied(t *testing.T) {
 			require.NoError(t, err, "unable to get node address")
 
 			// retry to give time for registry controller to transfer generated config to all nodes
-			err = wait.PollUntilContextTimeout(context.TODO(), retry.Interval, 5*time.Minute, true,
+			err = wait.PollUntilContextTimeout(context.TODO(), nodeRetryInterval, 5*time.Minute, true,
 				func(ctx context.Context) (done bool, err error) {
 					count, err := tc.countItemsInDir(windows.ContainerdConfigDir, addr)
 					require.NoErrorf(t, err, "error counting items in dir %s on node %s", windows.ContainerdConfigDir, addr)
@@ -98,7 +98,7 @@ func (tc *testContext) testMirrorSettingsCleared(t *testing.T) {
 			require.NoError(t, err, "unable to get node address")
 
 			// retry to give time for registry controller to clear settings from all nodes
-			err = wait.PollUntilContextTimeout(context.TODO(), retry.Interval, 5*time.Minute, true,
+			err = wait.PollUntilContextTimeout(context.TODO(), nodeRetryInterval, 5*time.Minute, true,
 				func(ctx context.Context) (done bool, err error) {
 					count, err := tc.countItemsInDir(windows.ContainerdConfigDir, addr)
 					require.NoErrorf(t, err, "error counting items in dir %s on node %s", windows.ContainerdConfigDir, addr)


### PR DESCRIPTION
Increase retry interval when checking for image mirroring settings on nodes. 15s can be too short for the Job pod to complete since it SSHs into the node. Use 1 minute instead, like is done elsewhere in the e2e tests for such Job pods.
Done to address flaky behavior presenting as timeouts waiting for the Job pod to succeed.