### PR TITLE
WINC-1442: Save configuration time data to artifacts directory

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -102,7 +102,7 @@ func (tc *testContext) testWindowsNodeCreation(t *testing.T) {
 	// TODO: Remove this dependency by rotating keys as part of https://issues.redhat.com/browse/WINC-655
 	t.Run("ConfigMap controller", tc.testBYOHConfiguration)
 
-	err := retrieveWindowsNodeObjects()
+	err := retrieveWindowsNodeObjects(tc.artifactDir)
 	if err != nil {
 		log.Printf("error retrieving windows node objects: %s", err)
 	}
@@ -696,7 +696,7 @@ func (tc *testContext) createPullSecret() error {
 }
 
 // retrieveWindowsNodeObjects retrieves the Windows node objects from the cluster and writes them to the given directory
-func retrieveWindowsNodeObjects() error {
+func retrieveWindowsNodeObjects(dir string) error {
 	outputFormat := "json"
 	cmd := exec.Command("oc", "get", "nodes", "-l kubernetes.io/os=windows", "-o"+outputFormat)
 	out, err := cmd.Output()
@@ -708,7 +708,7 @@ func retrieveWindowsNodeObjects() error {
 		}
 		return fmt.Errorf("oc get nodes failed with exit code %s and output: %s: %s", err, string(out), stderr)
 	}
-	destDir := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
+	destDir := filepath.Join(dir, "nodes")
 	err = os.MkdirAll(destDir, os.ModePerm)
 	if err != nil {
 		return err

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -29,7 +29,7 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"wicd/windows-instance-config-daemon.exe.INFO",
 		"csi-proxy/csi-proxy.log",
 	}
-	nodeArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes")
+	nodeArtifacts := filepath.Join(tc.artifactDir, "nodes")
 	for _, node := range gc.allNodes() {
 		nodeDir := filepath.Join(nodeArtifacts, node.Name)
 		for _, file := range mandatoryLogs {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -89,6 +89,8 @@ type testContext struct {
 	windowsServerVersion windows.ServerVersion
 	// mirrorRegistry is the container mirror registry URL
 	mirrorRegistry string
+	// artifactDir is a directory that logs are saved to. It will be created if it does not exist.
+	artifactDir string
 }
 
 // NewTestContext returns a new test context to be used by every test.
@@ -115,11 +117,17 @@ func NewTestContext() (*testContext, error) {
 		"pod-security.kubernetes.io/audit":   "privileged",
 		"pod-security.kubernetes.io/warn":    "privileged",
 	}
+	artifactDir := os.Getenv("ARTIFACT_DIR")
+	err = os.MkdirAll(artifactDir, os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("error creating artifact dir: %w", err)
+	}
 
 	// number of nodes, retry interval and timeout should come from user-input flags
 	return &testContext{client: oc, timeout: retry.Timeout, retryInterval: retry.Interval,
 		CloudProvider: cloudProvider, workloadNamespace: "wmco-test", workloadNamespaceLabels: workloadNamespaceLabels,
-		windowsServerVersion: windowsServerVersion, toolsImage: toolsImage, mirrorRegistry: mirrorRegistry}, nil
+		windowsServerVersion: windowsServerVersion, toolsImage: toolsImage, mirrorRegistry: mirrorRegistry,
+		artifactDir: artifactDir}, nil
 }
 
 // vmUsername returns the name of the user which can be used to log into each Windows instance

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -197,8 +197,8 @@ func (tc *testContext) stopPacketTrace(node *v1.Node) error {
 			return tc.isGatherDone(createdPod)
 		})
 
-	// Copy the packet trace from the pod to $ARTIFACT_DIR/nodes/$nodename/trace
-	nodeDir := filepath.Join(os.Getenv("ARTIFACT_DIR"), "nodes", node.Name)
+	// Copy the packet trace from the pod to the artifact directory
+	nodeDir := filepath.Join(tc.artifactDir, "nodes", node.Name)
 	err = os.MkdirAll(filepath.Join(nodeDir), os.ModePerm)
 	if err != nil {
 		return err
@@ -1159,7 +1159,7 @@ func (tc *testContext) waitUntilJobSucceeds(name string) (string, error) {
 // gatherPodLogs writes the logs associated with the label selector of a given pod job or deployment to the Artifacts
 // dir. Returns the written logs.
 func (tc *testContext) gatherPodLogs(labelSelector string, latestOnly bool) (string, error) {
-	podArtifacts := filepath.Join(os.Getenv("ARTIFACT_DIR"), "pods")
+	podArtifacts := filepath.Join(tc.artifactDir, "pods")
 	podDir := filepath.Join(podArtifacts, labelSelector)
 	err := os.MkdirAll(podDir, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
Adds configuration times to the e2e artifacts when creation tests are ran.

Example file contents:
{"nodeType":"machine","nodeCount":1,"machineProvisioned":"3m40s","sshAvailable":"10s","nodeConfigured":"4m30s"}
{"nodeType":"byoh","nodeCount":1,"nodeConfigured":"5m45s"}