### PR TITLE
OCPBUGS-48713: Improve debugging capabilities, code readability, and reliability in network tests

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -943,10 +943,10 @@ func (tc *testContext) getPodEvents(name string) ([]v1.Event, error) {
 func (tc *testContext) createLinuxCurlerJob(jobSuffix, endpoint string, continuous bool) (*batchv1.Job, error) {
 	// Retries a failed curl attempt once to avoid flakes
 	curlCommand := fmt.Sprintf(
-		"curl %s;"+
+		"curl -v %s;"+
 			" if [ $? != 0 ]; then"+
 			" sleep 60;"+
-			" curl %s || exit 1;"+
+			" curl -v %s || exit 1;"+
 			" fi",
 		endpoint, endpoint)
 	if continuous {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -921,6 +921,16 @@ func (tc *testContext) createWindowsServerDeployment(name string, command []stri
 								},
 							},
 							VolumeMounts: volumeMounts,
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("500m"),
+									v1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("500m"),
+									v1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+							},
 						},
 					},
 					RuntimeClassName: &rcName,

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -377,7 +377,7 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 					defer tc.deleteJob(curlerJob.Name)
 
 					_, err = tc.waitUntilJobSucceeds(curlerJob.Name)
-					assert.NoError(t, err, "could not curl the Windows server")
+					assert.NoErrorf(t, err, "error curling endpoint %s from %s pod", endpointIP, tt.curlerOS)
 				})
 			}
 			t.Run("service DNS resolution", func(t *testing.T) {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -260,39 +260,39 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 	}{
 		{
 			name:            "linux curling windows",
-			webserverOS:     windowsOS,
 			curlerOS:        linux,
+			webserverOS:     windowsOS,
 			useClusterIPSVC: false,
 		},
 		{
 			name:            "windows curling windows",
-			webserverOS:     windowsOS,
 			curlerOS:        windowsOS,
+			webserverOS:     windowsOS,
 			useClusterIPSVC: false,
 		},
 		{
 			name:            "linux curling windows through a clusterIP svc",
-			webserverOS:     windowsOS,
 			curlerOS:        linux,
+			webserverOS:     windowsOS,
 			useClusterIPSVC: true,
 		},
 		{
 			name:            "windows curling windows through a clusterIP svc",
-			webserverOS:     windowsOS,
 			curlerOS:        windowsOS,
+			webserverOS:     windowsOS,
+			useClusterIPSVC: true,
+		},
+		{
+			name:            "windows curling linux through a clusterIP svc",
+			curlerOS:        windowsOS,
+			webserverOS:     linux,
 			useClusterIPSVC: true,
 		},
 		{
 			name:            "windows curling linux",
-			webserverOS:     linux,
 			curlerOS:        windowsOS,
+			webserverOS:     linux,
 			useClusterIPSVC: false,
-		},
-		{
-			name:            "windows curling linux through a clusterIP svc",
-			webserverOS:     linux,
-			curlerOS:        windowsOS,
-			useClusterIPSVC: true,
 		},
 	}
 	require.Greater(t, len(gc.allNodes()), 0, "test requires at least one Windows node to run")

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -1071,6 +1071,10 @@ func (tc *testContext) waitUntilJobSucceeds(name string) (string, error) {
 			return logs, nil
 		}
 		if job.Status.Failed > 0 {
+			_, err = tc.gatherPodLogs(labelSelector)
+			if err != nil {
+				log.Printf("Unable to get logs associated with pod %s: %v", labelSelector, err)
+			}
 			events, _ := tc.getPodEvents(name)
 			return "", fmt.Errorf("job %v failed: %v", job, events)
 		}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -301,6 +301,7 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 
 	linuxServerDeployment, err := tc.deployLinuxWebServer()
 	require.NoError(t, err)
+	defer tc.collectDeploymentLogs(linuxServerDeployment)
 	defer tc.deleteDeployment(linuxServerDeployment.GetName())
 	linuxServerClusterIP, err := tc.createService(linuxServerDeployment.GetName(), 8080, v1.ServiceTypeClusterIP,
 		*linuxServerDeployment.Spec.Selector)
@@ -324,10 +325,8 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 				}
 			}
 			require.NoError(t, err, "could not create Windows Server deployment")
+			defer tc.collectDeploymentLogs(winServerDeployment)
 			defer tc.deleteDeployment(winServerDeployment.Name)
-			if err := tc.collectDeploymentLogs(winServerDeployment); err != nil {
-				log.Printf("error collecting deployment logs: %v", err)
-			}
 
 			// Get the pod so we can use its IP
 			winServerIP, err := tc.getPodIP(*winServerDeployment.Spec.Selector)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -307,7 +307,6 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 		*linuxServerDeployment.Spec.Selector)
 	require.NoError(t, err)
 	defer tc.deleteService(linuxServerClusterIP.GetName())
-	linuxServerIP, err := tc.getPodIP(*linuxServerDeployment.Spec.Selector)
 	require.NoError(t, err)
 	for _, node := range gc.allNodes() {
 		t.Run(node.Name, func(t *testing.T) {
@@ -328,10 +327,6 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 			defer tc.collectDeploymentLogs(winServerDeployment)
 			defer tc.deleteDeployment(winServerDeployment.Name)
 
-			// Get the pod so we can use its IP
-			winServerIP, err := tc.getPodIP(*winServerDeployment.Spec.Selector)
-			require.NoError(t, err, "could not retrieve pod with selector %v", *winServerDeployment.Spec.Selector)
-
 			// Create a clusterIP service which can be used to reach the Windows webserver
 			intermediarySVC, err := tc.createService(winServerDeployment.Name, 80, v1.ServiceTypeClusterIP, *winServerDeployment.Spec.Selector)
 			require.NoError(t, err, "could not create service")
@@ -347,13 +342,17 @@ func (tc *testContext) testEastWestNetworking(t *testing.T) {
 						if tt.useClusterIPSVC {
 							endpointIP = intermediarySVC.Spec.ClusterIP
 						} else {
-							endpointIP = winServerIP
-
+							// Get the pod so we can use its IP
+							endpointIP, err = tc.getPodIP(*winServerDeployment.Spec.Selector)
+							require.NoError(t, err, "could not retrieve pod with selector %v", *winServerDeployment.Spec.Selector)
 						}
 					} else {
 						if tt.useClusterIPSVC {
 							endpointIP = linuxServerClusterIP.Spec.ClusterIP
 						} else {
+							linuxServerIP, err := tc.getPodIP(*linuxServerDeployment.Spec.Selector)
+							require.NoError(t, err)
+
 							endpointIP = linuxServerIP + ":8080"
 						}
 					}


### PR DESCRIPTION
This PR fixes the issues in the East West Networking test by:
- Explicitly defining resource requests and limits of the Linux and Windows  web server pods to significantly reduce the likelihood of them being terminated due to resource constraints.
- Fetching the Linux and Windows webserver pod IP right after creating the corresponding curl job.

In addition:

**Debugging Enhancements:**

- Added logging of host and pod IP addresses to the Linux Webserver.
- Introduced logging of the Windows pod IP address in WinCurler and the server IP address in WinServer.
- Included response content logging in WinCurler for better troubleshooting.
- Enabled verbosity in the LinuxCurler command to provide detailed output.
- Added debug logging to the WinCurler curl script.

**Code Readability and Maintenance:**
- Expanded the WinCurler and WinServer commands into multiple lines for improved readability.
- Improved variable naming in WinCurler’s getWinCurlerCommand function.
- Removed an unused loop control variable in WinCurler to clean up the code.

**Reliability:**
- Adjusted the WinCurler command timeout to 2 minutes (25 attempts with 5-second intervals) to handle longer server response times.