### PR TITLE
Change operator image ref to stage

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -4,6 +4,6 @@ metadata:
   name: wmco-idms
 spec:
   imageDigestMirrors:
-  - source: registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator
+  - source: registry.stage.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator
     mirrors:
-      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-18
+      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-master

--- a/build/bundle-konflux.Dockerfile
+++ b/build/bundle-konflux.Dockerfile
@@ -1,6 +1,6 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as image-replacer
 COPY bundle/manifests /manifests
-RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:05223a792a351ac5d6e610544507c8ce59356c392c646ef79d4cfc24d1f04e52|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
+RUN sed -i "s|REPLACE_IMAGE|registry.stage.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:05223a792a351ac5d6e610544507c8ce59356c392c646ef79d4cfc24d1f04e52|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 
 FROM scratch
 


### PR DESCRIPTION
Changes the registry to stage as master will never have a production release. As there will be no prod RPA for master, the renovate nudge functionality will not work properly without this change.