### PR TITLE
OCPBUGS-60866: Fix HNS network removal error log level

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -970,7 +970,7 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 		err = wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
 			// reinitialize and retry on failure to avoid connection reset SSH errors
 			if err := vm.removeHNSNetwork(network); err != nil {
-				vm.log.V(1).Error(err, "error removing %s HNS network", "network", network)
+				vm.log.V(1).Info("error removing HNS network", "network", network, "err", err.Error())
 				if err := vm.reinitialize(); err != nil {
 					return false, fmt.Errorf("error reinitializing VM after removing %s HNS network: %w", network, err)
 				}
@@ -981,7 +981,7 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 			}
 			out, err := vm.Run(getHNSNetworkCmd(network), true)
 			if err != nil {
-				vm.log.V(1).Error(err, "error waiting for HNS network", "network", network)
+				vm.log.V(1).Info("error waiting for HNS network", "network", network, "err", err.Error())
 				return false, nil
 			}
 			return !strings.Contains(out, network), nil


### PR DESCRIPTION
A failure to remove an HNS network is a recoverable error, and should be logged at debug level. This commit fixes an issue where this being logged at info level.

log.V(1).Info needs to be used to log to debug level. log.V(1).Error does not work. logger.Error has the documentation: "The log message will always be emitted, regardless of verbosity level"