### PR TITLE
WINC-720: Improve network tests and add packet trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	k8s.io/kubectl v0.32.1
 	k8s.io/kubelet v0.32.1
 	k8s.io/kubernetes v1.32.1
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.19.5
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -138,7 +139,6 @@ require (
 	k8s.io/cli-runtime v0.32.1 // indirect
 	k8s.io/component-base v0.32.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
-	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.18.0 // indirect

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -554,7 +554,7 @@ func (tc *testContext) waitForConfiguredWindowsNodes(nodeCount int32, checkVersi
 
 	// We are waiting 20 minutes for each windows VM to be shown up in the cluster. The value comes from
 	// nodeCreationTime variable.
-	err := wait.Poll(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*nodeCreationTime, func() (done bool, err error) {
+	err := wait.PollImmediate(nodeRetryInterval, time.Duration(math.Max(float64(nodeCount), 1))*nodeCreationTime, func() (done bool, err error) {
 		nodes, err := tc.listFullyConfiguredWindowsNodes(isBYOH)
 		if err != nil {
 			log.Printf("failed to get list of configured Windows nodes: %s", err)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -1029,7 +1029,8 @@ func (tc *testContext) waitUntilJobSucceeds(name string) (string, error) {
 	var job *batchv1.Job
 	var err error
 	var labelSelector string
-	for i := 0; i < retryCount; i++ {
+	// Timeout after 5 min
+	for i := 0; i < 60; i++ {
 		job, err = tc.client.K8s.BatchV1().Jobs(tc.workloadNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Adds a packet trace to the networking tests which is saved in the artifacts of test runs.

Adds various improvements to timing to prevent the test run from being killed by timeout.
This is required to allow the packet trace to be completed before ending the test.