### PR TITLE
[release-4.18] WINC-1351: Fix WMCO's go build command to FIPS compliant and set strictfipsruntime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # downloading the latest version
 ENV GOTOOLCHAIN=local
 
+ENV GOEXPERIMENT=strictfipsruntime
+
 WORKDIR /build/windows-machine-config-operator/
 COPY .git .git
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
 
 LABEL stage=build
 
@@ -9,6 +9,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # Set go toolchain to local, this prevents it from
 # downloading the latest version
 ENV GOTOOLCHAIN=local
+
+ENV GOEXPERIMENT=strictfipsruntime
 
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
 LABEL stage=build
 
 # Silence go compliance shim output
@@ -8,6 +8,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # Set go toolchain to local, this prevents it from
 # downloading the latest version
 ENV GOTOOLCHAIN=local
+
+ENV GOEXPERIMENT=strictfipsruntime
 
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -14,6 +14,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # Set go toolchain to local, this prevents it from
 # downloading the latest version
 ENV GOTOOLCHAIN=local
+
+ENV GOEXPERIMENT=strictfipsruntime
 
 # dos2unix is needed to build CNI plugins
 RUN yum install -y dos2unix

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
 LABEL stage=build
 
 # Silence go compliance shim output
@@ -8,6 +8,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # Set go toolchain to local, this prevents it from
 # downloading the latest version
 ENV GOTOOLCHAIN=local
+
+ENV GOEXPERIMENT=strictfipsruntime
 
 WORKDIR /build/windows-machine-config-operator/
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -43,6 +43,4 @@ mkdir -p "${BIN_DIR}"
 
 # Account for environments where GOFLAGS is not set by setting goflags to an empty string if GOFLAGS is not set
 goflags=${GOFLAGS:-}
-
-
-CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build ${GOFLAGS} -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}'" -o ${BIN_DIR}/${BIN_NAME} ${WMCO_CMD_DIR}
+CGO_ENABLED=1 GO111MODULE=on GOOS=linux go build -tags strictfipsruntime ${GOFLAGS} -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}'" -o ${BIN_DIR}/${BIN_NAME} ${WMCO_CMD_DIR}


### PR DESCRIPTION
Run with GOEXPERIMENT var strictfipsruntime
Fix WMCO/WICD's go build command to FIPS compliant