### PR TITLE
Disable submodule renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -122,9 +122,8 @@
       "at any time"
     ]
   },
-  "ignoreDeps": ["kubelet/", "kube-proxy/","containerd/"],
   "git-submodules": {
-    "enabled": true,
+    "enabled": false,
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },


### PR DESCRIPTION
As submodule updates can't be selectively disabled, disable all submodule updates through renovate.