### PR TITLE
WINC-1383: Bump use-trusted-artifact step memory

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-master-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-master-pull-request.yaml
@@ -44,42 +44,36 @@ spec:
               memory: 10Gi
             limits:
               memory: 10Gi
+        - name: use-trusted-artifact
+          computeResources: &ta-resources
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: clone-repository
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: create-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: fips-operator-bundle-check-oci-ta
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: prefetch-dependencies
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-shell-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-snyk-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-unicode-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-bundle-master-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-master-push.yaml
@@ -41,42 +41,36 @@ spec:
               memory: 10Gi
             limits:
               memory: 10Gi
+        - name: use-trusted-artifact
+          computeResources: &ta-resources
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: clone-repository
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: create-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: fips-operator-bundle-check-oci-ta
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: prefetch-dependencies
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-shell-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-snyk-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-unicode-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-master-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-master-pull-request.yaml
@@ -44,42 +44,36 @@ spec:
               memory: 10Gi
             limits:
               memory: 10Gi
+        - name: use-trusted-artifact
+          computeResources: &ta-resources
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: build-container
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: clone-repository
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: create-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: prefetch-dependencies
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-shell-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-snyk-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-unicode-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/windows-machine-config-operator-master-push.yaml
+++ b/.tekton/windows-machine-config-operator-master-push.yaml
@@ -41,42 +41,36 @@ spec:
               memory: 10Gi
             limits:
               memory: 10Gi
+        - name: use-trusted-artifact
+          computeResources: &ta-resources
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: build-container
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: clone-repository
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: create-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: prefetch-dependencies
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-shell-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-snyk-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
     - pipelineTaskName: sast-unicode-check
-      computeResources:
-      requests:
-        memory: 10Gi
-      limits:
-        memory: 10Gi
+      stepSpecs:
+        - name: use-trusted-artifact
+          computeResources: *ta-resources
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
This step is the one in particular that is going OOM. Only it should be given the memory increase.