### PR TITLE
WINC-1326: Use new repo for vSphere CSI driver image

### DIFF
--- a/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
+++ b/hack/manifests/csi/vsphere/01-example-driver-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
                 - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0
+          image: registry.k8s.io/csi-vsphere/driver:v3.3.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/test/e2e/providers/vsphere/vsphere.go
+++ b/test/e2e/providers/vsphere/vsphere.go
@@ -292,7 +292,7 @@ func (p *Provider) ensureWindowsCSIDaemonSet(client client.Interface) error {
 						},
 						{
 							Name:  "vsphere-csi-node",
-							Image: "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.0",
+							Image: "registry.k8s.io/csi-vsphere/driver:v3.3.0",
 							Args:  []string{"--fss-name=" + windowsFSSName, "--fss-namespace=$(CSI_NAMESPACE)"},
 							Env: []core.EnvVar{
 								{


### PR DESCRIPTION
Use the new community owned registry for vSphere CSI driver image after the old one was deprecated and bump the driver version

