### PR TITLE
Address mirror test e2e flake

### DIFF
--- a/test/e2e/mirror_test.go
+++ b/test/e2e/mirror_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"testing"
@@ -80,7 +81,10 @@ func (tc *testContext) testMirrorSettingsApplied(t *testing.T) {
 			err = wait.PollUntilContextTimeout(context.TODO(), nodeRetryInterval, 5*time.Minute, true,
 				func(ctx context.Context) (done bool, err error) {
 					count, err := tc.countItemsInDir(windows.ContainerdConfigDir, addr)
-					require.NoErrorf(t, err, "error counting items in dir %s on node %s", windows.ContainerdConfigDir, addr)
+					if err != nil {
+						log.Printf("error counting items in dir %s on node %s: %s", windows.ContainerdConfigDir, addr, err)
+						return false, nil
+					}
 					return count == expectedNumConfigFiles, nil
 				})
 			assert.NoError(t, err, "error waiting for mirror settings to be applied")


### PR DESCRIPTION
Changes a retry loop within the mirror test, allowing the test to retry upon an error retrieving job logs.

The most probable reason for this flake to exist is that the Linux node the job pod is scheduled on is being drained to react to the IDMS changes, causing the pod to be deleted and the logs to be not retrievable.