### PR TITLE
WIP: Collect packet tracing on network_test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ WMCO_VERSION ?= 10.19.0
 KUBELET_GIT_VERSION=v1.32.1+cc13ce0
 KUBE-PROXY_GIT_VERSION=v1.32.1
 CONTAINERD_GIT_VERSION=v1.7.25
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -44,14 +44,15 @@ func testNetwork(t *testing.T) {
 	for _, node := range gc.allNodes() {
 		require.NoError(t, tc.startPacketTrace(&node))
 	}
+	defer func() {
+		for _, node := range gc.allNodes() {
+			require.NoError(t, tc.stopPacketTrace(&node))
+		}
+	}()
 
 	t.Run("East West Networking", tc.testEastWestNetworking)
 	t.Run("North south networking", tc.testNorthSouthNetworking)
 	t.Run("Pod DNS Resolution", tc.testPodDNSResolution)
-
-	for _, node := range gc.allNodes() {
-		require.NoError(t, tc.stopPacketTrace(&node))
-	}
 }
 
 var (


### PR DESCRIPTION
Moved the stopPacketTrace calls into a defer function to guarantee collection when tests fail or panic, improving test reliability.