### PR TITLE
Retry SSH server initialization

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -81,7 +81,19 @@ func generateUserDataWithPubKey(platformType oconfig.PlatformType, pubKey string
 				}
 			}
 
-			Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+			# This requires a network connection, which is not guaranteed at VM initialization. Retry to work around this.
+			$attempt = 0
+			$success = $false
+			while (-not $success -and $attempt -lt 10) {
+				try {
+					Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop
+					$success = $true
+				}
+				catch {
+					$attempt++
+					Start-Sleep -Seconds 5
+				}
+			}
 			$firewallRuleName = "ContainerLogsPort"
 			$containerLogsPort = "10250"
 			New-NetFirewallRule -DisplayName $firewallRuleName -Direction Inbound -Action Allow -Protocol TCP -LocalPort $containerLogsPort -EdgeTraversalPolicy Allow


### PR DESCRIPTION
Attempts to fix an issue where Windows Server 2019 machines were not having a running SSH server due to network instability.