### PR TITLE
[release-4.16] WINC-1365: Fix e2e warnings

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -112,6 +112,8 @@ func NewTestContext() (*testContext, error) {
 		"security.openshift.io/scc.podSecurityLabelSync": "false",
 		// set pods security profile to privileged. See https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-levels
 		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/audit":   "privileged",
+		"pod-security.kubernetes.io/warn":    "privileged",
 	}
 
 	// number of nodes, retry interval and timeout should come from user-input flags

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -826,7 +826,8 @@ func (tc *testContext) createJob(name, image string, command []string, runtimeCl
 // deleteJob deletes the job with the given name
 func (tc *testContext) deleteJob(name string) error {
 	jobsClient := tc.client.K8s.BatchV1().Jobs(tc.workloadNamespace)
-	return jobsClient.Delete(context.TODO(), name, metav1.DeleteOptions{})
+	propPolicy := metav1.DeletePropagationOrphan
+	return jobsClient.Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &propPolicy})
 }
 
 // waitUntilJobSucceeds will return an error if the job fails or reaches a timeout and return logs on success

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -126,6 +126,10 @@ func (a *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32, wind
 		return nil, fmt.Errorf("error choosing AMI: %w", err)
 	}
 	providerSpec := &mapi.AWSMachineProviderConfig{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: mapi.GroupVersion.String(),
+			Kind:       "AWSMachineProviderConfig",
+		},
 		AMI:                mapi.AWSResourceReference{ID: &ami},
 		InstanceType:       linuxWorkerSpec.InstanceType,
 		IAMInstanceProfile: linuxWorkerSpec.IAMInstanceProfile,


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/windows-machine-config-operator/pull/2658