### PR TITLE
WINC-1149: Use userdata task to persistent instance metadata routes  in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Nodes can be added through both MachineSets and the windows-instances ConfigMap.
 The image specified in MachineSets has an extra requirement of having [the OpenSSH.Server~~~~0.0.1.0 Windows capability installed](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=powershell#install-openssh-for-windows).
 This is normally installed by WMCO using the Machine's user-data, and is needed to configure a Windows instance.
 
+For AWS platform, the Windows AMI must have installed the EC2LaunchV2 agent with version 2.0.1643 or later.
+See install options in the [EC2LaunchV2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2launch-v2-install.html#lv2-configure-install).
+
 In order to run Windows workloads on Nodes, the image `mcr.microsoft.com/oss/kubernetes/pause:3.9` must be mirrored.
 See [Image configuration resources](https://docs.openshift.com/container-platform/latest/openshift_images/image-configuration.html) for general information on image mirroring.
 

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -543,13 +543,6 @@ func (nc *nodeConfig) Deconfigure() error {
 		return fmt.Errorf("error deconfiguring instance: %w", err)
 	}
 
-	// Windows Server 2022 VMs on AWS have a non-persistent route to the metadata endpoint. This is lost when the HNS
-	// networks are deleted. Explicitly restore them to allow the same VM to be configured as a node again.
-	if nc.platformType == configv1.AWSPlatformType {
-		if err := nc.Windows.RestoreAWSRoutes(); err != nil {
-			return err
-		}
-	}
 	nc.log.Info("instance has been deconfigured", "node", nc.node.GetName())
 	return nil
 }

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -267,8 +267,6 @@ type Windows interface {
 	// RunWICDCleanup ensures the WICD service is stopped and runs the cleanup command that ensures all WICD-managed
 	// services are also stopped
 	RunWICDCleanup(string, string) error
-	// RestoreAWSRoutes restores the default routes on AWS VMs. This function should not be called on non-AWS VMs
-	RestoreAWSRoutes() error
 }
 
 // windows implements the Windows interface
@@ -590,35 +588,6 @@ func (vm *windows) ConfigureWICD(watchNamespace, wicdKubeconfigContents string) 
 		return fmt.Errorf("error ensuring %s Windows service has started running: %w", WicdServiceName, err)
 	}
 	vm.log.Info("configured", "service", WicdServiceName, "args", wicdServiceArgs)
-	return nil
-}
-
-func (vm *windows) RestoreAWSRoutes() error {
-	ec2LaunchV2ServiceName := "\"Amazon EC2Launch\""
-	serviceExists, err := vm.serviceExists(ec2LaunchV2ServiceName)
-	if err != nil {
-		return fmt.Errorf("error checking if %s service exists: %w", ec2LaunchV2ServiceName, err)
-	}
-	// We don't want ensureServiceIsRunning to create the service if it does not exist, so we return without an error.
-	// Returning an error does not make sense as we could have an AMI configured without the EC2Launch service present
-	// and the route created using some other customer specific method which is unknown to us.
-	if !serviceExists {
-		vm.log.Info("missing", "service", ec2LaunchV2ServiceName)
-		return nil
-	}
-	ec2Launch, err := newService("C:\\Program Files\\Amazon\\EC2Launch\\service\\EC2LaunchService.exe",
-		ec2LaunchV2ServiceName, "", nil, nil, 0)
-	if err != nil {
-		return err
-	}
-	if err = vm.ensureServiceIsRunning(ec2Launch); err != nil {
-		return err
-	}
-	// The EC2Launch service stops running once it has completed its tasks like creating routes. So we wait until it
-	// has stopped running before proceeding.
-	if err = vm.waitStopped(ec2LaunchV2ServiceName); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Add a special command to the AWS userdata to add persistent routes for
the metadata endpoint, installs the EC2Launch.exe if missing, checks
the minimum required version and upgrades if needed.

This will allow the same VM to be configured, deconfigured, and reconfigured
without losing access to the metadata endpoint.

follow-up to prev PR, credits to @aravindhp 

- https://github.com/openshift/windows-machine-config-operator/pull/1847

