### PR TITLE
Run with GOEXPERIMENT var strictfipsruntime

### DIFF
--- a/.tekton/windows-machine-config-operator-master-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-master-pull-request.yaml
@@ -177,7 +177,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:994f816e36ac832f4020647afd69223a015c84c503f925013c573fed52f05420
+          value: quay.io/bpimente/test-images:prefetch-deps
         - name: kind
           value: task
         resolver: bundles

--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # downloading the latest version
 ENV GOTOOLCHAIN=local
 
+ENV GOEXPERIMENT=strictfipsruntime
+
 WORKDIR /build/windows-machine-config-operator/
 COPY .git .git
 


### PR DESCRIPTION
This PR sets the value of GOEXPERIMENT variable in Containerfile to strictfipsruntime.
This change is required to build fips compliant images and is in line with rest of the container files.