### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"golang.org/x/crypto/openpgp"
@@ -97,7 +96,7 @@ func decrypt(encrypted string, key []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	plainTextBytes, err := ioutil.ReadAll(msgBody)
+	plainTextBytes, err := io.ReadAll(msgBody)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse decrypted data into a readable value: %w", err)
 	}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
@@ -791,5 +790,5 @@ func retrieveWindowsNodeObjects(dir string) error {
 		return err
 	}
 	outputFile := filepath.Join(destDir, "nodes"+"."+outputFormat)
-	return ioutil.WriteFile(outputFile, out, os.ModePerm)
+	return os.WriteFile(outputFile, out, os.ModePerm)
 }

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -81,5 +80,5 @@ func retrieveLog(nodeName, srcPath, destDir string) error {
 		return fmt.Errorf("failed to create log directory: %w", err)
 	}
 	outputFile := filepath.Join(destDir, splitPath[0], filepath.Base(srcPath))
-	return ioutil.WriteFile(outputFile, out, os.ModePerm)
+	return os.WriteFile(outputFile, out, os.ModePerm)
 }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -467,7 +467,7 @@ func (tc *testContext) getLogs(podLabelSelector string, latestOnly bool) (string
 		if err != nil {
 			return "", fmt.Errorf("error getting pod logs: %w", err)
 		}
-		podLogs, err := ioutil.ReadAll(logStream)
+		podLogs, err := io.ReadAll(logStream)
 		if err != nil {
 			logStream.Close()
 			return "", fmt.Errorf("error reading pod logs: %w", err)
@@ -1155,7 +1155,7 @@ func (tc *testContext) gatherPodLogs(labelSelector string, latestOnly bool) (str
 	}
 	podLogFile := fmt.Sprintf("%s.log", labelSelector)
 	outputFile := filepath.Join(podDir, filepath.Base(podLogFile))
-	logsErr := ioutil.WriteFile(outputFile, []byte(logs), os.ModePerm)
+	logsErr := os.WriteFile(outputFile, []byte(logs), os.ModePerm)
 	if logsErr != nil {
 		return "", fmt.Errorf("unable to write %s pod logs to %s: %w", labelSelector, outputFile, logsErr)
 	}

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -8,8 +8,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -233,7 +233,7 @@ func (tc *testContext) createPrivateKeySecret(useKnownKey bool) error {
 	var keyData []byte
 	var err error
 	if useKnownKey {
-		keyData, err = ioutil.ReadFile(gc.privateKeyPath)
+		keyData, err = os.ReadFile(gc.privateKeyPath)
 		if err != nil {
 			return fmt.Errorf("unable to read private key data from file %s: %w", gc.privateKeyPath, err)
 		}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

**Migration from `ioutil` to `io`/`os`:**

* Replaced `ioutil.ReadAll` with `io.ReadAll` in `pkg/crypto/crypto.go` and `test/e2e/network_test.go` for reading data streams. [[1]](diffhunk://#diff-8a03969770d7b59692a408c8f8cfcff4c2b4f21281ac81f36d94d4b39306c434L100-R99) [[2]](diffhunk://#diff-84675b994e150b2fe4128b3f0a171854d1060ba909b9ff0aeb8833c8d9f4dae9L470-R470)
* Updated `ioutil.WriteFile` to `os.WriteFile` in `test/e2e/create_test.go`, `test/e2e/logs_test.go`, and `test/e2e/network_test.go` for writing files. [[1]](diffhunk://#diff-f08d14d1ac64442e0171050a9b9b70b50cfc7e1f0bc0eab1badc1e4a827252e3L794-R793) [[2]](diffhunk://#diff-2a3ec15f2cd9038bbb6ad1be37818927fb913fd7a7ebd7cbb29ab41aeac4c3f7L84-R83) [[3]](diffhunk://#diff-84675b994e150b2fe4128b3f0a171854d1060ba909b9ff0aeb8833c8d9f4dae9L1158-R1158)
* Changed `ioutil.ReadFile` to `os.ReadFile` in `test/e2e/secrets_test.go` for reading files.

**Import cleanup:**

* Removed all `ioutil` imports and added necessary `io` or `os` imports in affected files, including `pkg/crypto/crypto.go`, `test/e2e/create_test.go`, `test/e2e/logs_test.go`, `test/e2e/network_test.go`, and `test/e2e/secrets_test.go`. [[1]](diffhunk://#diff-8a03969770d7b59692a408c8f8cfcff4c2b4f21281ac81f36d94d4b39306c434L7) [[2]](diffhunk://#diff-f08d14d1ac64442e0171050a9b9b70b50cfc7e1f0bc0eab1badc1e4a827252e3L8) [[3]](diffhunk://#diff-2a3ec15f2cd9038bbb6ad1be37818927fb913fd7a7ebd7cbb29ab41aeac4c3f7L6) [[4]](diffhunk://#diff-84675b994e150b2fe4128b3f0a171854d1060ba909b9ff0aeb8833c8d9f4dae9L7-R7) [[5]](diffhunk://#diff-a2fb20e591ae92021a44611bb84969ddcb0ba67347ecbfc372cc43cc962ae1dbL11-R12)

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52