### PR TITLE
WINC-1337: Use upstreamed dependency code

### DIFF
--- a/pkg/daemon/fake/manager.go
+++ b/pkg/daemon/fake/manager.go
@@ -142,7 +142,7 @@ func (t *testMgr) EnsureServiceState(service winsvc.Service, state svc.State) er
 		if !ok {
 			return fmt.Errorf("service is not correct type")
 		}
-		dependentServices, err := t.listDependentServices(fakeService.name)
+		dependentServices, err := fakeService.ListDependentServices(svc.AnyActivity)
 		if err != nil {
 			return err
 		}
@@ -163,26 +163,6 @@ func (t *testMgr) EnsureServiceState(service winsvc.Service, state svc.State) er
 		return fmt.Errorf("unexpected state request: %d", state)
 	}
 }
-
-func (t *testMgr) listDependentServices(serviceName string) ([]string, error) {
-	var dependencies []string
-	for name, svc := range t.svcList.svcs {
-		if name == serviceName {
-			continue
-		}
-		config, err := svc.Config()
-		if err != nil {
-			return nil, err
-		}
-		for _, s := range config.Dependencies {
-			if s == serviceName {
-				dependencies = append(dependencies, name)
-			}
-		}
-	}
-	return dependencies, nil
-}
-
 func NewTestMgr(existingServices map[string]*FakeService) *testMgr {
 	testMgr := &testMgr{newFakeServiceList()}
 	if existingServices != nil {

--- a/pkg/daemon/winsvc/winsvc.go
+++ b/pkg/daemon/winsvc/winsvc.go
@@ -19,6 +19,7 @@ type Service interface {
 	Control(svc.Cmd) (svc.Status, error)
 	Query() (svc.Status, error)
 	UpdateConfig(mgr.Config) error
+	ListDependentServices(status svc.ActivityStatus) ([]string, error)
 }
 
 // WaitForState retries until the services reaches the expected state, or reaches timeout


### PR DESCRIPTION
Changes the code to list Windows services dependencies to use the function which was upstreamed into the go windows svc libraries.