### PR TITLE
OCPBUGS-60275: remove unused textfile collector from windows exporter

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -29,7 +29,7 @@ const (
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort string, platform config.PlatformType,
 	debug bool) (*servicescm.Data, error) {
 	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
-		"cpu,cs,logical_disk,net,os,service,system,textfile,container,memory,cpu_info --web.config.file %s",
+		"cpu,cs,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
 		windows.WindowsExporterPath, windows.TLSConfPath)
 	kubeletConfiguration, err := getKubeletServiceConfiguration(kubeletArgsFromIgnition, debug, platform)
 	if err != nil {


### PR DESCRIPTION
This commit removes the unused textfile collector from windows exporter to fix error reporting in logs about reading textfile directory C:\k\textfile_inputs