### PR TITLE
[release-4.14] OCPBUGS-51976: use openshift/golang-crypto v0.33.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/openshift/windows-machine-config-operator
 
 go 1.20
 
+// fix CVE-2025-22869 with downstream tag v0.33.openshift.1
+replace golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
+
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.44.298

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1034,4 +1034,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 # k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f


### PR DESCRIPTION
This commit leverages the openshift/golang-crypto
downstream with v0.33.1 that contains the patch
to address CVE-2025-22869