### PR TITLE
Adjust upgradeable condition timeout in test suite

### DIFF
--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -756,7 +756,7 @@ func (tc *testContext) validateUpgradeableCondition(expected meta.ConditionStatu
 	if err != nil {
 		return err
 	}
-	err = wait.Poll(retry.Interval, retry.ResourceChangeTimeout, func() (bool, error) {
+	err = wait.Poll(retry.Interval, retry.Timeout, func() (bool, error) {
 		oc, err := tc.client.Olm.OperatorsV2().OperatorConditions(wmcoNamespace).Get(context.TODO(), ocName, meta.GetOptions{})
 		if err != nil {
 			log.Printf("unable to get OperatorCondition %s from namespace %s", ocName, wmcoNamespace)


### PR DESCRIPTION
This PR increases the timeout of the UpgradeableCondition validation so that the tests have enough time to pull the change.

Follow-up to
- https://github.com/openshift/windows-machine-config-operator/pull/2568

Job failed due to UpgradeableCondition validation timing out. 

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_windows-machine-config-operator/2568/pull-ci-openshift-windows-machine-config-operator-release-4.18-aws-e2e-operator/1864538481087221760#1:build-log.txt%3A708