### PR TITLE
[bundle] Fix 'make bundle'

### DIFF
--- a/bundle/manifests/windows-exporter_v1_service.yaml
+++ b/bundle/manifests/windows-exporter_v1_service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: windows-machine-config-operator-tls
   creationTimestamp: null
   labels:
     name: windows-exporter
   name: windows-exporter
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: windows-machine-config-operator-tls
 spec:
   ports:
   - name: metrics

--- a/config/windows-exporter/kustomization.yaml
+++ b/config/windows-exporter/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
 - windows-exporter-service.yaml
-- windows-exporter-service-monitor.yaml
 - windows-exporter-role.yaml
 - windows-exporter-role-binding.yaml
 - prometheusRule.yaml

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,7 +28,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=create;get;delete;update;patch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list
-//+kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=create,get,delete
+//+kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=create;get;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=*
 
 var (


### PR DESCRIPTION
This PR fixes the make bundle command that was broken with recent changes to serviceMonitor. It removes the servicemonitor.yaml requirement from kustomization.yaml since the responsiblity of its generation has been moved from OLM to WMCO.
It also fixes the kubebuilder delimiters in metrics.go file.