### PR TITLE
OCPBUGS-35285: Remove HNS networks before rebooting in AWS

### DIFF
--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -276,6 +276,14 @@ func (nc *nodeConfig) SafeReboot(ctx context.Context) error {
 		return fmt.Errorf("unable to drain node %s: %w", nc.node.Name, err)
 	}
 
+	// HNS networks conflicts with the persistent route to the metadata endpoint in AWS. Explicitly remove them
+	// to allow the same VM to be configured as a node again.
+	if nc.platformType == configv1.AWSPlatformType {
+		if err := nc.Windows.EnsureHNSNetworksAreRemoved(); err != nil {
+			return err
+		}
+	}
+
 	if err := nc.Windows.RebootAndReinitialize(); err != nil {
 		return err
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -277,7 +277,7 @@ func (nc *nodeConfig) SafeReboot(ctx context.Context) error {
 	}
 
 	// HNS networks conflicts with the persistent route to the metadata endpoint in AWS. Explicitly remove them
-	// to allow the same VM to be configured as a node again.
+	// to allow the same instance to be configured as a node again.
 	if nc.platformType == configv1.AWSPlatformType {
 		if err := nc.Windows.EnsureHNSNetworksAreRemoved(); err != nil {
 			return err

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -250,6 +250,9 @@ type Windows interface {
 	// The content will be copied to the Windows VM if the file is not present or has incorrect contents. The remote
 	// directory is created if it does not exist.
 	EnsureFileContent([]byte, string, string) error
+	// EnsureHNSNetworksAreRemoved ensures the HNS networks created by the hybrid-overlay configuration process are removed
+	// by repeatedly checking and retrying the removal of each network.
+	EnsureHNSNetworksAreRemoved() error
 	// FileExists returns true if a specific file exists at the given path and checksum on the Windows VM. Set an
 	// empty checksum (checksum == "") to disable checksum check.
 	FileExists(string, string) (bool, error)
@@ -519,7 +522,7 @@ func (vm *windows) RunWICDCleanup(watchNamespace, wicdKubeconfig string) error {
 }
 
 func (vm *windows) RemoveFilesAndNetworks() error {
-	if err := vm.ensureHNSNetworksAreRemoved(); err != nil {
+	if err := vm.EnsureHNSNetworksAreRemoved(); err != nil {
 		return fmt.Errorf("unable to ensure HNS networks are removed: %w", err)
 	}
 	if err := vm.removeDirectories(); err != nil {
@@ -955,9 +958,7 @@ func (vm *windows) newFileInfo(path string) (*payload.FileInfo, error) {
 	return &payload.FileInfo{Path: path, SHA256: sha}, nil
 }
 
-// ensureHNSNetworksAreRemoved ensures the HNS networks created by the hybrid-overlay configuration process are removed
-// by repeatedly checking and retrying the removal of each network.
-func (vm *windows) ensureHNSNetworksAreRemoved() error {
+func (vm *windows) EnsureHNSNetworksAreRemoved() error {
 	vm.log.Info("removing HNS networks")
 	var err error
 	// VIP HNS endpoint created by the operator is also deleted when the HNS networks are deleted.

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -3,12 +3,16 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
 	"testing"
 
+	config "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
@@ -16,8 +20,36 @@ import (
 func reconfigurationTestSuite(t *testing.T) {
 	tc, err := NewTestContext()
 	require.NoError(t, err)
+	t.Run("Remove version annotation", tc.testRemoveVersionAnnotation)
 	t.Run("Re-add removed instance", tc.testReAddInstance)
 	t.Run("Change private key", testPrivateKeyChange)
+}
+
+// testRemoveVersionAnnotation tests the case where the version annotation is removed from the node.
+func (tc *testContext) testRemoveVersionAnnotation(t *testing.T) {
+	if tc.CloudProvider.GetType() == config.AWSPlatformType {
+		t.Skipf("Skipping for %s", tc.CloudProvider.GetType())
+	}
+	ctx := context.TODO()
+	require.NoError(t, tc.loadExistingNodes(), "error getting the current Windows nodes in the cluster")
+	// machines instances
+	for _, node := range gc.machineNodes {
+		err := removeVersionAnnotation(tc, ctx, node.Name)
+		require.NoError(t, err, "error removing version annotation")
+
+		err = tc.waitForConfiguredWindowsNodes(gc.numberOfMachineNodes, true, false)
+		require.NoError(t, err, "error waiting for the machine instance to become Windows node")
+	}
+	// BYOH instances
+	for _, node := range gc.byohNodes {
+		err := removeVersionAnnotation(tc, ctx, node.Name)
+		require.NoError(t, err, "error removing version annotation")
+
+		err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
+		require.NoError(t, err, "error waiting for the BYOH instance to become Windows node")
+	}
+	// check nodes are ready and schedulable
+	tc.testNodesBecomeReadyAndSchedulable(t)
 }
 
 // testReAddInstance tests the case where a Windows BYOH instance was removed from the cluster, and then re-added.
@@ -72,4 +104,18 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	require.NoError(t, err, "error waiting for the Windows node to be re-added")
 	tc.testNodesBecomeReadyAndSchedulable(t)
+}
+
+// removeVersionAnnotation removes the version annotation from the given node
+func removeVersionAnnotation(tc *testContext, ctx context.Context, nodeName string) error {
+	log.Printf("removing version annotation from node: %s", nodeName)
+	patchData, err := metadata.GenerateRemovePatch([]string{}, []string{metadata.VersionAnnotation})
+	if err != nil {
+		return fmt.Errorf("error creating version annotation remove request: %w", err)
+	}
+	_, err = tc.client.K8s.CoreV1().Nodes().Patch(ctx, nodeName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("error removing version annotation from node %s: %w", nodeName, err)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR introduces a fix for AWS as a particular case where the EC2 Agent fails to configure the metadata endpoint when the HNS are fully configured with the virtual network interfaces.

followup-to
- https://github.com/openshift/windows-machine-config-operator/pull/2282