### PR TITLE
Enable Go dependency updates in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
     "enabled": false
   },
   "enabledManagers": [
+    "gomod",
     "tekton",
     "dockerfile",
     "rpm",
@@ -130,6 +131,28 @@
     "branchTopic": "lock-file-maintenance",
     "schedule": [
       "at any time"
+    ]
+  },
+  "gomod": {
+    "enabled": true,
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/",
+    "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+    "postUpgradeTasks": {
+      "commands": ["go mod vendor", "go mod verify"],
+      "fileFilters": ["vendor/**"]
+    },
+    "packageRules": [
+      {
+        "groupName": "Go dependencies",
+        "matchManagers": ["gomod"],
+        "excludePackageNames": [
+          "k8s.io/kubernetes",
+          "github.com/openshift/api",
+          "github.com/openshift/client-go",
+          "github.com/openshift/library-go"
+        ]
+      }
     ]
   },
   "git-submodules": {
@@ -277,7 +300,10 @@
   },
   "forkProcessing": "enabled",
   "allowedCommands": [
-    "^rpm-lockfile-prototype rpms.in.yaml$"
+    "^rpm-lockfile-prototype rpms.in.yaml$",
+    "^go mod vendor$",
+    "^go mod tidy$",
+    "^go mod verify$"
   ],
   "dependencyDashboard": false
 }


### PR DESCRIPTION
Add gomod manager and vendor directory handling to automatically update Go dependencies and their vendored files via Renovate PRs.