### PR TITLE
WINC-710: replaces kube-proxy flags with config file

### DIFF
--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -256,7 +256,6 @@ conntrack:
   udpStreamTimeout: 0s
 configSyncPeriod: 0s
 portRange: ''
-windowsRunAsService: true
 "@
 
 # Generate kube-proxy config 

--- a/pkg/nodeconfig/payload/payload.go
+++ b/pkg/nodeconfig/payload/payload.go
@@ -80,7 +80,36 @@ const (
 	// TODO: This script is doing both CNI configuration and HNS endpoint creation, two things that aren't necessarily
 	//       related. Correct that in: https://issues.redhat.com/browse/WINC-882
 	// networkConfTemplate is the template used to generate the network configuration script
-	networkConfTemplate = `# This script ensures the contents of the CNI config file is correct, and returns the HNS endpoint IP
+	networkConfTemplate = `# This script ensures the contents of the CNI config file is correct, and creates the kube-proxy config file.
+
+param(
+    [string]$hostnameOverride,
+    [string]$clusterCIDR,
+    [string]$kubeConfigPath,
+    [string]$kubeProxyConfigPath,
+    [string]$verbosity
+)
+  # this compares the config with the existing config, and replaces if necessary
+  function Compare-And-Replace-Config {
+    param (
+        [string]$ConfigPath,
+        [string]$NewConfigContent
+    )
+    
+    # Read existing config content
+    $existing_config = ""
+    if (Test-Path -Path $ConfigPath) {
+        $config_file_content = Get-Content -Path $ConfigPath -Raw
+        if ($config_file_content -ne $null) {
+` + "        $existing_config=$config_file_content.Replace(\"`r\",\"\")" + `
+        }
+    }
+    
+    if ($existing_config -ne $NewConfigContent) {
+        Set-Content -Path $ConfigPath -Value $NewConfigContent -NoNewline
+    }
+  }
+
 $ErrorActionPreference = "Stop"
 Import-Module -DisableNameChecking HNS_MODULE_PATH
 
@@ -143,17 +172,7 @@ $cni_template=$cni_template.Replace("ovn_host_subnet",$subnet)
 $provider_address=$hns_network.ManagementIP
 $cni_template=$cni_template.Replace("provider_address",$provider_address)
 
-# Compare CNI config with existing file, and replace if necessary
-$existing_config=""
-if(Test-Path -Path CNI_CONFIG_PATH) {
-    $config_file_content=(Get-Content -Path CNI_CONFIG_PATH -Raw)
-    if($config_file_content -ne $null) {
-` + "        $existing_config=$config_file_content.Replace(\"`r\",\"\")" + `
-    }
-}
-if($existing_config -ne $cni_template){
-    Set-Content -Path "CNI_CONFIG_PATH" -Value $cni_template -NoNewline
-}
+Compare-And-Replace-Config -ConfigPath CNI_CONFIG_PATH -NewConfigContent $cni_template
 
 # Create HNS endpoint if it doesn't exist
 $endpoint = Invoke-HNSRequest GET endpoints | where { $_.Name -eq 'VIPEndpoint'}
@@ -161,9 +180,87 @@ if( $endpoint -eq $null) {
     $endpoint = New-HnsEndpoint -NetworkId $hns_network.ID -Name "VIPEndpoint"
     Attach-HNSHostEndpoint -EndpointID $endpoint.ID -CompartmentID 1
 }
+# Get HNS endpoint IP
+$sourceVip = (Get-NetIPConfiguration -AllCompartments -All -Detailed | where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()
 
-# Return HNS endpoint IP
-(Get-NetIPConfiguration -AllCompartments -All -Detailed | where { $_.NetAdapter.LinkLayerAddress -eq $endpoint.MacAddress }).IPV4Address.IPAddress.Trim()
+#Kube Proxy configuration
+
+$kube_proxy_config=@"
+kind: KubeProxyConfiguration
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+featureGates:
+  WinDSR: true
+  WinOverlay: true
+clientConnection:
+  kubeconfig: $kubeConfigPath
+  acceptContentTypes: ''
+  contentType: ''
+  qps: 0
+  burst: 0
+logging:
+  flushFrequency: 0
+  verbosity: $verbosity
+  options:
+    text:
+      infoBufferSize: '0'
+    json:
+      infoBufferSize: '0'
+hostnameOverride: $hostnameOverride
+bindAddress: ''
+healthzBindAddress: ''
+metricsBindAddress: ''
+bindAddressHardFail: false
+enableProfiling: false
+showHiddenMetricsForVersion: ''
+mode: kernelspace
+iptables:
+  masqueradeBit: null
+  masqueradeAll: false
+  localhostNodePorts: null
+  syncPeriod: 0s
+  minSyncPeriod: 0s
+ipvs:
+  syncPeriod: 0s
+  minSyncPeriod: 0s
+  scheduler: ''
+  excludeCIDRs: null
+  strictARP: false
+  tcpTimeout: 0s
+  tcpFinTimeout: 0s
+  udpTimeout: 0s
+nftables:
+  masqueradeBit: null
+  masqueradeAll: false
+  syncPeriod: 0s
+  minSyncPeriod: 0s
+winkernel:
+  networkName: OVNKubernetesHybridOverlayNetwork
+  sourceVip: $sourceVip
+  enableDSR: true
+  rootHnsEndpointName: ''
+  forwardHealthCheckVip: false
+detectLocalMode: ''
+detectLocal:
+  bridgeInterface: ''
+  interfaceNamePrefix: ''
+clusterCIDR: $clusterCIDR
+nodePortAddresses: null
+oomScoreAdj: null
+conntrack:
+  maxPerCore: null
+  min: null
+  tcpEstablishedTimeout: null
+  tcpCloseWaitTimeout: null
+  tcpBeLiberal: false
+  udpTimeout: 0s
+  udpStreamTimeout: 0s
+configSyncPeriod: 0s
+portRange: ''
+windowsRunAsService: true
+"@
+
+# Generate kube-proxy config 
+Compare-And-Replace-Config -ConfigPath $kubeProxyConfigPath -NewConfigContent $kube_proxy_config
 `
 )
 

--- a/pkg/nodeconfig/payload/payload_test.go
+++ b/pkg/nodeconfig/payload/payload_test.go
@@ -184,7 +184,6 @@ conntrack:
   udpStreamTimeout: 0s
 configSyncPeriod: 0s
 portRange: ''
-windowsRunAsService: true
 "@
 
 # Generate kube-proxy config 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -136,7 +136,7 @@ func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service
 
 // kubeProxyConfiguration returns the Service definition for kube-proxy
 func kubeProxyConfiguration(debug bool) servicescm.Service {
-	cmd := fmt.Sprintf("%s -log-file=%s %s --config %s", windows.KubeLogRunnerPath, windows.KubeProxyLog,
+	cmd := fmt.Sprintf("%s -log-file=%s %s --config %s --windows-service", windows.KubeLogRunnerPath, windows.KubeProxyLog,
 		windows.KubeProxyPath, windows.KubeProxyConfigPath)
 
 	verbosity := "0"

--- a/pkg/servicescm/servicescm.go
+++ b/pkg/servicescm/servicescm.go
@@ -58,6 +58,8 @@ type PowershellPreScript struct {
 	VariableName string `json:"variableName,omitempty"`
 	// Path is the location of a PowerShell script to be ran
 	Path string `json:"path"`
+	// NodeArgs contains the arguments to be given to the pre script
+	NodeArgs []NodeCmdArg
 }
 
 // Service represents the configuration spec of a Windows service

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -95,6 +95,8 @@ const (
 	KubeletConfigPath = K8sDir + "\\kubelet.conf"
 	// KubeletLog is the location of the kubelet log file
 	KubeletLog = KubeletLogDir + "\\kubelet.log"
+	// KubeProxyConfigPath is the location of the kube proxy configuration file
+	KubeProxyConfigPath = K8sDir + "\\kube-proxy.conf"
 	// KubeProxyLog is the location of the kube-proxy log file
 	KubeProxyLog = KubeProxyLogDir + "\\kube-proxy.log"
 	// KubeProxyPath is the location of the kube-proxy exe


### PR DESCRIPTION
launching kube-proxy with flags is now deprecated. Changes to using a config file instead.
This adds the creation of the kube-proxy config file to the script run before setting up kube-proxy. This script also contains the post-configuration setup steps for  CNI. Ideally this script will be broken up or retired, and we will be able to generate the kube-proxy configuration in a more idiomatic way. 