### PR TITLE
WINC-1439: Prep for 10.19.1 release

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -201,6 +201,6 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v10.19.0"
+LABEL version="v10.19.1"
 
 USER ${USER_UID}

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -16,7 +16,7 @@ LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
     io.openshift.tags=""
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v10.19.0"
+LABEL version="v10.19.1"
 # Component to file bugs against
 LABEL com.redhat.component="Windows Containers"
 
@@ -32,7 +32,7 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 LABEL distribution-scope=public
-LABEL release="10.19.0"
+LABEL release="10.19.1"
 LABEL url="https://docs.openshift.com/container-platform/4.19/windows_containers/index.html"
 LABEL vendor="Red Hat, Inc."
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 10.19.0
+WMCO_VERSION ?= 10.19.1
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.18.0 <10.19.0'
+    olm.skipRange: '>=10.18.0 <10.19.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -27,7 +27,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v10.19.0
+  name: windows-machine-config-operator.v10.19.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -528,4 +528,4 @@ spec:
   minKubeVersion: 1.32.0
   provider:
     name: Red Hat
-  version: 10.19.0
+  version: 10.19.1

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v10.19.0
+  - currentCSV: windows-machine-config-operator.v10.19.1
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.18.0 <10.19.0'
+    olm.skipRange: '>=10.18.0 <10.19.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: windows-machine-config-operator
 rules:
 - apiGroups:


### PR DESCRIPTION

Version update across project files:

* Updated the version label in the main container `Containerfile` to `v10.19.1`
* Updated the version and release labels in `Containerfile.bundle` to `v10.19.1` 
* Updated the default `WMCO_VERSION` in the `Makefile` to `10.19.1`

Operator bundle and manifest adjustments:

* Updated all references to the operator version and skip range in `windows-machine-config-operator.clusterserviceversion.yaml` and related bundle files to `10.19.1` 

