### PR TITLE
Hardcode Azure SKU version for 2019 nodes

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -152,10 +152,12 @@ get_azure_ms() {
   local byoh=$6
 
   local sku="2022-datacenter-smalldisk"
+  local release="latest"
   if [ "$winver" == "2019" ]; then
 		# 2019 images without the containers feature pre-installed cannot be used due to
 		# https://issues.redhat.com/browse/OCPBUGS-13244
     sku="2019-datacenter-with-containers-smalldisk"
+    release="17763.6293.240905"   
   fi
 
   cat <<EOF
@@ -171,7 +173,7 @@ $(get_spec $infraID $az $provider $byoh)
             publisher: MicrosoftWindowsServer
             resourceID: ""
             sku: $sku
-            version: latest
+            version: $release
           kind: AzureMachineProviderSpec
           location: ${region}
           managedIdentity: ${infraID}-identity

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -52,6 +52,11 @@ func New(clientset *clusterinfo.OpenShift, infraStatus *config.InfrastructureSta
 
 // newAzureMachineProviderSpec returns an AzureMachineProviderSpec generated from the inputs, or an error
 func (p *Provider) newAzureMachineProviderSpec(location string, zone string, windowsServerVersion windows.ServerVersion) (*mapi.AzureMachineProviderSpec, error) {
+	imageVersion := defaultImageVersion
+	if windowsServerVersion == windows.Server2019 {
+		// TODO: remove when VM SSH issue is patched in Azure cloud
+		imageVersion = "17763.6293.240905"
+	}
 	return &mapi.AzureMachineProviderSpec{
 		TypeMeta: meta.TypeMeta{
 			APIVersion: "azureproviderconfig.openshift.io/v1beta1",
@@ -72,7 +77,7 @@ func (p *Provider) newAzureMachineProviderSpec(location string, zone string, win
 			Publisher: defaultImagePublisher,
 			Offer:     defaultImageOffer,
 			SKU:       getImageSKU(windowsServerVersion),
-			Version:   defaultImageVersion,
+			Version:   imageVersion,
 		},
 		OSDisk: mapi.OSDisk{
 			OSType:     "Windows",


### PR DESCRIPTION
This PR hardcodes Azure VMs to a specific version as the latest build released by MSFT is unstable. Any Windows Server 2019 VMs created from the October 2024 release `"version": "17763.6414.241004"` has issues preventing SSH connections.

Required to unblock CI. Should be reverted when patched Windows Server images are released.