### PR TITLE
Add node object to e2e artifacts and remove unused test code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ bin/
 
 # Temporary test and deploy files
 MachineSet.yaml
+/test/e2e/pods/
+/test/e2e/nodes/
 
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -3,10 +3,15 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math"
 	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +101,11 @@ func (tc *testContext) testWindowsNodeCreation(t *testing.T) {
 	// failing the pub key annotation validation as it compares the current private key secret with the annotation.
 	// TODO: Remove this dependency by rotating keys as part of https://issues.redhat.com/browse/WINC-655
 	t.Run("ConfigMap controller", tc.testBYOHConfiguration)
+
+	err := retrieveWindowsNodeObjects()
+	if err != nil {
+		log.Printf("error retrieving windows node objects: %s", err)
+	}
 }
 
 // nodelessLogCollection runs a job which will print to stdout all logs in /var/log on the given instance
@@ -683,4 +693,26 @@ func (tc *testContext) createPullSecret() error {
 	}
 
 	return nil
+}
+
+// retrieveWindowsNodeObjects retrieves the Windows node objects from the cluster and writes them to the given directory
+func retrieveWindowsNodeObjects() error {
+	outputFormat := "json"
+	cmd := exec.Command("oc", "get", "nodes", "-l kubernetes.io/os=windows", "-o"+outputFormat)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		stderr := ""
+		if errors.As(err, &exitError) {
+			stderr = string(exitError.Stderr)
+		}
+		return fmt.Errorf("oc get nodes failed with exit code %s and output: %s: %s", err, string(out), stderr)
+	}
+	destDir := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
+	err = os.MkdirAll(destDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	outputFile := filepath.Join(destDir, "nodes"+"."+outputFormat)
+	return ioutil.WriteFile(outputFile, out, os.ModePerm)
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -191,25 +191,6 @@ func (tc *testContext) getKubeletServiceBinPath(node *core.Node) (string, error)
 	return out, nil
 }
 
-// getInstanceID gets the instanceID of VM for a given cloud provider ID
-// Ex: aws:///us-east-1e/i-078285fdadccb2eaa. We always want the last entry which is the instanceID
-func getInstanceID(providerID string) string {
-	providerTokens := strings.Split(providerID, "/")
-	return providerTokens[len(providerTokens)-1]
-}
-
-// getInstanceIDsOfNodes returns the instanceIDs of all the Windows nodes created
-func (tc *testContext) getInstanceIDsOfNodes() ([]string, error) {
-	instanceIDs := make([]string, 0, len(gc.allNodes()))
-	for _, node := range gc.allNodes() {
-		if len(node.Spec.ProviderID) > 0 {
-			instanceID := getInstanceID(node.Spec.ProviderID)
-			instanceIDs = append(instanceIDs, instanceID)
-		}
-	}
-	return instanceIDs, nil
-}
-
 // getWMCOVersion returns the version that the operator reports
 func getWMCOVersion() (string, error) {
 	cmd := exec.Command("oc", "exec", "deploy/windows-machine-config-operator", "-n", wmcoNamespace, "--",


### PR DESCRIPTION
- introduces the `nodes.json` file in the nodes artifact dir
with a dump of the existing Windows node objects so that there is information
of the Windows node objects after the test suite ends.

- deletes the getInstanceIDsOfNodes and getInstanceID helpers,
no longer in use.