### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for windows-machine-config-operator-bundle-release-4-16

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -35,6 +35,7 @@ LABEL distribution-scope=public
 LABEL release="10.16.3"
 LABEL url="https://docs.openshift.com/container-platform/4.17/windows_containers/index.html"
 LABEL vendor="Red Hat, Inc."
+LABEL cpe="cpe:/a:redhat:windows_machine_config:10.16::el9"
 
 # Copy files to locations specified by labels.
 COPY --from=image-replacer /manifests /manifests/


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
