### PR TITLE
OCPBUGS-60771: Fix job success logic

### DIFF
--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -110,7 +110,7 @@ func (tc *testContext) testParallelUpgradesChecker(t *testing.T) {
 	failedPods, err := tc.client.K8s.CoreV1().Pods(tc.workloadNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "job-name=" + parallelUpgradesCheckerJobName, FieldSelector: "status.phase=Failed"})
 	require.NoError(t, err)
-	_, err = tc.gatherPodLogs("job-name=" + parallelUpgradesCheckerJobName)
+	_, err = tc.gatherPodLogs("job-name="+parallelUpgradesCheckerJobName, false)
 	if err != nil {
 		log.Printf("unable to gather logs: %v", err)
 	}


### PR DESCRIPTION
We are reporting jobs as failed if a pod within the job failed. This is incorrect logic, as a single pod failing is not a failure state for the entire job. The job will keep creating pods until a success is seen.