### PR TITLE
WINC-1329: [bundle.Dockerfile] Update supported version to 4.18

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.17"
+LABEL com.redhat.openshift.versions="=v4.18"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically


### PR DESCRIPTION
This PR updates the operator-supported version label to 4.18. We were waiting for CVP to support
4.18 before making this change, this can be done with the latest support announcement.
This will also help with a failing CVP test that checks if the OCP version label corresponds to the minkubeversion specified in the CSV.