### PR TITLE
Include tag in fips check tekton bundle image ref

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-master-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-master-pull-request.yaml
@@ -287,7 +287,7 @@ spec:
         - name: name
           value: fips-operator-bundle-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta@sha256:e088dbdfdd4918cdb3e0f3a9d5a1569e170cb59d30ec488ea0a429f9fb310236
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:e088dbdfdd4918cdb3e0f3a9d5a1569e170cb59d30ec488ea0a429f9fb310236
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-bundle-master-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-master-push.yaml
@@ -284,7 +284,7 @@ spec:
         - name: name
           value: fips-operator-bundle-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta@sha256:e088dbdfdd4918cdb3e0f3a9d5a1569e170cb59d30ec488ea0a429f9fb310236
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:e088dbdfdd4918cdb3e0f3a9d5a1569e170cb59d30ec488ea0a429f9fb310236
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Without the tag in the image ref, the Conforma lookup fails and the task is considered untrusted.

See https://issues.redhat.com/browse/EC-712 for more details about the root case.

This should fix "Code tampering violation" problem described in https://issues.redhat.com/browse/KFLUXSPRT-1798