### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,13 +318,13 @@ autoscaling support is not available for Windows workloads.
 
 ### Other limitations
 WMCO / Windows nodes does not work with the following products:
-* [odo](https://docs.redhat.com/en/documentation/openshift_container_platform/4.8/html/cli_tools/developer-cli-odo)
+* [odo](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/developer-cli-odo)
 * [OpenShift Builds](https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.4/html/about_builds/overview-of-builds)
 * [OpenShift Pipelines](https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/1.17/html-single/about_openshift_pipelines/index)
 * [OpenShift Service Mesh](https://docs.redhat.com/en/documentation/openshift_container_platform/4.1/html/service_mesh/service-mesh-architecture#understanding-service-mesh)
 * [Red Hat Insights cost management](https://docs.redhat.com/en/documentation/cost_management_service/1-latest)
 * [Red Hat OpenShift Local](https://developers.redhat.com/products/openshift-local/overview)
-* [OpenShift monitoring of user defined project](https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html/monitoring/enabling-monitoring-for-user-defined-projects)
+* [OpenShift monitoring of user defined project](https://docs.redhat.com/en/documentation/openshift_container_platform/4.13/html/monitoring/enabling-monitoring-for-user-defined-projects)
 * [HugePages](https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/)
 
 ### Trunk port

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -238,7 +238,7 @@ opm index rm --from-index $INDEX_IMAGE:$INDEX_TAG
 ```
 #### Create a CatalogSource using the index
 
-See the OpenShift docs for [adding a CatalogSource to a cluster](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/extensions/catalogs)
+See the OpenShift docs for [adding a CatalogSource to a cluster](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/extensions/catalogs)
 
 #### Create a subscription object 
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -32,7 +32,7 @@ not yet supported for Windows. Instead, a Windows node can be accessed using SSH
 [SSH bastion](https://github.com/eparis/ssh-bastion) needs to be setup for both methods. The following information is
 common across both methods:
 * The key used in the *cloud-private-key* [secret](../README.md#Usage) and the key used when creating the cluster should
-  be added to the [ssh-agent](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default).
+  be added to the [ssh-agent](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default).
   For [security reasons](https://manpages.debian.org/buster/openssh-client/ssh.1.en.html#A) we suggest removing the keys
   from the ssh-agent after use.
 * *\<username\>* is *Administrator* (AWS) or *capi* (Azure)

--- a/hack/community/csv/description.md
+++ b/hack/community/csv/description.md
@@ -9,8 +9,8 @@ version of OKD/OCP you are using. This CSV is meant for OKD/OCP COMMUNITY_VERSIO
 ## Documentation
 ### Introduction
 The Windows Machine Config Operator configures Windows instances into nodes, enabling Windows container workloads
-to be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
-or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/byoh-windows-instance).
+to be ran within OKD/OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
+or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/windows_container_support_for_openshift/byoh-windows-instance).
 The operator will do all the necessary steps to configure the instance so that it can join the cluster as a worker node.
 ### Pre-requisites
 - [Cluster and OS pre-requisites](https://github.com/openshift/windows-machine-config-operator/blob/COMMUNITY_VERSION/docs/wmco-prerequisites.md)


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18