### PR TITLE
[hack] Fix typo in machineset.sh script

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -90,7 +90,7 @@ get_aws_ms() {
   fi
 
 
-  local az=$(echo "$linuxWorkerSpec" | jq -r .providerSpec.value.placement.availibilityZone)
+  local az=$(echo "$linuxWorkerSpec" | jq -r .providerSpec.value.placement.availabilityZone)
   local region=$(echo "$linuxWorkerSpec" | jq -r .providerSpec.value.placement.region)
   #
   # get the AMI id for the Windows VM


### PR DESCRIPTION
This commit fixed a typo in the machineset.sh script while setting the availabilityZone for machineset

follow-up to:
 - https://github.com/openshift/windows-machine-config-operator/pull/2786