### PR TITLE
Add version label to operator image

### DIFF
--- a/build/Dockerfile.konflux
+++ b/build/Dockerfile.konflux
@@ -201,4 +201,7 @@ RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
+# Used to tag the released image. Should be a semver.
+LABEL version="v10.19.0"
+
 USER ${USER_UID}

--- a/build/bundle-konflux.Dockerfile
+++ b/build/bundle-konflux.Dockerfile
@@ -29,6 +29,7 @@ LABEL com.redhat.openshift.versions="=v4.19"
 # registry endpoints.
 LABEL com.redhat.delivery.backport=false
 
+# Used to tag the released image. Should be a semver.
 LABEL version="v10.19.0"
 
 # This label maps to the brew build target


### PR DESCRIPTION
This label is used by the konflux RPA to tag the image with the correct semver.