### PR TITLE
[release-4.14] WINC-1417: Update Konflux references and add image digest to task-sast-unicode-check-oci-ta 

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4-14-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-14-pull-request.yaml
@@ -379,6 +379,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/windows-machine-config-operator-bundle-release-4-14-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-14-push.yaml
@@ -376,6 +376,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/windows-machine-config-operator-release-4-14-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-14-pull-request.yaml
@@ -375,6 +375,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/windows-machine-config-operator-release-4-14-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-14-push.yaml
@@ -396,6 +396,8 @@ spec:
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
Reacts to task-sast-unicode-check-oci-ta migration
from 0.2 to 0.3 and adds the now required image-digest to
the sast-unicode-check task.

https://github.com/konflux-ci/build-definitions/blob/main/task/sast-unicode-check-oci-ta/0.3/MIGRATION.md