### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for windows-machine-config-operator-bundle-release-4-17

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -19,6 +19,7 @@ LABEL version="v10.17.2"
 
 # Component to file bugs against
 LABEL com.redhat.component="Windows Containers"
+LABEL cpe="cpe:/a:redhat:windows_machine_config:10.17::el9"
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
