### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for windows-machine-config-operator-release-4-18

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -127,7 +127,8 @@ LABEL stage=operator
 COPY LICENSE /licenses/LICENSE
 
 # This block contains standard Red Hat container labels
-LABEL name="openshift4-wincw/windows-machine-config-operator" \
+LABEL name="openshift4-wincw/windows-machine-config-rhel9-operator" \
+    cpe="cpe:/a:redhat:windows_machine_config:10.18::el9" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator" \
     io.k8s.description="Windows Machine Config Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
