### PR TITLE
Add generated MachineSet.yaml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 build/_output
 build/_test
 bin/
+
+# Temporary test and deploy files
+MachineSet.yaml
+
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-


### PR DESCRIPTION
This commit exclude the MachineSet.yaml file generated by hack/machineset.sh for local development.