### PR TITLE
[release-4.20] set windows_exporter submodule to 4.20 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,6 +12,7 @@
 [submodule "windows_exporter"]
 	path = windows_exporter
 	url = https://github.com/openshift/prometheus-community-windows_exporter
+	branch = release-4.20
 [submodule "kubelet"]
 	path = kubelet
 	url = https://github.com/openshift/kubernetes


### PR DESCRIPTION
update to the `.gitmodules` file, specifying that the `windows_exporter` submodule should track the `release-4.20` branch.