### PR TITLE
WINC-1380 [release-4.18] - increases resource limits to avoid OOMkilling

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4-18-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-18-pull-request.yaml
@@ -35,6 +35,15 @@ spec:
     value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-18:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-source-image
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-bundle-release-4-18-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-18-push.yaml
@@ -32,6 +32,15 @@ spec:
     value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-18:{{revision}}
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-source-image
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-release-4-18-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-18-pull-request.yaml
@@ -35,6 +35,15 @@ spec:
     value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-18:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-source-image
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-release-4-18-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-18-push.yaml
@@ -32,6 +32,15 @@ spec:
     value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-18:{{revision}}
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-source-image
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 10Gi
+            limits:
+              memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
increasing our resource request to 10gi to avoid OOMkill. Should probably be lowered.
based on the docs here
https://konflux.pages.redhat.com/docs/users/building/overriding-compute-resources.html