### PR TITLE
[release-4.15] OCPBUGS-38485: Always use created WICD SA token

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vincent-petithory/dataurl"
 	"golang.org/x/crypto/ssh"
 	core "k8s.io/api/core/v1"
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -281,33 +282,26 @@ func (nc *nodeConfig) SafeReboot(ctx context.Context) error {
 	return nil
 }
 
-// getWICDServiceAccountSecret returns the secret which holds the credentials for the WICD ServiceAccount
+// getWICDServiceAccountSecret returns the secret which holds the credentials for the WICD ServiceAccount, creating one
+// if necessary
 func (nc *nodeConfig) getWICDServiceAccountSecret() (*core.Secret, error) {
-	var secrets core.SecretList
-	err := nc.client.List(context.TODO(), &secrets, client.InNamespace(nc.wmcoNamespace))
+	var tokenSecret core.Secret
+	err := nc.client.Get(context.TODO(),
+		types.NamespacedName{Namespace: nc.wmcoNamespace, Name: windows.WicdServiceName}, &tokenSecret)
 	if err != nil {
+		if k8sapierrors.IsNotFound(err) {
+			return nc.createWICDServiceAccountTokenSecret()
+		}
 		return nil, err
 	}
-	// Go through all the secrets in the WMCO namespace, and find the token secret which contains the auth credentials
-	// for the WICD ServiceAccount
-	var filteredSecrets []core.Secret
-	for _, secret := range secrets.Items {
-		if secret.Type != core.SecretTypeServiceAccountToken {
-			// skip non-serviceAccount token secrets
-			continue
-		}
-		if secret.Annotations[core.ServiceAccountNameKey] == windows.WicdServiceName {
-			filteredSecrets = append(filteredSecrets, secret)
-		}
+	if validWICDServiceAccountTokenSecret(tokenSecret) {
+		return &tokenSecret, nil
 	}
-	if len(filteredSecrets) == 1 {
-		return &filteredSecrets[0], nil
+
+	// If the secret is invalid, a new one should be created
+	if err = nc.client.Delete(context.TODO(), &tokenSecret); err != nil {
+		return nil, fmt.Errorf("error deleting invalid WICD service account token secret: %w", err)
 	}
-	if len(filteredSecrets) > 1 {
-		return nil, fmt.Errorf("expected 1 secret for SA '%s', found %d", windows.WicdServiceName,
-			len(filteredSecrets))
-	}
-	// no secret token found for WICD service account, create one
 	return nc.createWICDServiceAccountTokenSecret()
 }
 
@@ -716,4 +710,15 @@ func CreatePubKeyHashAnnotation(key ssh.PublicKey) string {
 	pubKey := string(ssh.MarshalAuthorizedKey(key))
 	trimmedKey := strings.TrimSuffix(pubKey, "\n")
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(trimmedKey)))
+}
+
+// validWICDServiceAccountTokenSecret returns true if the given secret provides a token for the WICD SA
+func validWICDServiceAccountTokenSecret(secret core.Secret) bool {
+	if secret.Type != core.SecretTypeServiceAccountToken {
+		return false
+	}
+	if secret.Annotations[core.ServiceAccountNameKey] != windows.WicdServiceName {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/windows-machine-config-operator/pull/2285

This is a behavior change which comes as a result of inconsistencies across OCP platforms and versions. Previously WMCO would check if the cluster created a SA token secret for the WICD SA, and if it exists would use the cluster created secret, else it would create its own secret.

We are finding that on upgrades from 4.15 to 4.16 the secret was missing on 4.15, but then created by an entity in the cluster on 4.16. This is throwing off WMCO's logic to get the secret as there will be multiple SA token secrets, one created by WMCO in 4.15, and an additional one when the 4.16 upgrade occurs.

This commit remedies this issue by having WMCO only use the secret it creates, ignoring any other service account token secrets in the WMCO namespace.