### PR TITLE
Fix incorrect rolebinding error message and improve logging

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -118,6 +118,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("platform", "type", clusterConfig.Platform())
+
 	// Checking if required files exist before starting the operator
 	requiredFiles := []string{
 		payload.HostLocalCNIPlugin,

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -604,13 +604,15 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding(ctx context.Context) error {
 			"RoleRef", existingRB.RoleRef.Name, "Subjects", existingRB.Subjects)
 	}
 	// create proper resource if it does not exist
-	_, err = r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Create(ctx, expectedRB,
+	createdRB, err := r.k8sclientset.RbacV1().RoleBindings(r.watchNamespace).Create(ctx, expectedRB,
 		meta.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
 	}
 	r.log.Info("Created resource", "RoleBinding",
-		kubeTypes.NamespacedName{Namespace: r.watchNamespace, Name: expectedRB.Name})
+		kubeTypes.NamespacedName{Namespace: createdRB.Namespace, Name: createdRB.Name},
+		"RoleRef", createdRB.RoleRef.Name, "Subjects", createdRB.Subjects)
+
 	return nil
 }
 
@@ -653,9 +655,10 @@ func (r *ConfigMapReconciler) ensureWICDClusterRoleBinding(ctx context.Context) 
 			"RoleRef", existingCRB.RoleRef.Name, "Subjects", existingCRB.Subjects)
 	}
 	// create proper resource if it does not exist
-	_, err = r.k8sclientset.RbacV1().ClusterRoleBindings().Create(ctx, expectedCRB, meta.CreateOptions{})
+	createdCRB, err := r.k8sclientset.RbacV1().ClusterRoleBindings().Create(ctx, expectedCRB, meta.CreateOptions{})
 	if err == nil {
-		r.log.Info("Created resource", "ClusterRoleBinding", expectedCRB.Name)
+		r.log.Info("Created resource", "ClusterRoleBinding", createdCRB.Name,
+			"RoleRef", createdCRB.RoleRef.Name, "Subjects", createdCRB.Subjects)
 	}
 	return err
 }

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -600,7 +600,7 @@ func (r *ConfigMapReconciler) ensureWICDRoleBinding(ctx context.Context) error {
 			return fmt.Errorf("unable to delete RoleBinding %s/%s: %w", r.watchNamespace, wicdRBACResourceName, err)
 		}
 		r.log.Info("Deleted malformed resource", "RoleBinding",
-			kubeTypes.NamespacedName{Namespace: r.watchNamespace, Name: existingRB.Name},
+			kubeTypes.NamespacedName{Namespace: existingRB.Namespace, Name: existingRB.Name},
 			"RoleRef", existingRB.RoleRef.Name, "Subjects", existingRB.Subjects)
 	}
 	// create proper resource if it does not exist


### PR DESCRIPTION
This PR introduces fixes and improvements to the logging messages in both the `cmd` and `controller` packages to enhance debugging capabilities. Particularly, correct the log message for RB deletion to show the namespace of the malformed resource properly.