### PR TITLE
[vendor] bump aws-sdk-go to v1.55.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go v1.55.8
 	github.com/coreos/ignition/v2 v2.20.0
 	github.com/go-imports-organizer/goio v1.5.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
-github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
+github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
@@ -1,4 +1,7 @@
 // Package arn provides a parser for interacting with Amazon Resource Names.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package arn
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/auth/bearer/token.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/auth/bearer/token.go
@@ -1,8 +1,11 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package bearer
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 // Token provides a type wrapping a bearer token and expiration metadata.

--- a/vendor/github.com/aws/aws-sdk-go/aws/awserr/error.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awserr/error.go
@@ -1,4 +1,7 @@
 // Package awserr represents API error interface accessors for the SDK.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package awserr
 
 // An Error wraps lower level errors with code, message and an original error.
@@ -10,24 +13,23 @@ package awserr
 //
 // Example:
 //
-//     output, err := s3manage.Upload(svc, input, opts)
-//     if err != nil {
-//         if awsErr, ok := err.(awserr.Error); ok {
-//             // Get error details
-//             log.Println("Error:", awsErr.Code(), awsErr.Message())
+//	output, err := s3manage.Upload(svc, input, opts)
+//	if err != nil {
+//	    if awsErr, ok := err.(awserr.Error); ok {
+//	        // Get error details
+//	        log.Println("Error:", awsErr.Code(), awsErr.Message())
 //
-//             // Prints out full error message, including original error if there was one.
-//             log.Println("Error:", awsErr.Error())
+//	        // Prints out full error message, including original error if there was one.
+//	        log.Println("Error:", awsErr.Error())
 //
-//             // Get original error
-//             if origErr := awsErr.OrigErr(); origErr != nil {
-//                 // operate on original error.
-//             }
-//         } else {
-//             fmt.Println(err.Error())
-//         }
-//     }
-//
+//	        // Get original error
+//	        if origErr := awsErr.OrigErr(); origErr != nil {
+//	            // operate on original error.
+//	        }
+//	    } else {
+//	        fmt.Println(err.Error())
+//	    }
+//	}
 type Error interface {
 	// Satisfy the generic error interface.
 	error
@@ -100,32 +102,31 @@ func NewBatchError(code, message string, errs []error) BatchedErrors {
 //
 // Example:
 //
-//     output, err := s3manage.Upload(svc, input, opts)
-//     if err != nil {
-//         if reqerr, ok := err.(RequestFailure); ok {
-//             log.Println("Request failed", reqerr.Code(), reqerr.Message(), reqerr.RequestID())
-//         } else {
-//             log.Println("Error:", err.Error())
-//         }
-//     }
+//	output, err := s3manage.Upload(svc, input, opts)
+//	if err != nil {
+//	    if reqerr, ok := err.(RequestFailure); ok {
+//	        log.Println("Request failed", reqerr.Code(), reqerr.Message(), reqerr.RequestID())
+//	    } else {
+//	        log.Println("Error:", err.Error())
+//	    }
+//	}
 //
 // Combined with awserr.Error:
 //
-//    output, err := s3manage.Upload(svc, input, opts)
-//    if err != nil {
-//        if awsErr, ok := err.(awserr.Error); ok {
-//            // Generic AWS Error with Code, Message, and original error (if any)
-//            fmt.Println(awsErr.Code(), awsErr.Message(), awsErr.OrigErr())
+//	output, err := s3manage.Upload(svc, input, opts)
+//	if err != nil {
+//	    if awsErr, ok := err.(awserr.Error); ok {
+//	        // Generic AWS Error with Code, Message, and original error (if any)
+//	        fmt.Println(awsErr.Code(), awsErr.Message(), awsErr.OrigErr())
 //
-//            if reqErr, ok := err.(awserr.RequestFailure); ok {
-//                // A service error occurred
-//                fmt.Println(reqErr.StatusCode(), reqErr.RequestID())
-//            }
-//        } else {
-//            fmt.Println(err.Error())
-//        }
-//    }
-//
+//	        if reqErr, ok := err.(awserr.RequestFailure); ok {
+//	            // A service error occurred
+//	            fmt.Println(reqErr.StatusCode(), reqErr.RequestID())
+//	        }
+//	    } else {
+//	        fmt.Println(err.Error())
+//	    }
+//	}
 type RequestFailure interface {
 	Error
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/awsutil/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awsutil/doc.go
@@ -1,0 +1,3 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
+package awsutil

--- a/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/client.go
@@ -1,3 +1,5 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package client
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/metadata/client_info.go
@@ -1,3 +1,5 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package metadata
 
 // ClientInfo wraps immutable data from the client.Client structure.

--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -1,3 +1,5 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package corehandlers
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
@@ -14,38 +14,39 @@
 //
 // Example of using the environment variable credentials.
 //
-//     creds := credentials.NewEnvCredentials()
+//	creds := credentials.NewEnvCredentials()
 //
-//     // Retrieve the credentials value
-//     credValue, err := creds.Get()
-//     if err != nil {
-//         // handle error
-//     }
+//	// Retrieve the credentials value
+//	credValue, err := creds.Get()
+//	if err != nil {
+//	    // handle error
+//	}
 //
 // Example of forcing credentials to expire and be refreshed on the next Get().
 // This may be helpful to proactively expire credentials and refresh them sooner
 // than they would naturally expire on their own.
 //
-//     creds := credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{})
-//     creds.Expire()
-//     credsValue, err := creds.Get()
-//     // New credentials will be retrieved instead of from cache.
+//	creds := credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{})
+//	creds.Expire()
+//	credsValue, err := creds.Get()
+//	// New credentials will be retrieved instead of from cache.
 //
-//
-// Custom Provider
+// # Custom Provider
 //
 // Each Provider built into this package also provides a helper method to generate
 // a Credentials pointer setup with the provider. To use a custom Provider just
 // create a type which satisfies the Provider interface and pass it to the
 // NewCredentials method.
 //
-//     type MyProvider struct{}
-//     func (m *MyProvider) Retrieve() (Value, error) {...}
-//     func (m *MyProvider) IsExpired() bool {...}
+//	type MyProvider struct{}
+//	func (m *MyProvider) Retrieve() (Value, error) {...}
+//	func (m *MyProvider) IsExpired() bool {...}
 //
-//     creds := credentials.NewCredentials(&MyProvider{})
-//     credValue, err := creds.Get()
+//	creds := credentials.NewCredentials(&MyProvider{})
+//	credValue, err := creds.Get()
 //
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package credentials
 
 import (
@@ -64,10 +65,10 @@ import (
 // when making service API calls. For example, when accessing public
 // s3 buckets.
 //
-//     svc := s3.New(session.Must(session.NewSession(&aws.Config{
-//       Credentials: credentials.AnonymousCredentials,
-//     })))
-//     // Access public S3 buckets.
+//	svc := s3.New(session.Must(session.NewSession(&aws.Config{
+//	  Credentials: credentials.AnonymousCredentials,
+//	})))
+//	// Access public S3 buckets.
 var AnonymousCredentials = NewStaticCredentials("", "", "")
 
 // A Value is the AWS credentials value for individual credential fields.
@@ -150,10 +151,11 @@ func (p ErrorProvider) IsExpired() bool {
 // provider's struct.
 //
 // Example:
-//     type EC2RoleProvider struct {
-//         Expiry
-//         ...
-//     }
+//
+//	type EC2RoleProvider struct {
+//	    Expiry
+//	    ...
+//	}
 type Expiry struct {
 	// The date/time when to expire on
 	expiration time.Time

--- a/vendor/github.com/aws/aws-sdk-go/aws/csm/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/csm/doc.go
@@ -3,7 +3,7 @@
 // control options, and configuration for the CSM client. The client can be
 // controlled manually, or automatically via the SDK's Session configuration.
 //
-// Enabling CSM client via SDK's Session configuration
+// # Enabling CSM client via SDK's Session configuration
 //
 // The CSM client can be enabled automatically via SDK's Session configuration.
 // The SDK's session configuration enables the CSM client if the AWS_CSM_PORT
@@ -12,39 +12,39 @@
 // The configuration options for the CSM client via the SDK's session
 // configuration are:
 //
-//	* AWS_CSM_PORT=<port number>
-//	  The port number the CSM agent will receive metrics on.
+//   - AWS_CSM_PORT=<port number>
+//     The port number the CSM agent will receive metrics on.
 //
-//	* AWS_CSM_HOST=<hostname or ip>
-//	  The hostname, or IP address the CSM agent will receive metrics on.
-//	  Without port number.
+//   - AWS_CSM_HOST=<hostname or ip>
+//     The hostname, or IP address the CSM agent will receive metrics on.
+//     Without port number.
 //
-// Manually enabling the CSM client
+// # Manually enabling the CSM client
 //
 // The CSM client can be started, paused, and resumed manually. The Start
 // function will enable the CSM client to publish metrics to the CSM agent. It
 // is safe to call Start concurrently, but if Start is called additional times
 // with different ClientID or address it will panic.
 //
-//		r, err := csm.Start("clientID", ":31000")
-//		if err != nil {
-//			panic(fmt.Errorf("failed starting CSM:  %v", err))
-//		}
+//	r, err := csm.Start("clientID", ":31000")
+//	if err != nil {
+//		panic(fmt.Errorf("failed starting CSM:  %v", err))
+//	}
 //
 // When controlling the CSM client manually, you must also inject its request
 // handlers into the SDK's Session configuration for the SDK's API clients to
 // publish metrics.
 //
-//		sess, err := session.NewSession(&aws.Config{})
-//		if err != nil {
-//			panic(fmt.Errorf("failed loading session: %v", err))
-//		}
+//	sess, err := session.NewSession(&aws.Config{})
+//	if err != nil {
+//		panic(fmt.Errorf("failed loading session: %v", err))
+//	}
 //
-//		// Add CSM client's metric publishing request handlers to the SDK's
-//		// Session Configuration.
-//		r.InjectHandlers(&sess.Handlers)
+//	// Add CSM client's metric publishing request handlers to the SDK's
+//	// Session Configuration.
+//	r.InjectHandlers(&sess.Handlers)
 //
-// Controlling CSM client
+// # Controlling CSM client
 //
 // Once the CSM client has been enabled the Get function will return a Reporter
 // value that you can use to pause and resume the metrics published to the CSM
@@ -54,16 +54,19 @@
 // The Pause method can be called to stop the CSM client publishing metrics to
 // the CSM agent. The Continue method will resume metric publishing.
 //
-//		// Get the CSM client Reporter.
-//		r := csm.Get()
+//	// Get the CSM client Reporter.
+//	r := csm.Get()
 //
-//		// Will pause monitoring
-//		r.Pause()
-//		resp, err = client.GetObject(&s3.GetObjectInput{
-//			Bucket: aws.String("bucket"),
-//			Key: aws.String("key"),
-//		})
+//	// Will pause monitoring
+//	r.Pause()
+//	resp, err = client.GetObject(&s3.GetObjectInput{
+//		Bucket: aws.String("bucket"),
+//		Key: aws.String("key"),
+//	})
 //
-//		// Resume monitoring
-//		r.Continue()
+//	// Resume monitoring
+//	r.Continue()
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package csm

--- a/vendor/github.com/aws/aws-sdk-go/aws/defaults/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/defaults/defaults.go
@@ -5,6 +5,9 @@
 // instead. This package is useful when you need to reset the defaults
 // of a session or service client to the SDK defaults before setting
 // additional parameters.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package defaults
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/doc.go
@@ -1,7 +1,7 @@
 // Package aws provides the core SDK's utilities and shared types. Use this package's
 // utilities to simplify setting and reading API operations parameters.
 //
-// Value and Pointer Conversion Utilities
+// # Value and Pointer Conversion Utilities
 //
 // This package includes a helper conversion utility for each scalar type the SDK's
 // API use. These utilities make getting a pointer of the scalar, and dereferencing
@@ -16,33 +16,33 @@
 // to get pointer of a literal string value, because getting the address of a
 // literal requires assigning the value to a variable first.
 //
-//    var strPtr *string
+//	var strPtr *string
 //
-//    // Without the SDK's conversion functions
-//    str := "my string"
-//    strPtr = &str
+//	// Without the SDK's conversion functions
+//	str := "my string"
+//	strPtr = &str
 //
-//    // With the SDK's conversion functions
-//    strPtr = aws.String("my string")
+//	// With the SDK's conversion functions
+//	strPtr = aws.String("my string")
 //
-//    // Convert *string to string value
-//    str = aws.StringValue(strPtr)
+//	// Convert *string to string value
+//	str = aws.StringValue(strPtr)
 //
 // In addition to scalars the aws package also includes conversion utilities for
 // map and slice for commonly types used in API parameters. The map and slice
 // conversion functions use similar naming pattern as the scalar conversion
 // functions.
 //
-//    var strPtrs []*string
-//    var strs []string = []string{"Go", "Gophers", "Go"}
+//	var strPtrs []*string
+//	var strs []string = []string{"Go", "Gophers", "Go"}
 //
-//    // Convert []string to []*string
-//    strPtrs = aws.StringSlice(strs)
+//	// Convert []string to []*string
+//	strPtrs = aws.StringSlice(strs)
 //
-//    // Convert []*string to []string
-//    strs = aws.StringValueSlice(strPtrs)
+//	// Convert []*string to []string
+//	strs = aws.StringValueSlice(strPtrs)
 //
-// SDK Default HTTP Client
+// # SDK Default HTTP Client
 //
 // The SDK will use the http.DefaultClient if a HTTP client is not provided to
 // the SDK's Session, or service client constructor. This means that if the
@@ -53,4 +53,7 @@
 // a custom HTTP Client to share explicitly through your application. You can
 // configure the SDK to use the custom HTTP Client by setting the HTTPClient
 // value of the SDK's Config type when creating a Session or service client.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/service.go
@@ -9,6 +9,9 @@
 // The endpoint of the EC2 IMDS client can be configured via the environment
 // variable, AWS_EC2_METADATA_SERVICE_ENDPOINT when creating the client with a
 // Session. See aws/session#Options.EC2IMDSEndpoint for more details.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package ec2metadata
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/doc.go
@@ -62,4 +62,7 @@
 //	    Region:           aws.String("us-west-2"),
 //	    EndpointResolver: endpoints.ResolverFunc(myCustomResolver),
 //	}))
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package endpoints

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/doc.go
@@ -1,0 +1,3 @@
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
+package request

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/doc.go
@@ -1,367 +1,366 @@
-/*
-Package session provides configuration for the SDK's service clients. Sessions
-can be shared across service clients that share the same base configuration.
-
-Sessions are safe to use concurrently as long as the Session is not being
-modified. Sessions should be cached when possible, because creating a new
-Session will load all configuration values from the environment, and config
-files each time the Session is created. Sharing the Session value across all of
-your service clients will ensure the configuration is loaded the fewest number
-of times possible.
-
-Sessions options from Shared Config
-
-By default NewSession will only load credentials from the shared credentials
-file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
-set to a truthy value the Session will be created from the configuration
-values from the shared config (~/.aws/config) and shared credentials
-(~/.aws/credentials) files. Using the NewSessionWithOptions with
-SharedConfigState set to SharedConfigEnable will create the session as if the
-AWS_SDK_LOAD_CONFIG environment variable was set.
-
-Credential and config loading order
-
-The Session will attempt to load configuration and credentials from the
-environment, configuration files, and other credential sources. The order
-configuration is loaded in is:
-
-  * Environment Variables
-  * Shared Credentials file
-  * Shared Configuration file (if SharedConfig is enabled)
-  * EC2 Instance Metadata (credentials only)
-
-The Environment variables for credentials will have precedence over shared
-config even if SharedConfig is enabled. To override this behavior, and use
-shared config credentials instead specify the session.Options.Profile, (e.g.
-when using credential_source=Environment to assume a role).
-
-  sess, err := session.NewSessionWithOptions(session.Options{
-	  Profile: "myProfile",
-  })
-
-Creating Sessions
-
-Creating a Session without additional options will load credentials region, and
-profile loaded from the environment and shared config automatically. See,
-"Environment Variables" section for information on environment variables used
-by Session.
-
-	// Create Session
-	sess, err := session.NewSession()
-
-
-When creating Sessions optional aws.Config values can be passed in that will
-override the default, or loaded, config values the Session is being created
-with. This allows you to provide additional, or case based, configuration
-as needed.
-
-	// Create a Session with a custom region
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-west-2"),
-	})
-
-Use NewSessionWithOptions to provide additional configuration driving how the
-Session's configuration will be loaded. Such as, specifying shared config
-profile, or override the shared config state,  (AWS_SDK_LOAD_CONFIG).
-
-	// Equivalent to session.NewSession()
-	sess, err := session.NewSessionWithOptions(session.Options{
-		// Options
-	})
-
-	sess, err := session.NewSessionWithOptions(session.Options{
-		// Specify profile to load for the session's config
-		Profile: "profile_name",
-
-		// Provide SDK Config options, such as Region.
-		Config: aws.Config{
-			Region: aws.String("us-west-2"),
-		},
-
-		// Force enable Shared Config support
-		SharedConfigState: session.SharedConfigEnable,
-	})
-
-Adding Handlers
-
-You can add handlers to a session to decorate API operation, (e.g. adding HTTP
-headers). All clients that use the Session receive a copy of the Session's
-handlers. For example, the following request handler added to the Session logs
-every requests made.
-
-	// Create a session, and add additional handlers for all service
-	// clients created with the Session to inherit. Adds logging handler.
-	sess := session.Must(session.NewSession())
-
-	sess.Handlers.Send.PushFront(func(r *request.Request) {
-		// Log every request made and its payload
-		logger.Printf("Request: %s/%s, Params: %s",
-			r.ClientInfo.ServiceName, r.Operation, r.Params)
-	})
-
-Shared Config Fields
-
-By default the SDK will only load the shared credentials file's
-(~/.aws/credentials) credentials values, and all other config is provided by
-the environment variables, SDK defaults, and user provided aws.Config values.
-
-If the AWS_SDK_LOAD_CONFIG environment variable is set, or SharedConfigEnable
-option is used to create the Session the full shared config values will be
-loaded. This includes credentials, region, and support for assume role. In
-addition the Session will load its configuration from both the shared config
-file (~/.aws/config) and shared credentials file (~/.aws/credentials). Both
-files have the same format.
-
-If both config files are present the configuration from both files will be
-read. The Session will be created from configuration values from the shared
-credentials file (~/.aws/credentials) over those in the shared config file
-(~/.aws/config).
-
-Credentials are the values the SDK uses to authenticating requests with AWS
-Services. When specified in a file, both aws_access_key_id and
-aws_secret_access_key must be provided together in the same file to be
-considered valid. They will be ignored if both are not present.
-aws_session_token is an optional field that can be provided in addition to the
-other two fields.
-
-	aws_access_key_id = AKID
-	aws_secret_access_key = SECRET
-	aws_session_token = TOKEN
-
-	; region only supported if SharedConfigEnabled.
-	region = us-east-1
-
-Assume Role configuration
-
-The role_arn field allows you to configure the SDK to assume an IAM role using
-a set of credentials from another source. Such as when paired with static
-credentials, "profile_source", "credential_process", or "credential_source"
-fields. If "role_arn" is provided, a source of credentials must also be
-specified, such as "source_profile", "credential_source", or
-"credential_process".
-
-	role_arn = arn:aws:iam::<account_number>:role/<role_name>
-	source_profile = profile_with_creds
-	external_id = 1234
-	mfa_serial = <serial or mfa arn>
-	role_session_name = session_name
-
-
-The SDK supports assuming a role with MFA token. If "mfa_serial" is set, you
-must also set the Session Option.AssumeRoleTokenProvider. The Session will fail
-to load if the AssumeRoleTokenProvider is not specified.
-
-    sess := session.Must(session.NewSessionWithOptions(session.Options{
-        AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-    }))
-
-To setup Assume Role outside of a session see the stscreds.AssumeRoleProvider
-documentation.
-
-Environment Variables
-
-When a Session is created several environment variables can be set to adjust
-how the SDK functions, and what configuration data it loads when creating
-Sessions. All environment values are optional, but some values like credentials
-require multiple of the values to set or the partial values will be ignored.
-All environment variable values are strings unless otherwise noted.
-
-Environment configuration values. If set both Access Key ID and Secret Access
-Key must be provided. Session Token and optionally also be provided, but is
-not required.
-
-	# Access Key ID
-	AWS_ACCESS_KEY_ID=AKID
-	AWS_ACCESS_KEY=AKID # only read if AWS_ACCESS_KEY_ID is not set.
-
-	# Secret Access Key
-	AWS_SECRET_ACCESS_KEY=SECRET
-	AWS_SECRET_KEY=SECRET=SECRET # only read if AWS_SECRET_ACCESS_KEY is not set.
-
-	# Session Token
-	AWS_SESSION_TOKEN=TOKEN
-
-Region value will instruct the SDK where to make service API requests to. If is
-not provided in the environment the region must be provided before a service
-client request is made.
-
-	AWS_REGION=us-east-1
-
-	# AWS_DEFAULT_REGION is only read if AWS_SDK_LOAD_CONFIG is also set,
-	# and AWS_REGION is not also set.
-	AWS_DEFAULT_REGION=us-east-1
-
-Profile name the SDK should load use when loading shared config from the
-configuration files. If not provided "default" will be used as the profile name.
-
-	AWS_PROFILE=my_profile
-
-	# AWS_DEFAULT_PROFILE is only read if AWS_SDK_LOAD_CONFIG is also set,
-	# and AWS_PROFILE is not also set.
-	AWS_DEFAULT_PROFILE=my_profile
-
-SDK load config instructs the SDK to load the shared config in addition to
-shared credentials. This also expands the configuration loaded so the shared
-credentials will have parity with the shared config file. This also enables
-Region and Profile support for the AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE
-env values as well.
-
-	AWS_SDK_LOAD_CONFIG=1
-
-Custom Shared Config and Credential Files
-
-Shared credentials file path can be set to instruct the SDK to use an alternative
-file for the shared credentials. If not set the file will be loaded from
-$HOME/.aws/credentials on Linux/Unix based systems, and
-%USERPROFILE%\.aws\credentials on Windows.
-
-	AWS_SHARED_CREDENTIALS_FILE=$HOME/my_shared_credentials
-
-Shared config file path can be set to instruct the SDK to use an alternative
-file for the shared config. If not set the file will be loaded from
-$HOME/.aws/config on Linux/Unix based systems, and
-%USERPROFILE%\.aws\config on Windows.
-
-	AWS_CONFIG_FILE=$HOME/my_shared_config
-
-Custom CA Bundle
-
-Path to a custom Credentials Authority (CA) bundle PEM file that the SDK
-will use instead of the default system's root CA bundle. Use this only
-if you want to replace the CA bundle the SDK uses for TLS requests.
-
-	AWS_CA_BUNDLE=$HOME/my_custom_ca_bundle
-
-Enabling this option will attempt to merge the Transport into the SDK's HTTP
-client. If the client's Transport is not a http.Transport an error will be
-returned. If the Transport's TLS config is set this option will cause the SDK
-to overwrite the Transport's TLS config's  RootCAs value. If the CA bundle file
-contains multiple certificates all of them will be loaded.
-
-The Session option CustomCABundle is also available when creating sessions
-to also enable this feature. CustomCABundle session option field has priority
-over the AWS_CA_BUNDLE environment variable, and will be used if both are set.
-
-Setting a custom HTTPClient in the aws.Config options will override this setting.
-To use this option and custom HTTP client, the HTTP client needs to be provided
-when creating the session. Not the service client.
-
-Custom Client TLS Certificate
-
-The SDK supports the environment and session option being configured with
-Client TLS certificates that are sent as a part of the client's TLS handshake
-for client authentication. If used, both Cert and Key values are required. If
-one is missing, or either fail to load the contents of the file an error will
-be returned.
-
-HTTP Client's Transport concrete implementation must be a http.Transport
-or creating the session will fail.
-
-	AWS_SDK_GO_CLIENT_TLS_KEY=$HOME/my_client_key
-	AWS_SDK_GO_CLIENT_TLS_CERT=$HOME/my_client_cert
-
-This can also be configured via the session.Options ClientTLSCert and ClientTLSKey.
-
-	sess, err := session.NewSessionWithOptions(session.Options{
-		ClientTLSCert: myCertFile,
-		ClientTLSKey: myKeyFile,
-	})
-
-Custom EC2 IMDS Endpoint
-
-The endpoint of the EC2 IMDS client can be configured via the environment
-variable, AWS_EC2_METADATA_SERVICE_ENDPOINT when creating the client with a
-Session. See Options.EC2IMDSEndpoint for more details.
-
-  AWS_EC2_METADATA_SERVICE_ENDPOINT=http://169.254.169.254
-
-If using an URL with an IPv6 address literal, the IPv6 address
-component must be enclosed in square brackets.
-
-  AWS_EC2_METADATA_SERVICE_ENDPOINT=http://[::1]
-
-The custom EC2 IMDS endpoint can also be specified via the Session options.
-
-  sess, err := session.NewSessionWithOptions(session.Options{
-      EC2MetadataEndpoint: "http://[::1]",
-  })
-
-FIPS and DualStack Endpoints
-
-The SDK can be configured to resolve an endpoint with certain capabilities such as FIPS and DualStack.
-
-You can configure a FIPS endpoint using an environment variable, shared config ($HOME/.aws/config),
-or programmatically.
-
-To configure a FIPS endpoint set the environment variable set the AWS_USE_FIPS_ENDPOINT to true or false to enable
-or disable FIPS endpoint resolution.
-
-  AWS_USE_FIPS_ENDPOINT=true
-
-To configure a FIPS endpoint using shared config, set use_fips_endpoint to true or false to enable
-or disable FIPS endpoint resolution.
-
-  [profile myprofile]
-  region=us-west-2
-  use_fips_endpoint=true
-
-To configure a FIPS endpoint programmatically
-
-  // Option 1: Configure it on a session for all clients
-  sess, err := session.NewSessionWithOptions(session.Options{
-      UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
-  })
-  if err != nil {
-      // handle error
-  }
-
-  client := s3.New(sess)
-
-  // Option 2: Configure it per client
-  sess, err := session.NewSession()
-  if err != nil {
-      // handle error
-  }
-
-  client := s3.New(sess, &aws.Config{
-      UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
-  })
-
-You can configure a DualStack endpoint using an environment variable, shared config ($HOME/.aws/config),
-or programmatically.
-
-To configure a DualStack endpoint set the environment variable set the AWS_USE_DUALSTACK_ENDPOINT to true or false to
-enable or disable DualStack endpoint resolution.
-
-  AWS_USE_DUALSTACK_ENDPOINT=true
-
-To configure a DualStack endpoint using shared config, set use_dualstack_endpoint to true or false to enable
-or disable DualStack endpoint resolution.
-
-  [profile myprofile]
-  region=us-west-2
-  use_dualstack_endpoint=true
-
-To configure a DualStack endpoint programmatically
-
-  // Option 1: Configure it on a session for all clients
-  sess, err := session.NewSessionWithOptions(session.Options{
-      UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
-  })
-  if err != nil {
-      // handle error
-  }
-
-  client := s3.New(sess)
-
-  // Option 2: Configure it per client
-  sess, err := session.NewSession()
-  if err != nil {
-      // handle error
-  }
-
-  client := s3.New(sess, &aws.Config{
-      UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
-  })
-*/
+// Package session provides configuration for the SDK's service clients. Sessions
+// can be shared across service clients that share the same base configuration.
+//
+// Sessions are safe to use concurrently as long as the Session is not being
+// modified. Sessions should be cached when possible, because creating a new
+// Session will load all configuration values from the environment, and config
+// files each time the Session is created. Sharing the Session value across all of
+// your service clients will ensure the configuration is loaded the fewest number
+// of times possible.
+//
+// # Sessions options from Shared Config
+//
+// By default NewSession will only load credentials from the shared credentials
+// file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
+// set to a truthy value the Session will be created from the configuration
+// values from the shared config (~/.aws/config) and shared credentials
+// (~/.aws/credentials) files. Using the NewSessionWithOptions with
+// SharedConfigState set to SharedConfigEnable will create the session as if the
+// AWS_SDK_LOAD_CONFIG environment variable was set.
+//
+// # Credential and config loading order
+//
+// The Session will attempt to load configuration and credentials from the
+// environment, configuration files, and other credential sources. The order
+// configuration is loaded in is:
+//
+//   - Environment Variables
+//   - Shared Credentials file
+//   - Shared Configuration file (if SharedConfig is enabled)
+//   - EC2 Instance Metadata (credentials only)
+//
+// The Environment variables for credentials will have precedence over shared
+// config even if SharedConfig is enabled. To override this behavior, and use
+// shared config credentials instead specify the session.Options.Profile, (e.g.
+// when using credential_source=Environment to assume a role).
+//
+//	  sess, err := session.NewSessionWithOptions(session.Options{
+//		  Profile: "myProfile",
+//	  })
+//
+// # Creating Sessions
+//
+// Creating a Session without additional options will load credentials region, and
+// profile loaded from the environment and shared config automatically. See,
+// "Environment Variables" section for information on environment variables used
+// by Session.
+//
+//	// Create Session
+//	sess, err := session.NewSession()
+//
+// When creating Sessions optional aws.Config values can be passed in that will
+// override the default, or loaded, config values the Session is being created
+// with. This allows you to provide additional, or case based, configuration
+// as needed.
+//
+//	// Create a Session with a custom region
+//	sess, err := session.NewSession(&aws.Config{
+//		Region: aws.String("us-west-2"),
+//	})
+//
+// Use NewSessionWithOptions to provide additional configuration driving how the
+// Session's configuration will be loaded. Such as, specifying shared config
+// profile, or override the shared config state,  (AWS_SDK_LOAD_CONFIG).
+//
+//	// Equivalent to session.NewSession()
+//	sess, err := session.NewSessionWithOptions(session.Options{
+//		// Options
+//	})
+//
+//	sess, err := session.NewSessionWithOptions(session.Options{
+//		// Specify profile to load for the session's config
+//		Profile: "profile_name",
+//
+//		// Provide SDK Config options, such as Region.
+//		Config: aws.Config{
+//			Region: aws.String("us-west-2"),
+//		},
+//
+//		// Force enable Shared Config support
+//		SharedConfigState: session.SharedConfigEnable,
+//	})
+//
+// # Adding Handlers
+//
+// You can add handlers to a session to decorate API operation, (e.g. adding HTTP
+// headers). All clients that use the Session receive a copy of the Session's
+// handlers. For example, the following request handler added to the Session logs
+// every requests made.
+//
+//	// Create a session, and add additional handlers for all service
+//	// clients created with the Session to inherit. Adds logging handler.
+//	sess := session.Must(session.NewSession())
+//
+//	sess.Handlers.Send.PushFront(func(r *request.Request) {
+//		// Log every request made and its payload
+//		logger.Printf("Request: %s/%s, Params: %s",
+//			r.ClientInfo.ServiceName, r.Operation, r.Params)
+//	})
+//
+// # Shared Config Fields
+//
+// By default the SDK will only load the shared credentials file's
+// (~/.aws/credentials) credentials values, and all other config is provided by
+// the environment variables, SDK defaults, and user provided aws.Config values.
+//
+// If the AWS_SDK_LOAD_CONFIG environment variable is set, or SharedConfigEnable
+// option is used to create the Session the full shared config values will be
+// loaded. This includes credentials, region, and support for assume role. In
+// addition the Session will load its configuration from both the shared config
+// file (~/.aws/config) and shared credentials file (~/.aws/credentials). Both
+// files have the same format.
+//
+// If both config files are present the configuration from both files will be
+// read. The Session will be created from configuration values from the shared
+// credentials file (~/.aws/credentials) over those in the shared config file
+// (~/.aws/config).
+//
+// Credentials are the values the SDK uses to authenticating requests with AWS
+// Services. When specified in a file, both aws_access_key_id and
+// aws_secret_access_key must be provided together in the same file to be
+// considered valid. They will be ignored if both are not present.
+// aws_session_token is an optional field that can be provided in addition to the
+// other two fields.
+//
+//	aws_access_key_id = AKID
+//	aws_secret_access_key = SECRET
+//	aws_session_token = TOKEN
+//
+//	; region only supported if SharedConfigEnabled.
+//	region = us-east-1
+//
+// # Assume Role configuration
+//
+// The role_arn field allows you to configure the SDK to assume an IAM role using
+// a set of credentials from another source. Such as when paired with static
+// credentials, "profile_source", "credential_process", or "credential_source"
+// fields. If "role_arn" is provided, a source of credentials must also be
+// specified, such as "source_profile", "credential_source", or
+// "credential_process".
+//
+//	role_arn = arn:aws:iam::<account_number>:role/<role_name>
+//	source_profile = profile_with_creds
+//	external_id = 1234
+//	mfa_serial = <serial or mfa arn>
+//	role_session_name = session_name
+//
+// The SDK supports assuming a role with MFA token. If "mfa_serial" is set, you
+// must also set the Session Option.AssumeRoleTokenProvider. The Session will fail
+// to load if the AssumeRoleTokenProvider is not specified.
+//
+//	sess := session.Must(session.NewSessionWithOptions(session.Options{
+//		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+//	}))
+//
+// To setup Assume Role outside of a session see the stscreds.AssumeRoleProvider
+// documentation.
+//
+// # Environment Variables
+//
+// When a Session is created several environment variables can be set to adjust
+// how the SDK functions, and what configuration data it loads when creating
+// Sessions. All environment values are optional, but some values like credentials
+// require multiple of the values to set or the partial values will be ignored.
+// All environment variable values are strings unless otherwise noted.
+//
+// Environment configuration values. If set both Access Key ID and Secret Access
+// Key must be provided. Session Token and optionally also be provided, but is
+// not required.
+//
+//	# Access Key ID
+//	AWS_ACCESS_KEY_ID=AKID
+//	AWS_ACCESS_KEY=AKID # only read if AWS_ACCESS_KEY_ID is not set.
+//
+//	# Secret Access Key
+//	AWS_SECRET_ACCESS_KEY=SECRET
+//	AWS_SECRET_KEY=SECRET=SECRET # only read if AWS_SECRET_ACCESS_KEY is not set.
+//
+//	# Session Token
+//	AWS_SESSION_TOKEN=TOKEN
+//
+// Region value will instruct the SDK where to make service API requests to. If is
+// not provided in the environment the region must be provided before a service
+// client request is made.
+//
+//	AWS_REGION=us-east-1
+//
+//	# AWS_DEFAULT_REGION is only read if AWS_SDK_LOAD_CONFIG is also set,
+//	# and AWS_REGION is not also set.
+//	AWS_DEFAULT_REGION=us-east-1
+//
+// Profile name the SDK should load use when loading shared config from the
+// configuration files. If not provided "default" will be used as the profile name.
+//
+//	AWS_PROFILE=my_profile
+//
+//	# AWS_DEFAULT_PROFILE is only read if AWS_SDK_LOAD_CONFIG is also set,
+//	# and AWS_PROFILE is not also set.
+//	AWS_DEFAULT_PROFILE=my_profile
+//
+// SDK load config instructs the SDK to load the shared config in addition to
+// shared credentials. This also expands the configuration loaded so the shared
+// credentials will have parity with the shared config file. This also enables
+// Region and Profile support for the AWS_DEFAULT_REGION and AWS_DEFAULT_PROFILE
+// env values as well.
+//
+//	AWS_SDK_LOAD_CONFIG=1
+//
+// # Custom Shared Config and Credential Files
+//
+// Shared credentials file path can be set to instruct the SDK to use an alternative
+// file for the shared credentials. If not set the file will be loaded from
+// $HOME/.aws/credentials on Linux/Unix based systems, and
+// %USERPROFILE%\.aws\credentials on Windows.
+//
+//	AWS_SHARED_CREDENTIALS_FILE=$HOME/my_shared_credentials
+//
+// Shared config file path can be set to instruct the SDK to use an alternative
+// file for the shared config. If not set the file will be loaded from
+// $HOME/.aws/config on Linux/Unix based systems, and
+// %USERPROFILE%\.aws\config on Windows.
+//
+//	AWS_CONFIG_FILE=$HOME/my_shared_config
+//
+// # Custom CA Bundle
+//
+// Path to a custom Credentials Authority (CA) bundle PEM file that the SDK
+// will use instead of the default system's root CA bundle. Use this only
+// if you want to replace the CA bundle the SDK uses for TLS requests.
+//
+//	AWS_CA_BUNDLE=$HOME/my_custom_ca_bundle
+//
+// Enabling this option will attempt to merge the Transport into the SDK's HTTP
+// client. If the client's Transport is not a http.Transport an error will be
+// returned. If the Transport's TLS config is set this option will cause the SDK
+// to overwrite the Transport's TLS config's  RootCAs value. If the CA bundle file
+// contains multiple certificates all of them will be loaded.
+//
+// The Session option CustomCABundle is also available when creating sessions
+// to also enable this feature. CustomCABundle session option field has priority
+// over the AWS_CA_BUNDLE environment variable, and will be used if both are set.
+//
+// Setting a custom HTTPClient in the aws.Config options will override this setting.
+// To use this option and custom HTTP client, the HTTP client needs to be provided
+// when creating the session. Not the service client.
+//
+// # Custom Client TLS Certificate
+//
+// The SDK supports the environment and session option being configured with
+// Client TLS certificates that are sent as a part of the client's TLS handshake
+// for client authentication. If used, both Cert and Key values are required. If
+// one is missing, or either fail to load the contents of the file an error will
+// be returned.
+//
+// HTTP Client's Transport concrete implementation must be a http.Transport
+// or creating the session will fail.
+//
+//	AWS_SDK_GO_CLIENT_TLS_KEY=$HOME/my_client_key
+//	AWS_SDK_GO_CLIENT_TLS_CERT=$HOME/my_client_cert
+//
+// This can also be configured via the session.Options ClientTLSCert and ClientTLSKey.
+//
+//	sess, err := session.NewSessionWithOptions(session.Options{
+//		ClientTLSCert: myCertFile,
+//		ClientTLSKey: myKeyFile,
+//	})
+//
+// # Custom EC2 IMDS Endpoint
+//
+// The endpoint of the EC2 IMDS client can be configured via the environment
+// variable, AWS_EC2_METADATA_SERVICE_ENDPOINT when creating the client with a
+// Session. See Options.EC2IMDSEndpoint for more details.
+//
+//	AWS_EC2_METADATA_SERVICE_ENDPOINT=http://169.254.169.254
+//
+// If using an URL with an IPv6 address literal, the IPv6 address
+// component must be enclosed in square brackets.
+//
+//	AWS_EC2_METADATA_SERVICE_ENDPOINT=http://[::1]
+//
+// The custom EC2 IMDS endpoint can also be specified via the Session options.
+//
+//	  sess, err := session.NewSessionWithOptions(session.Options{
+//		  EC2MetadataEndpoint: "http://[::1]",
+//	  })
+//
+// # FIPS and DualStack Endpoints
+//
+// The SDK can be configured to resolve an endpoint with certain capabilities such as FIPS and DualStack.
+//
+// You can configure a FIPS endpoint using an environment variable, shared config ($HOME/.aws/config),
+// or programmatically.
+//
+// To configure a FIPS endpoint set the environment variable set the AWS_USE_FIPS_ENDPOINT to true or false to enable
+// or disable FIPS endpoint resolution.
+//
+//	AWS_USE_FIPS_ENDPOINT=true
+//
+// To configure a FIPS endpoint using shared config, set use_fips_endpoint to true or false to enable
+// or disable FIPS endpoint resolution.
+//
+//	[profile myprofile]
+//	region=us-west-2
+//	use_fips_endpoint=true
+//
+// To configure a FIPS endpoint programmatically
+//
+//	  // Option 1: Configure it on a session for all clients
+//	  sess, err := session.NewSessionWithOptions(session.Options{
+//		  UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
+//	  })
+//	  if err != nil {
+//		  // handle error
+//	  }
+//
+//	  client := s3.New(sess)
+//
+//	  // Option 2: Configure it per client
+//	  sess, err := session.NewSession()
+//	  if err != nil {
+//		  // handle error
+//	  }
+//
+//	  client := s3.New(sess, &aws.Config{
+//		  UseFIPSEndpoint: endpoints.FIPSEndpointStateEnabled,
+//	  })
+//
+// You can configure a DualStack endpoint using an environment variable, shared config ($HOME/.aws/config),
+// or programmatically.
+//
+// To configure a DualStack endpoint set the environment variable set the AWS_USE_DUALSTACK_ENDPOINT to true or false to
+// enable or disable DualStack endpoint resolution.
+//
+//	AWS_USE_DUALSTACK_ENDPOINT=true
+//
+// To configure a DualStack endpoint using shared config, set use_dualstack_endpoint to true or false to enable
+// or disable DualStack endpoint resolution.
+//
+//	[profile myprofile]
+//	region=us-west-2
+//	use_dualstack_endpoint=true
+//
+// To configure a DualStack endpoint programmatically
+//
+//	  // Option 1: Configure it on a session for all clients
+//	  sess, err := session.NewSessionWithOptions(session.Options{
+//		  UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
+//	  })
+//	  if err != nil {
+//		  // handle error
+//	  }
+//
+//	  client := s3.New(sess)
+//
+//	  // Option 2: Configure it per client
+//	  sess, err := session.NewSession()
+//	  if err != nil {
+//		  // handle error
+//	  }
+//
+//	  client := s3.New(sess, &aws.Config{
+//		  UseDualStackEndpoint: endpoints.DualStackEndpointStateEnabled,
+//	  })
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package session

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -52,6 +52,9 @@
 //
 // Test `TestStandaloneSign` provides a complete example of using the signer
 // outside of the SDK and pre-escaping the URI path.
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package v4
 
 import (

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.55.7"
+const SDKVersion = "1.55.8"

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/doc.go
@@ -27,4 +27,7 @@
 // See the Amazon Elastic Compute Cloud client EC2 for more
 // information on creating client for this service.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#New
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package ec2

--- a/vendor/github.com/aws/aws-sdk-go/service/sso/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sso/doc.go
@@ -42,4 +42,7 @@
 // See the AWS Single Sign-On client SSO for more
 // information on creating client for this service.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/sso/#New
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package sso

--- a/vendor/github.com/aws/aws-sdk-go/service/ssooidc/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssooidc/doc.go
@@ -64,4 +64,7 @@
 // See the AWS SSO OIDC client SSOOIDC for more
 // information on creating client for this service.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ssooidc/#New
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package ssooidc

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/doc.go
@@ -28,4 +28,7 @@
 // See the AWS Security Token Service client STS for more
 // information on creating client for this service.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/sts/#New
+//
+// Deprecated: aws-sdk-go is deprecated. Use aws-sdk-go-v2.
+// See https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/.
 package sts

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 ## explicit; go 1.13
 github.com/asaskevich/govalidator
-# github.com/aws/aws-sdk-go v1.55.7
+# github.com/aws/aws-sdk-go v1.55.8
 ## explicit; go 1.19
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn


### PR DESCRIPTION
This pull request updates a dependency version in the `go.mod` file. The change is minor and involves upgrading the `github.com/aws/aws-sdk-go` library from version 1.55.7 to 1.55.8.