### PR TITLE
Change how extra arguments are processed

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -430,7 +430,6 @@ spec:
               containers:
               - args:
                 - --metrics-bind-address=0.0.0.0:9182
-                - $(ARGS)
                 command:
                 - windows-machine-config-operator
                 env:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -64,6 +64,14 @@ func main() {
 	var debugLogging bool
 	var metricsAddr string
 
+	if extraArgs := os.Getenv("ARGS"); extraArgs != "" {
+		for _, arg := range strings.Split(extraArgs, " ") {
+			if len(arg) > 0 {
+				os.Args = append(os.Args, arg)
+			}
+		}
+	}
+
 	flag.BoolVar(&debugLogging, "debugLogging", false, "Log debug messages")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0.0.0.0:9182",
 		"The address and port the metric endpoint binds to 0.0.0.0:9182")

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,6 @@ spec:
         - windows-machine-config-operator
         args:
         - "--metrics-bind-address=0.0.0.0:9182"
-        - $(ARGS)
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
$(ARGS) is not being processed correctly when the operator is ran without another argument before it.