### PR TITLE
Fix WMCO/WICD's go build command to FIPS compliant

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -45,4 +45,4 @@ mkdir -p "${BIN_DIR}"
 goflags=${GOFLAGS:-}
 
 
-CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build ${GOFLAGS} -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}'" -o ${BIN_DIR}/${BIN_NAME} ${WMCO_CMD_DIR}
+CGO_ENABLED=1 GO111MODULE=on GOOS=linux go build -tags strictfipsruntime ${GOFLAGS} -ldflags="-X 'github.com/openshift/windows-machine-config-operator/version.Version=${VERSION}'" -o ${BIN_DIR}/${BIN_NAME} ${WMCO_CMD_DIR}


### PR DESCRIPTION
Builds WMCO with CGO_ENABLED