### PR TITLE
[release-4.18] Fix WMCO image reference

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -1,6 +1,6 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as image-replacer
 COPY bundle/manifests /manifests
-RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator:10.18.0@sha256:3d3ae08a7c979f6d18e22db4f395b4d6dfe72bfd88404e7291549a29863d0566|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
+RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:99e0a712da0c681840bf0de7595f1b3e80b07d2bb4a46d71e3d14b338b92908e|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 
 FROM scratch
 


### PR DESCRIPTION
Was incorrectly using tag + digest. When referencing an image only the digest should be used.