### PR TITLE
OCPBUGS-18898: Highlight UPI support for platform:none and update pre-req docs

### DIFF
--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -9,8 +9,8 @@ may be relevant.
   platform (`platform: none`) for the [BYOH (Bring Your Own Host)](byoh-instance-pre-requisites.md#byoh-instance-pre-requisites)
   use case. UPI is not supported in any other platform.
 
-## Supported Cloud Providers based on OKD/OCP Version and WMCO version
-| Cloud Provider            | Supported OKD/OCP Version | Supported WMCO version |
+## Supported Platforms based on OKD/OCP Version and WMCO version
+| Platforms                 | Supported OKD/OCP Version | Supported WMCO version |
 |---------------------------|---------------------------|------------------------|
 | VMware vSphere            | 4.7+                      | WMCO 2.0+              |
 | Platform none (BYOH)      | 4.8+                      | WMCO 3.1.0+            |

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -2,6 +2,13 @@
 Below are the Cluster and OS prerequisites for WMCO. Please also see the vSphere-specific section that 
 may be relevant.
 
+## Supported Installation method
+* Installer-Provisioned Infrastructure (IPI) installation method is supported and the recommended installation method.
+
+* User-Provisioned Infrastructure (UPI) is **only supported** on Bare metal or Provider-agnostic
+  platform (`platform: none`) for the [BYOH (Bring Your Own Host)](byoh-instance-pre-requisites.md#byoh-instance-pre-requisites)
+  use case. UPI is not supported in any other platform.
+
 ## Supported Cloud Providers based on OKD/OCP Version and WMCO version
 | Cloud Provider            | Supported OKD/OCP Version | Supported WMCO version |
 |---------------------------|---------------------------|------------------------|
@@ -57,12 +64,6 @@ Note:
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Default VXLAN port   | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
 | Custom VXLAN port    | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
-
-## Supported Installation method
-* Installer-Provisioned Infrastructure installation method is the only supported installation method. This is 
-consistent across all supported cloud providers.
-  
-* User-Provisioned Infrastructure is NOT supported.
 
 ## vSphere Specific Requirements
 Please refer to [VMware vSphere pre-requisites](vsphere-prerequisites.md).

--- a/docs/wmco-prerequisites.md
+++ b/docs/wmco-prerequisites.md
@@ -33,13 +33,13 @@ applicable cloud provider.
 Note: Any unlisted Windows Server version are NOT supported, and will cause errors. To prevent 
 these errors, only use the appropriate version according to the cloud provider in use. 
 
-| Cloud Provider | Supported Windows Server version                                                                                                  |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| AWS            | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
-| Azure          | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
-| GCP            | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
-| VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
-| Nutanix        | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
+| Cloud Provider | Supported Windows Server version                                                                                                   |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| AWS            | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC) |
+| Azure          | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC) |
+| GCP            | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                             |
+| VMware vSphere | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                             |
+| Nutanix        | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                             |
 
 *Please note that the Windows Server 2022 image must contain the OS-level container networking patch [KB5012637](https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d).*
 
@@ -52,18 +52,18 @@ Note:
 * OpenShiftSDN networking is the default network for OpenShift clusters. It is NOT supported by WMCO.
 * Dual NIC is NOT supported by WMCO.
 
-| Cloud Provider | Supported networking                                                                           |
-|----------------|------------------------------------------------------------------------------------------------|
-| AWS            | Hybrid OVNKubernetes                                                                           |
-| Azure          | Hybrid OVNKubernetes                                                                           |
-| GCP            | Hybrid OVNKubernetes                                                                           |
+| Cloud Provider | Supported networking                                                                                                                                                                |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AWS            | Hybrid OVNKubernetes                                                                                                                                                                |
+| Azure          | Hybrid OVNKubernetes                                                                                                                                                                |
+| GCP            | Hybrid OVNKubernetes                                                                                                                                                                |
 | VMware vSphere | Hybrid OVNKubernetes with a [Custom VXLAN port](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html) |
-| Nutanix        | Hybrid OVNKubernetes                                                                           |
+| Nutanix        | Hybrid OVNKubernetes                                                                                                                                                                |
 
-| Hybrid OVNKubernetes | Supported Windows Server version                                                                                                  |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Default VXLAN port   | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC)|
-| Custom VXLAN port    | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                            |
+| Hybrid OVNKubernetes | Supported Windows Server version                                                                                                   |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| Default VXLAN port   | - Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)<br>- Windows Server 2022 Long-Term Servicing Channel (LTSC) |
+| Custom VXLAN port    | Windows Server 2022 Long-Term Servicing Channel (LTSC)                                                                             |
 
 ## vSphere Specific Requirements
 Please refer to [VMware vSphere pre-requisites](vsphere-prerequisites.md).


### PR DESCRIPTION
This PR moves the Supported Installation method section up in the
Pre-Requisites to highlight that UPI is supported for platform:none.