### PR TITLE
Increase network test timeout

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -197,7 +197,7 @@ if [[ "$TEST" = "basic" ]]; then
   printf "\n####### Testing image mirroring #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/image_mirroring -v -timeout=10m -args $GO_TEST_ARGS
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
-  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=20m -args $GO_TEST_ARGS
+  go test ./test/e2e/... -run=TestWMCO/network -v -timeout=40m -args $GO_TEST_ARGS
   printf "\n####### Testing storage #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/storage -v -timeout=10m -args $GO_TEST_ARGS
   printf "\n####### Testing wicd rbac #######\n" >> "$ARTIFACT_DIR"/wmco.log


### PR DESCRIPTION
The network test being killed before all tests complete results in the Windows packet capture not running. This is necessary in order to debug networking issues. This commit increases the timeout to be greater than the sum of the timeouts of all subtests which are prone to failure. This timeout can be increased further in the future if necessary.