### PR TITLE
renovate: add branch name to PR title

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,7 @@
           "commitMessageTopic": "{{{groupName}}}"
         },
         "commitMessageTopic": "Konflux references",
+        "commitMessagePrefix": "[{{baseBranch}}]",
         "semanticCommits": "enabled",
         "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",
         "prBodyColumns": [


### PR DESCRIPTION
This PR adds the branch name as a prefix
to the commit message, since the PR title follows the commit message, the PR title will correctly reflects the base branch, for example `[release-4.20] Update Konflux references`

see https://docs.renovatebot.com/configuration-options/#commitmessage