### PR TITLE
vendor: fix golang-jwt to v4.5.2 and v5.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,12 @@ go 1.23.0
 
 toolchain go1.23.5
 
+replace (
+	// fix CVE-2025-30204 transitive deps still using older v4. Remove once `go mod graph` shows only 4.5.2 or higher
+	github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 => github.com/golang-jwt/jwt/v5 v5.2.2
+)
+
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.55.6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1455,3 +1455,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
+# github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2
+# github.com/golang-jwt/jwt/v5 => github.com/golang-jwt/jwt/v5 v5.2.2


### PR DESCRIPTION
This commit addresses CVE-2025-30204 in transitive deps that are still using vulnerable v4 and v5 versions

