### PR TITLE
OCPBUGS-60482: Fix SSH connection leak

### DIFF
--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -545,6 +545,12 @@ func (r *ConfigMapReconciler) ensureTrustedCABundleInNode(ctx context.Context, n
 	if err != nil {
 		return fmt.Errorf("failed to create new nodeconfig: %w", err)
 	}
+	defer func() {
+		err := nc.Close()
+		if err != nil {
+			r.log.Info("WARNING: error closing nodeconfig", "error", err.Error())
+		}
+	}()
 	return nc.SyncTrustedCABundle(ctx)
 }
 

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -109,6 +109,12 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)
 		}
+		defer func() {
+			err := nc.Close()
+			if err != nil {
+				r.log.Info("WARNING: error closing nodeconfig", "error", err.Error())
+			}
+		}()
 
 		if err := nc.SafeReboot(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("full instance reboot failed: %w", err)

--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -115,6 +115,12 @@ func (r *registryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)
 		}
+		defer func() {
+			err := nc.Close()
+			if err != nil {
+				r.log.Info("WARNING: error closing nodeconfig", "error", err.Error())
+			}
+		}()
 
 		r.log.Info("updating containerd config", "directory", windows.ContainerdConfigDir, "node", node.Name)
 		// TODO: If this flakes for any one node, we have to loop over all nodes again and re-transfer the directory to

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -255,6 +255,12 @@ func (r *SecretReconciler) reconcileTLSSecret(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to create new nodeconfig: %w", err)
 		}
+		defer func() {
+			err := nc.Close()
+			if err != nil {
+				r.log.Info("WARNING: error closing nodeconfig", "error", err.Error())
+			}
+		}()
 		if err = nc.Windows.ReplaceDir(certFiles, windows.TLSCertsPath); err != nil {
 			return fmt.Errorf("unable to transfer TLS certs: %w", err)
 		}

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -323,6 +323,7 @@ func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (strin
 	if err != nil {
 		return "", fmt.Errorf("error instantiating Windows instance: %w", err)
 	}
+	defer win.Close()
 	// get the instance host name  by running hostname command on remote VM
 	return win.GetHostname()
 }

--- a/pkg/nodeconfig/init.go
+++ b/pkg/nodeconfig/init.go
@@ -10,9 +10,9 @@ import (
 	crclientcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-// cache holds the information of the nodeConfig that is invariant for multiple reconciliation cycles. We'll use this
+// cache holds the information of the NodeConfig that is invariant for multiple reconciliation cycles. We'll use this
 // information when we don't want to get the information from the global context coming from reconciler
-// but to have something at nodeConfig package locally which will be passed onto other structs. There is no need to
+// but to have something at NodeConfig package locally which will be passed onto other structs. There is no need to
 // invalidate this cache as of now, since if someone wants to change any of the fields, they've to restart the operator
 // which will invalidate the cache automatically.
 type cache struct {
@@ -20,10 +20,10 @@ type cache struct {
 	apiServerEndpoint string
 }
 
-// cache has the information related to nodeConfig that should not be changed.
+// cache has the information related to NodeConfig that should not be changed.
 var nodeConfigCache = cache{}
 
-// init populates the cache that we need for nodeConfig
+// init populates the cache that we need for NodeConfig
 func init() {
 	var kubeAPIServerEndpoint string
 	log := ctrl.Log.WithName("nodeconfig").WithName("init")

--- a/pkg/windows/connectivity.go
+++ b/pkg/windows/connectivity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -44,6 +45,8 @@ type connectivity interface {
 	transfer(*sftp.Client, io.Reader, string, string) error
 	// transferFiles transfers the given files to a given remote directory
 	transferFiles(*sftp.Client, map[string][]byte, string) error
+	// close closes all network connections
+	close() error
 }
 
 // sshConnectivity encapsulates the information needed to connect to the Windows VM over ssh
@@ -188,4 +191,13 @@ func (c *sshConnectivity) transferFiles(sftpClient *sftp.Client, files map[strin
 		}
 	}
 	return nil
+}
+
+func (c *sshConnectivity) close() error {
+	err := c.sshClient.Close()
+	// If the error is due to the underlying connection being already closed, don't return an error
+	if errors.Is(syscall.EINVAL, err) {
+		return nil
+	}
+	return err
 }

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -273,6 +273,7 @@ type Windows interface {
 	// RunWICDCleanup ensures the WICD service is stopped and runs the cleanup command that ensures all WICD-managed
 	// services are also stopped
 	RunWICDCleanup(string, string) error
+	Close() error
 }
 
 // windows implements the Windows interface
@@ -291,6 +292,10 @@ type windows struct {
 	defaultShellPowerShell bool
 	// filesToTransfer is the map of files needed for the windows VM
 	filesToTransfer map[*payload.FileInfo]string
+}
+
+func (vm *windows) Close() error {
+	return vm.interact.close()
 }
 
 // New returns a new Windows instance constructed from the given WindowsVM


### PR DESCRIPTION
Adds Close() methods to NodeConfig and Windows interfaces to allow callers to ensure that SSH connections to the VM are closed.