### PR TITLE
Fix renovate artifact update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,7 +121,6 @@
     "enabled": true,
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/",
-    "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
     "postUpgradeTasks": {
       "commands": ["go mod vendor", "go mod verify"],
       "fileFilters": ["vendor/**"]
@@ -140,7 +139,9 @@
           "k8s.io/kubernetes",
           "github.com/openshift/api",
           "github.com/openshift/client-go",
-          "github.com/openshift/library-go"
+          "github.com/openshift/library-go",
+          "github.com/golang-jwt/jwt/v4",
+          "github.com/golang-jwt/jwt/v5"
         ]
       }
     ]
@@ -290,10 +291,7 @@
   },
   "forkProcessing": "enabled",
   "allowedCommands": [
-    "^rpm-lockfile-prototype rpms.in.yaml$",
-    "^go mod vendor$",
-    "^go mod tidy$",
-    "^go mod verify$"
+    "^rpm-lockfile-prototype rpms.in.yaml$"
   ],
   "dependencyDashboard": false
 }


### PR DESCRIPTION
This PR removes the allowedCommands as
they have to be enabled by konflux team on
their end and also removes postupdateoptions
as the config exists by default
https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json#L603C6-L603C11
Additionally there is an issue with downgrading
go packages to a particular version so the jwt
package needs to be excluded from upgrades.
