### PR TITLE
React to master application removal

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -4,6 +4,6 @@ metadata:
   name: wmco-idms
 spec:
   imageDigestMirrors:
-  - source: registry.stage.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator
+  - source: registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator
     mirrors:
-      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-master
+      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-20

--- a/.tekton/windows-machine-config-operator-bundle-release-4-20-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-20-pull-request.yaml
@@ -10,13 +10,13 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "master"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
+      && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-master
-    appstudio.openshift.io/component: windows-machine-config-operator-master
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-20
+    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-4-20
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-master-on-pull-request
+  name: windows-machine-config-operator-bundle-release-4-20-on-pull-request
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -27,13 +27,13 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: dockerfile
-    value: Containerfile
+    value: Containerfile.bundle
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-master:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-20:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -277,6 +277,30 @@ spec:
         operator: in
         values:
         - "false"
+    - name: fips-operator-bundle-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: fips-operator-bundle-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:6391e16a811ccca24d54b57eb03ba4bc65a58da00ead95580a03c0c66efac3b4
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: clair-scan
       params:
       - name: image-digest
@@ -291,26 +315,6 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
         - name: kind
           value: task
         resolver: bundles
@@ -472,14 +476,6 @@ spec:
         requests:
           memory: 8Gi
       name: use-trusted-artifact
-  - pipelineTaskName: build-container
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 8Gi
-        requests:
-          memory: 8Gi
-      name: use-trusted-artifact
   - pipelineTaskName: clone-repository
     stepSpecs:
     - computeResources:
@@ -488,6 +484,14 @@ spec:
         requests:
           memory: 8Gi
       name: create-trusted-artifact
+  - pipelineTaskName: fips-operator-bundle-check-oci-ta
+    stepSpecs:
+    - computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 8Gi
+      name: use-trusted-artifact
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
     - computeResources:
@@ -521,7 +525,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-master
+    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-4-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-bundle-release-4-20-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-20-push.yaml
@@ -4,19 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/windows-machine-config-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
+      event == "push"
       && target_branch == "master"
       && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-master
-    appstudio.openshift.io/component: windows-machine-config-operator-bundle-master
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-20
+    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-4-20
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-bundle-master-on-pull-request
+  name: windows-machine-config-operator-bundle-release-4-20-on-push
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -30,10 +29,8 @@ spec:
     value: Containerfile.bundle
   - name: git-url
     value: '{{source_url}}'
-  - name: image-expires-after
-    value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-master:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-20:{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -525,7 +522,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-master
+    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-4-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-release-4-20-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-20-pull-request.yaml
@@ -4,18 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/windows-machine-config-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
+      event == "pull_request"
       && target_branch == "master"
       && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-master
-    appstudio.openshift.io/component: windows-machine-config-operator-master
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-20
+    appstudio.openshift.io/component: windows-machine-config-operator-release-4-20
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-master-on-push
+  name: windows-machine-config-operator-release-4-20-on-pull-request
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -29,8 +30,10 @@ spec:
     value: Containerfile
   - name: git-url
     value: '{{source_url}}'
+  - name: image-expires-after
+    value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-master:{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-20:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -518,7 +521,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-master
+    serviceAccountName: build-pipeline-windows-machine-config-operator-release-4-20
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-release-4-20-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-20-push.yaml
@@ -9,13 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "master"
-      && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
+      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-master
-    appstudio.openshift.io/component: windows-machine-config-operator-bundle-master
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-20
+    appstudio.openshift.io/component: windows-machine-config-operator-release-4-20
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-bundle-master-on-push
+  name: windows-machine-config-operator-release-4-20-on-push
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -26,11 +26,11 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: dockerfile
-    value: Containerfile.bundle
+    value: Containerfile
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-master:{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-20:{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -274,30 +274,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: fips-operator-bundle-check-oci-ta
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: fips-operator-bundle-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:6391e16a811ccca24d54b57eb03ba4bc65a58da00ead95580a03c0c66efac3b4
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clair-scan
       params:
       - name: image-digest
@@ -312,6 +288,26 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
         - name: kind
           value: task
         resolver: bundles
@@ -473,6 +469,14 @@ spec:
         requests:
           memory: 8Gi
       name: use-trusted-artifact
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 8Gi
+      name: use-trusted-artifact
   - pipelineTaskName: clone-repository
     stepSpecs:
     - computeResources:
@@ -481,14 +485,6 @@ spec:
         requests:
           memory: 8Gi
       name: create-trusted-artifact
-  - pipelineTaskName: fips-operator-bundle-check-oci-ta
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 8Gi
-        requests:
-          memory: 8Gi
-      name: use-trusted-artifact
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
     - computeResources:
@@ -522,7 +518,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-master
+    serviceAccountName: build-pipeline-windows-machine-config-operator-release-4-20
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
As the master branch tracks 4.20 development for now, the master application and components have been removed. The 4.20 application and components will be used in master until the next branching day.