### PR TITLE
[release-4.17] Change how extra arguments are processed

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -424,9 +424,7 @@ spec:
                 name: windows-machine-config-operator
             spec:
               containers:
-              - args:
-                - $(ARGS)
-                command:
+              - command:
                 - windows-machine-config-operator
                 env:
                 - name: WATCH_NAMESPACE

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -62,6 +62,14 @@ func init() {
 func main() {
 	var debugLogging bool
 
+	if extraArgs := os.Getenv("ARGS"); extraArgs != "" {
+		for _, arg := range strings.Split(extraArgs, " ") {
+			if len(arg) > 0 {
+				os.Args = append(os.Args, arg)
+			}
+		}
+	}
+
 	flag.BoolVar(&debugLogging, "debugLogging", false, "Log debug messages")
 
 	// Add flags registered by imported packages (e.g. glog and

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,8 +33,6 @@ spec:
       containers:
       - command:
         - windows-machine-config-operator
-        args:
-        - $(ARGS)
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
$(ARGS) is not being processed correctly when the operator is ran without another argument before it.