### PR TITLE
[release-4.13] submodule update 09 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WMCO_VERSION ?= 8.1.4
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh
-KUBELET_GIT_VERSION=v1.26.15+e0953cc
+KUBELET_GIT_VERSION=v1.26.15+53fd427
 KUBE-PROXY_GIT_VERSION=v1.26.0+ec42cea
 CONTAINERD_GIT_VERSION=v1.6.24-8-g6bbc7a691
 


### PR DESCRIPTION
[[submodule][kubelet] Update to 53fd427d582](https://github.com/openshift/windows-machine-config-operator/commit/3944bc6962b30ec92a2f525b90247faeaf99803b)
[[build] Update kubelet version to v1.26.15+53fd427](https://github.com/openshift/windows-machine-config-operator/commit/4729b1eaf74cceba9389e579ee333766a1ec80c0)