### PR TITLE
Switch to 2019-datacenter-smalldisk sku  for Azure in machineset.sh

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -154,10 +154,9 @@ get_azure_ms() {
   local sku="2022-datacenter-smalldisk"
   local release="latest"
   if [ "$winver" == "2019" ]; then
-		# 2019 images without the containers feature pre-installed cannot be used due to
-		# https://issues.redhat.com/browse/OCPBUGS-13244
-    sku="2019-datacenter-with-containers-smalldisk"
-    release="17763.6293.240905"   
+    sku="2019-datacenter-smalldisk"
+    # TODO: remove when VM SSH issue is patched in Azure cloud
+    release="17763.6293.240905"
   fi
   local az=$(echo "$linuxWorkerSpec" | jq -r .providerSpec.value.zone | sed 's/null/""/g')
   local region=$(echo "$linuxWorkerSpec" | jq -r .providerSpec.value.location)


### PR DESCRIPTION
Switch to 2019-datacenter-smalldisk for Azure, as the "with-containers" images were retired.

follow-up to [10271cc81abce9d9f0adccbcb33b1157eab78dde](https://github.com/openshift/windows-machine-config-operator/pull/1626/commits/10271cc81abce9d9f0adccbcb33b1157eab78dde)