### PR TITLE
[release-4.19] Update Konflux references and add image digest to task-sast-unicode-check-oci-ta 

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
@@ -412,6 +412,8 @@ spec:
       workspaces: []
     - name: sast-unicode-check
       params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-container.results.IMAGE_URL)
         - name: SOURCE_ARTIFACT

--- a/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
@@ -216,7 +216,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:5e15408f997557153b13d492aeccb51c01923bfbe4fbdf6f1e8695ce1b82f826
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:a1ddc34bf0a169bb2e64a98caf9027b66af8fc66a3a60f71bb451ce36af6a399
         - name: kind
           value: task
         resolver: bundles
@@ -252,7 +252,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:65864bd7623b8819707ffc0949c390152f99f24308803e773000009f71ed2d6b
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:48b99ad18fd3bde2d22ec2c397d36c55e45ca90ddf1620c9e00bdee518e297bf
         - name: kind
           value: task
         resolver: bundles
@@ -326,7 +326,7 @@ spec:
         - name: name
           value: fips-operator-bundle-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:2423f052f2bd4e3ea593d67ff334b8886dabf11ab0c461734e91c48a9092550d
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:f9cdd3bd78cac1fcd6b2414fc9c0c9d1363c4f70eab4a14b6f2f9b7e590e4439
         - name: kind
           value: task
         resolver: bundles
@@ -425,7 +425,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-bundle-release-4.19-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4.19-push.yaml
@@ -409,6 +409,8 @@ spec:
       workspaces: []
     - name: sast-unicode-check
       params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-container.results.IMAGE_URL)
         - name: SOURCE_ARTIFACT

--- a/.tekton/windows-machine-config-operator-bundle-release-4.19-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4.19-push.yaml
@@ -213,7 +213,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:5e15408f997557153b13d492aeccb51c01923bfbe4fbdf6f1e8695ce1b82f826
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:a1ddc34bf0a169bb2e64a98caf9027b66af8fc66a3a60f71bb451ce36af6a399
         - name: kind
           value: task
         resolver: bundles
@@ -249,7 +249,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:65864bd7623b8819707ffc0949c390152f99f24308803e773000009f71ed2d6b
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:48b99ad18fd3bde2d22ec2c397d36c55e45ca90ddf1620c9e00bdee518e297bf
         - name: kind
           value: task
         resolver: bundles
@@ -323,7 +323,7 @@ spec:
         - name: name
           value: fips-operator-bundle-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:2423f052f2bd4e3ea593d67ff334b8886dabf11ab0c461734e91c48a9092550d
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:f9cdd3bd78cac1fcd6b2414fc9c0c9d1363c4f70eab4a14b6f2f9b7e590e4439
         - name: kind
           value: task
         resolver: bundles
@@ -422,7 +422,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-release-4.19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4.19-pull-request.yaml
@@ -216,7 +216,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:5e15408f997557153b13d492aeccb51c01923bfbe4fbdf6f1e8695ce1b82f826
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:a1ddc34bf0a169bb2e64a98caf9027b66af8fc66a3a60f71bb451ce36af6a399
         - name: kind
           value: task
         resolver: bundles
@@ -252,7 +252,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:65864bd7623b8819707ffc0949c390152f99f24308803e773000009f71ed2d6b
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:48b99ad18fd3bde2d22ec2c397d36c55e45ca90ddf1620c9e00bdee518e297bf
         - name: kind
           value: task
         resolver: bundles
@@ -421,7 +421,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651
           - name: kind
             value: task
         resolver: bundles

--- a/.tekton/windows-machine-config-operator-release-4.19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4.19-pull-request.yaml
@@ -408,6 +408,8 @@ spec:
       workspaces: []
     - name: sast-unicode-check
       params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-container.results.IMAGE_URL)
         - name: SOURCE_ARTIFACT

--- a/.tekton/windows-machine-config-operator-release-4.19-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4.19-push.yaml
@@ -405,6 +405,8 @@ spec:
       workspaces: []
     - name: sast-unicode-check
       params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-container.results.IMAGE_URL)
         - name: SOURCE_ARTIFACT

--- a/.tekton/windows-machine-config-operator-release-4.19-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4.19-push.yaml
@@ -213,7 +213,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:5e15408f997557153b13d492aeccb51c01923bfbe4fbdf6f1e8695ce1b82f826
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:a1ddc34bf0a169bb2e64a98caf9027b66af8fc66a3a60f71bb451ce36af6a399
         - name: kind
           value: task
         resolver: bundles
@@ -249,7 +249,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:65864bd7623b8819707ffc0949c390152f99f24308803e773000009f71ed2d6b
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:48b99ad18fd3bde2d22ec2c397d36c55e45ca90ddf1620c9e00bdee518e297bf
         - name: kind
           value: task
         resolver: bundles
@@ -418,7 +418,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:24ad71fde435fc25abba2c4c550beb088b1530f738d3c377e2f635b5f320d57b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
Reacts to task-sast-unicode-check-oci-ta migration
from 0.2 to 0.3 and adds the now required image-digest to
the sast-unicode-check task.

https://github.com/konflux-ci/build-definitions/blob/main/task/sast-unicode-check-oci-ta/0.3/MIGRATION.md