### PR TITLE
WINC-1352: Build CNI plugins with CGO_ENABLED

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -71,8 +71,7 @@ RUN env -u VERSION GOOS=windows make ecr-credential-provider
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
-RUN ./build_windows.sh
+RUN CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc ./build_windows.sh
 
 # Build csi-proxy
 WORKDIR /build/windows-machine-config-operator/csi-proxy

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -70,8 +70,7 @@ RUN env -u VERSION GOOS=windows make ecr-credential-provider
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
-RUN ./build_windows.sh
+RUN CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc ./build_windows.sh
 
 # Build csi-proxy
 WORKDIR /build/windows-machine-config-operator/csi-proxy

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -78,8 +78,7 @@ RUN env -u VERSION GOOS=windows make ecr-credential-provider
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
-RUN ./build_windows.sh
+RUN CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc ./build_windows.sh
 
 # Build csi-proxy
 WORKDIR /build/windows-machine-config-operator/csi-proxy

--- a/build/Dockerfile.konflux
+++ b/build/Dockerfile.konflux
@@ -68,8 +68,7 @@ RUN env -u VERSION GOOS=windows make ecr-credential-provider
 # Build CNI plugins
 WORKDIR /build/windows-machine-config-operator/containernetworking-plugins/
 COPY containernetworking-plugins/ .
-ENV CGO_ENABLED=0
-RUN ./build_windows.sh
+RUN CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc ./build_windows.sh
 
 # Build csi-proxy
 WORKDIR /build/windows-machine-config-operator/csi-proxy


### PR DESCRIPTION
CNI submodule is compiled by explicitly setting CGO_ENABLED=0 which is not FIPS compliant. This commit remidaiates this by using a Windows-compatible C compiler “CC=gcc-mingw-w64” in the go build command.
