### PR TITLE
[build] Add licenses dir to operator and bundle images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -188,6 +188,10 @@ COPY pkg/internal/hns.psm1 .
 
 WORKDIR /
 
+# create licenses directory
+# See https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images
+COPY LICENSE /licenses/
+
 ENV OPERATOR=/usr/local/bin/windows-machine-config-operator \
     USER_UID=1001 \
     USER_NAME=windows-machine-config-operator

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -36,6 +36,10 @@ LABEL release="10.21.0"
 LABEL url="https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/index"
 LABEL vendor="Red Hat, Inc."
 
+# create licenses directory
+# See https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images
+COPY LICENSE /licenses/
+
 # Copy files to locations specified by labels.
 COPY --from=image-replacer /manifests /manifests/
 COPY bundle/metadata /metadata/


### PR DESCRIPTION
This PR adds the licenses dir containing the LICENSE for compliance with OpenShift certification policy to the operator and bundle images.

https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images

fixes ecosystem-cert-preflight-checks
```
        "failed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
            }
        ],
```

https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/windows-machine-conf-tenant/applications/windows-machine-config-operator-release-4-21/taskruns/windows-machine-config-operator91918e2f74a7e9a81b69fa0c32b63bf0/logs