### PR TITLE
WINC-1366: changes NodeSelector from master to control-plane

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -460,7 +460,7 @@ spec:
               dnsPolicy: ClusterFirstWithHostNet
               hostNetwork: true
               nodeSelector:
-                node-role.kubernetes.io/master: ""
+                node-role.kubernetes.io/control-plane: ""
               priorityClassName: system-cluster-critical
               serviceAccountName: windows-machine-config-operator
               terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: windows-machine-config-operator
       terminationGracePeriodSeconds: 10
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"


### PR DESCRIPTION
removes the deprecation warning by updating the NodeSelector from master to control-plane 