### PR TITLE
[build] fix name and set cpe label

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -125,7 +125,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL stage=operator
 
 # This block contains standard Red Hat container labels
-LABEL name="openshift4-wincw/windows-machine-config-operator" \
+LABEL name="openshift4-wincw/windows-machine-config-rhel9-operator" \
+    cpe="cpe:/a:redhat:windows_machine_config:10.21::el9" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator" \
     io.k8s.description="Windows Machine Config Operator" \

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -19,6 +19,7 @@ LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
 LABEL version="v10.21.0"
 # Component to file bugs against
 LABEL com.redhat.component="Windows Containers"
+LABEL cpe="cpe:/a:redhat:windows_machine_config:10.21::el9"
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149