### PR TITLE
[release-4.16] OCPBUGS-55939: Make debugLogging non-default

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -416,9 +416,7 @@ spec:
                 name: windows-machine-config-operator
             spec:
               containers:
-              - args:
-                - $(ARGS)
-                command:
+              - command:
                 - windows-machine-config-operator
                 env:
                 - name: WATCH_NAMESPACE

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -417,7 +417,7 @@ spec:
             spec:
               containers:
               - args:
-                - --debugLogging
+                - $(ARGS)
                 command:
                 - windows-machine-config-operator
                 env:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -62,6 +62,14 @@ func init() {
 func main() {
 	var debugLogging bool
 
+	if extraArgs := os.Getenv("ARGS"); extraArgs != "" {
+		for _, arg := range strings.Split(extraArgs, " ") {
+			if len(arg) > 0 {
+				os.Args = append(os.Args, arg)
+			}
+		}
+	}
+
 	flag.BoolVar(&debugLogging, "debugLogging", false, "Log debug messages")
 
 	// Add flags registered by imported packages (e.g. glog and

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,8 +33,6 @@ spec:
       containers:
       - command:
         - windows-machine-config-operator
-        args:
-        - $(ARGS)
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
       - command:
         - windows-machine-config-operator
         args:
-        - "--debugLogging"
+        - $(ARGS)
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,5 +1,16 @@
 # Troubleshooting guide
 
+## Enabling debug level logging
+In the Subscription created to deploy the operator add the following to .spec.config.env
+```
+kind: Subscription
+spec:
+  config:
+    env:
+    - name: ARGS
+      value: "--debugLogging"
+```
+
 ## WMCO does not go to running
 Please check if you are using an OKD/OCP cluster adhering to the [operator pre-requisites](wmco-prerequisites.md).
 

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -112,6 +112,10 @@ if  ! oc get deploy/windows-machine-config-operator -n $WMCO_DEPLOY_NAMESPACE > 
   wmco_deployed_by_script=true
 fi
 
+# Enable debug logging
+WMCO_SUB=$(oc get sub -n $WMCO_DEPLOY_NAMESPACE --no-headers |awk '{print $1}')
+oc patch subscription $WMCO_SUB -n $WMCO_DEPLOY_NAMESPACE --type=merge -p '{"spec":{"config":{"env":[{"name":"ARGS","value":"--debugLogging"}]}}}'
+
 # WINDOWS_INSTANCES_DATA holds the windows-instances ConfigMap data section
 WINDOWS_INSTANCES_DATA=${WINDOWS_INSTANCES_DATA:-}
 # Check WINDOWS_INSTANCES_DATA and create the windows-instances ConfigMap, if

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -656,10 +656,15 @@ func (tc *testContext) waitForValidWindowsServicesConfigMap(cmName string,
 			}
 			return false, fmt.Errorf("error retrieving ConfigMap: %s: %w", cmName, err)
 		}
-		// Here, we've retreived a ConfigMap but still need to ensure it is valid.
+		// Here, we've retrieved a ConfigMap but still need to ensure it is valid.
 		// If it's not valid, retry in hopes that WMCO will replace it with a valid one as expected.
 		data, err := servicescm.Parse(configMap.Data)
-		if err != nil || data.ValidateExpectedContent(expected) != nil {
+		if err != nil {
+			log.Printf("error parsing %s data: %v", cmName, err)
+			return false, nil
+		}
+		if err = data.ValidateExpectedContent(expected); err != nil {
+			log.Printf("error validating %s data: %v", cmName, err)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
Manual backport of github.com/openshift/windows-machine-config-operator/pull/2784