### PR TITLE
Disable renovate gomod updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,7 +118,7 @@
     ]
   },
   "gomod": {
-    "enabled": true,
+    "enabled": false,
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/",
     "packageRules": [


### PR DESCRIPTION
This change disables automatic Go module dependency updates by renovate by setting "enabled": false in the gomod configuration section.