### PR TITLE
OCPBUGS-42827: [release-4.17] Adjust k8s version for kube 1.30

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -518,7 +518,7 @@ spec:
   - email: team-winc@redhat.com
     name: Red Hat, Windows Container Support for OpenShift
   maturity: stable
-  minKubeVersion: 1.29.0
+  minKubeVersion: 1.30.0
   provider:
     name: Red Hat
   version: 10.17.1

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -176,7 +176,7 @@ spec:
   - email: team-winc@redhat.com
     name: Red Hat, Windows Container Support for OpenShift
   maturity: stable
-  minKubeVersion: 1.29.0
+  minKubeVersion: 1.30.0
   provider:
     name: Red Hat
   version: 0.0.0

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -24,7 +24,7 @@ const (
 	ovnKubernetesNetwork = "OVNKubernetes"
 	// baseK8sVersion specifies the base k8s version supported by the operator. (For eg. All versions in the format
 	// 1.20.x are supported for baseK8sVersion 1.20)
-	baseK8sVersion = "v1.29"
+	baseK8sVersion = "v1.30"
 	// MachineAPINamespace is the name of the namespace in which machine objects and userData secret is created.
 	MachineAPINamespace = "openshift-machine-api"
 )

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -125,9 +125,9 @@ func TestIsValidKubernetesVersion(t *testing.T) {
 		error   bool
 	}{
 		{"cluster version lower than supported version ", "v1.17.1", true},
-		{"cluster version equals supported version", "v1.29.0", false},
-		{"cluster version equals supported version", "v1.30.4", false},
-		{"cluster version greater than supported version ", "v1.31.2", true},
+		{"cluster version equals supported version", "v1.30.0", false},
+		{"cluster version equals supported version", "v1.31.4", false},
+		{"cluster version greater than supported version ", "v1.32.2", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Supports k8s versions 1.30 & 1.31.