### PR TITLE
Use golang builder image and bundle dockerfile  in line with OCP 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.22-openshift-4.19

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 as build
 
 LABEL stage=build
 

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 as build
 LABEL stage=build
 WORKDIR /build/
 
@@ -136,7 +136,7 @@ RUN make build-daemon
 #│   └── windows-exporter-webconfig.yaml
 #└── windows-instance-config-daemon.exe
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.19
 LABEL stage=operator
 
 WORKDIR /payload/

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL com.redhat.delivery.operator.bundle=true
 
 # This second label tells the pipeline which versions of OpenShift the operator supports.
 # This is used to control which index images should include this operator.
-LABEL com.redhat.openshift.versions="=v4.18"
+LABEL com.redhat.openshift.versions="=v4.19"
 
 # This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
 # earlier.  It is used to control whether or not the pipeline should attempt to automatically


### PR DESCRIPTION
- Use golang builder image in line with OCP 4.19
- adjust dockerfile for OCP 4.19


Release repo counter part:
- https://github.com/openshift/release/pull/61109