### PR TITLE
Stop depending on `jq` binary in e2e run script

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -343,12 +343,13 @@ ${DATA}
 EOF
 }
 
-# returns the number of instances from `windows-instances` ConfigMap
+# returns the number of instances from `windows-instances` ConfigMap by
+# counting the number of values in the data section
 getWindowsInstanceCountFromConfigMap() {
  oc get configmaps \
    windows-instances \
    -n "${WMCO_DEPLOY_NAMESPACE}" \
-   -o json | jq '.data | length'
+   -o jsonpath='{.data.*}' | wc -w
 }
 
 # creates the a job and required RBAC to check the number of Windows nodes performing


### PR DESCRIPTION
This commit replaces the dependency on jq for a core utility to parse the ConfigMap in the common.sh script so that the e2e test scripts does not depend on jq binary installed in the CI image.