### PR TITLE
[release-4.12] Disable buildvcs for ovn-kubernetes build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ COPY .git .git
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/
 COPY ovn-kubernetes/ .
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
-RUN make windows
+RUN WINDOWS_BUILD="yes" GOFLAGS=-buildvcs=false hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -11,7 +11,7 @@ COPY .git .git
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/
 COPY ovn-kubernetes/ .
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
-RUN make windows
+RUN WINDOWS_BUILD="yes" GOFLAGS=-buildvcs=false hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -19,7 +19,7 @@ COPY .git .git
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/
 COPY ovn-kubernetes/ .
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
-RUN make windows
+RUN WINDOWS_BUILD="yes" GOFLAGS=-buildvcs=false hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/

--- a/build/Dockerfile.konflux
+++ b/build/Dockerfile.konflux
@@ -8,7 +8,7 @@ COPY .git .git
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/
 COPY ovn-kubernetes/ .
 WORKDIR /build/windows-machine-config-operator/ovn-kubernetes/go-controller/
-RUN make windows
+RUN WINDOWS_BUILD="yes" GOFLAGS=-buildvcs=false hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
 # Build promu utility tool, needed to build the windows_exporter.exe metrics binary
 WORKDIR /build/windows-machine-config-operator/promu/


### PR DESCRIPTION
This PR adjust the build settings for ovn-kubernetes with buildvcs=false

xref https://issues.redhat.com/browse/OCPBUGS-37282?focusedId=25438575&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25438575

