### PR TITLE
Run with GOEXPERIMENT var strictfipsruntime

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ ENV GO_COMPLIANCE_DEBUG=0
 # downloading the latest version
 ENV GOTOOLCHAIN=local
 
+ENV GOEXPERIMENT=strictfipsruntime
+
 WORKDIR /build/windows-machine-config-operator/
 COPY .git .git
 


### PR DESCRIPTION
This commit sets the value of GOEXPERIMENT
variable in Containerfile to strictfipsruntime.
This change is required to build fips compliant
images and is in line with rest of the container
files.