### PR TITLE
[release-4.17] Adjust konflux pipelines to work with Enterprise Contract

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-17-pull-request.yaml
@@ -20,6 +20,8 @@ metadata:
   namespace: windows-machine-conf-tenant
 spec:
   params:
+  - name: hermetic
+    value: "false"
   - name: dockerfile
     value: build/bundle-konflux.Dockerfile
   - name: git-url
@@ -226,9 +228,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-10gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-10gb:0.2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:ae8dcd146ac80f5b3f9fece916b5125417fc7db1b37ec176068f9cd0801cebfb
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-bundle-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-17-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "release-4.17"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && "build/bundle-konflux.Dockerfile".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-4-17

--- a/.tekton/windows-machine-config-operator-bundle-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-17-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "release-4.17"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && "build/bundle-konflux.Dockerfile".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-4-17

--- a/.tekton/windows-machine-config-operator-bundle-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-17-push.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: windows-machine-conf-tenant
 spec:
   params:
+  - name: hermetic
+    value: "false"
   - name: dockerfile
     value: build/bundle-konflux.Dockerfile
   - name: git-url
@@ -223,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-10gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-10gb:0.2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:ae8dcd146ac80f5b3f9fece916b5125417fc7db1b37ec176068f9cd0801cebfb
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-17-pull-request.yaml
@@ -20,6 +20,8 @@ metadata:
   namespace: windows-machine-conf-tenant
 spec:
   params:
+  - name: hermetic
+    value: "false"
   - name: dockerfile
     value: build/Dockerfile.konflux
   - name: git-url
@@ -226,9 +228,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-10gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-10gb:0.2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:ae8dcd146ac80f5b3f9fece916b5125417fc7db1b37ec176068f9cd0801cebfb
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-release-4-17-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-17-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "release-4.17"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|bundle-konflux.Dockerfile)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-4-17

--- a/.tekton/windows-machine-config-operator-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-17-push.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: windows-machine-conf-tenant
 spec:
   params:
+  - name: hermetic
+    value: "false"
   - name: dockerfile
     value: build/Dockerfile.konflux
   - name: git-url
@@ -223,9 +225,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-10gb
+          value: buildah
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-10gb:0.2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:ae8dcd146ac80f5b3f9fece916b5125417fc7db1b37ec176068f9cd0801cebfb
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-release-4-17-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-17-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "release-4.17"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|bundle-konflux.Dockerfile)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-4-17

--- a/build/Dockerfile.konflux
+++ b/build/Dockerfile.konflux
@@ -124,6 +124,17 @@ RUN make build-daemon
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=operator
 
+# This block contains standard Red Hat container labels
+LABEL name="openshift4-wincw/windows-machine-config-operator" \
+    License="ASL 2.0" \
+    io.k8s.display-name="Windows Machine Config Operator" \
+    io.k8s.description="Windows Machine Config Operator" \
+    description="Windows Machine Config Operator" \
+    summary="Windows Machine Config Operator" \
+    maintainer="Team Windows Containers <team-winc@redhat.com>" \
+    com.redhat.component="windows-machine-config-operator-container" \
+    io.openshift.tags=""
+
 WORKDIR /payload/
 # Copy WICD
 COPY --from=build /build/windows-machine-config-operator/build/_output/bin/windows-instance-config-daemon.exe .

--- a/build/bundle-konflux.Dockerfile
+++ b/build/bundle-konflux.Dockerfile
@@ -4,13 +4,15 @@ RUN sed -i "s|REPLACE_IMAGE|quay.io/redhat-user-workloads/windows-machine-conf-t
 
 FROM scratch
 
-# This block are standard Red Hat container labels
+# This block contains standard Red Hat container labels
 LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator bundle" \
     io.k8s.description="Windows Machine Config Operator's OLM bundle image" \
+	description="Windows Machine Config Operator's OLM bundle image" \
     summary="Windows Machine Config Operator's OLM bundle image" \
-    maintainer="Team Windows Containers <team-winc@redhat.com>"
+    maintainer="Team Windows Containers <team-winc@redhat.com>" \
+    io.openshift.tags=""
 
 # These are three labels needed to control how the pipeline should handle this container image
 # This first label tells the pipeline that this is a bundle image and should be
@@ -42,6 +44,11 @@ LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+LABEL distribution-scope=public
+LABEL release="10.17.1"
+LABEL url="https://docs.openshift.com/container-platform/4.17/windows_containers/index.html"
+LABEL vendor="Red Hat"
 
 # Copy files to locations specified by labels.
 COPY --from=image-replacer /manifests /manifests/


### PR DESCRIPTION
Adds changes to adhere to the required build policies
Also prevents operator from being built when only the bundle should built.