### PR TITLE
OCPBUGS-50511: Make debugLogging non-default

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -427,8 +427,8 @@ spec:
             spec:
               containers:
               - args:
-                - --debugLogging
                 - --metrics-bind-address=0.0.0.0:9182
+                - $(ARGS)
                 command:
                 - windows-machine-config-operator
                 env:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,8 +34,8 @@ spec:
       - command:
         - windows-machine-config-operator
         args:
-        - "--debugLogging"
         - "--metrics-bind-address=0.0.0.0:9182"
+        - $(ARGS)
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,5 +1,16 @@
 # Troubleshooting guide
 
+## Enabling debug level logging
+In the Subscription created to deploy the operator add the following to .spec.config.env
+```
+kind: Subscription
+spec:
+  config:
+    env:
+    - name: ARGS
+      value: "--debugLogging"
+```
+
 ## WMCO does not go to running
 Please check if you are using an OKD/OCP cluster adhering to the [operator pre-requisites](wmco-prerequisites.md).
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -112,6 +112,10 @@ if  ! oc get deploy/windows-machine-config-operator -n $WMCO_DEPLOY_NAMESPACE > 
   wmco_deployed_by_script=true
 fi
 
+# Enable debug logging
+WMCO_SUB=$(oc get sub -n $WMCO_DEPLOY_NAMESPACE --no-headers |awk '{print $1}')
+oc patch subscription $WMCO_SUB -n $WMCO_DEPLOY_NAMESPACE --type=merge -p '{"spec":{"config":{"env":[{"name":"ARGS","value":"--debugLogging"}]}}}'
+
 # WINDOWS_INSTANCES_DATA holds the windows-instances ConfigMap data section
 WINDOWS_INSTANCES_DATA=${WINDOWS_INSTANCES_DATA:-}
 # Check WINDOWS_INSTANCES_DATA and create the windows-instances ConfigMap, if


### PR DESCRIPTION
Debug logging can now be enabled by configuring the OLM subscription.