### PR TITLE
[release-4.17] OCPBUGS-51979: use openshift/golang-crypto v0.33.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ toolchain go1.22.3
 replace (
 	// fix the latest working version for go1.22
 	golang.org/x/exp => golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
+	// fix CVE-2025-22869 with downstream tag v0.33.openshift.1
+	golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 	// fix to solve the issue of unknown field IgnoredFields in struct literal of type merge.Updater
 	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.4.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1072,5 +1072,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # golang.org/x/exp => golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
+# golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 # sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 # sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.4.1


### PR DESCRIPTION
This PR leverages the openshift/golang-crypto
downstream with v0.33.1 that contains the patch
to address CVE-2025-22869


Follow-up to:
- https://github.com/openshift/windows-machine-config-operator/pull/2867