### PR TITLE
Fix unknown verb in message and ignore SSH known hosts in test suite

### DIFF
--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -46,7 +46,7 @@ func (tc *testContext) testKubeletCARotation(t *testing.T) {
 		// spin-off subtests to ensure the CA bundle file is verified in all Windows nodes
 		t.Run("node/"+winNode.Name, func(t *testing.T) {
 			err := tc.waitForKubeletCACertificateInNode(&winNode)
-			assert.NoErrorf(t, err, "kubelet CA certificate should be present in node %S", winNode.Name)
+			assert.NoErrorf(t, err, "kubelet CA certificate should be present in node %s", winNode.Name)
 		})
 	}
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -375,11 +375,12 @@ func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, er
 	}
 
 	keyMountDir := "/private-key"
+	sshOptions := "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 	sshCommand := []string{"bash", "-c",
 		fmt.Sprintf(
 			// first determine if the host has PowerShell or cmd as the default shell by running a simple PowerShell
 			// command. If it succeeds, then the host's default shell is PowerShell
-			"if ssh -o StrictHostKeyChecking=no -i %s %s@%s 'Get-Help';"+
+			"if ssh "+sshOptions+" -i %s %s@%s 'Get-Help';"+
 				"then CMD_PREFIX=\"\";CMD_SUFFIX=\"\";"+
 				// to respect quoting within the given command, wrap the command as a script block
 				"COMMAND='{"+powershellDefaultCommand+"}';"+
@@ -388,7 +389,7 @@ func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, er
 				"COMMAND='{"+command+"}';"+
 				"fi;"+
 				// execute the command as a script block via the PowerShell call operator `&`
-				"ssh -o StrictHostKeyChecking=no -i %s %s@%s ${CMD_PREFIX}\" & $COMMAND \"${CMD_SUFFIX}",
+				"ssh "+sshOptions+" -i %s %s@%s ${CMD_PREFIX}\" & $COMMAND \"${CMD_SUFFIX}",
 			filepath.Join(keyMountDir, secrets.PrivateKeySecretKey), tc.vmUsername(), ip,
 			filepath.Join(keyMountDir, secrets.PrivateKeySecretKey), tc.vmUsername(), ip)}
 


### PR DESCRIPTION
This PR fixes the formatting in error message for kubelet CA certificate assertion and  the error message in e2e windows pods:
```
Could not create directory '/.ssh' (Permission denied).
Failed to add the host to the list of known hosts (/.ssh/known_hosts).
```

for example:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_windows-machine-config-operator/2843/pull-ci-openshift-windows-machine-config-operator-master-vsphere-disconnected-e2e-operator/1916921306410913792/artifacts/vsphere-disconnected-e2e-operator/windows-e2e-operator-test/artifacts/pods/job-name=check-win-dirs-job-jz8n7/job-name=check-win-dirs-job-jz8n7.log