### PR TITLE
Reduce node retry interval in e2e tests

### DIFF
--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	nodeCreationTime  = time.Minute * 35
-	nodeRetryInterval = time.Minute * 1
+	nodeRetryInterval = time.Second * 15
 	// deploymentRetries is the amount of time to retry creating a Windows Server deployment, to compensate for the
 	// time it takes to download the Server image to the node
 	deploymentRetries = 10


### PR DESCRIPTION
This reduces the retry interval from 60 -> 15 seconds. This change reduces the potential wasted time of a Node finishing configuration immediately after a retry.