### PR TITLE
Follow up to fix renovate artifact update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,10 +121,6 @@
     "enabled": true,
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/",
-    "postUpgradeTasks": {
-      "commands": ["go mod vendor", "go mod verify"],
-      "fileFilters": ["vendor/**"]
-    },
     "packageRules": [
       {
         "matchManagers": ["gomod"],


### PR DESCRIPTION
Remove postupgradecommands as they can only contain
allowedcommands added by the default mintmaker config.
According to renovate docs, go mod vendor is run if
vendored modules are detected
https://docs.renovatebot.com/golang/