### PR TITLE
OCPBUGS-64719: Add APIServer to HybridOverlay config

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -336,6 +336,8 @@ spec:
           - infrastructures
           verbs:
           - get
+          - list
+          - watch
         - apiGroups:
           - config.openshift.io
           - operator.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -176,6 +176,8 @@ rules:
   - infrastructures
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   - operator.openshift.io

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -67,6 +67,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;create;delete
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;create;delete
+//+kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures,verbs=get;list;watch
 
 const (
 	// BYOHLabel is a label that should be applied to all Windows nodes not associated with a Machine.
@@ -714,6 +715,17 @@ func (r *ConfigMapReconciler) EnsureTrustedCAConfigMapExists(ctx context.Context
 // this gets called when the configmap reconciler is first created, to create the services manifest,
 // and also when the rendered-worker configmap is changed, to regenerate it.
 func generateServicesManifest(ctx context.Context, client client.Client, port string, platform oconfig.PlatformType) (*servicescm.Data, error) {
+	// Fetch the infrastructure object to get the API server endpoint
+	infra := &oconfig.Infrastructure{}
+	if err := client.Get(ctx, kubeTypes.NamespacedName{Name: "cluster"}, infra); err != nil {
+		return nil, fmt.Errorf("unable to get cluster infrastructure: %w", err)
+	}
+
+	apiServerEndpoint := infra.Status.APIServerInternalURL
+	if apiServerEndpoint == "" {
+		return nil, fmt.Errorf("APIServerInternalURL is not set in infrastructure")
+	}
+
 	ign, err := ignition.New(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ignition object: %w", err)
@@ -722,7 +734,8 @@ func generateServicesManifest(ctx context.Context, client client.Client, port st
 	if err != nil {
 		return nil, fmt.Errorf("Error getting kubelet args from ignition: %w", err)
 	}
-	svcData, err := services.GenerateManifest(argsFromIgnition, port, platform, ctrl.Log.V(1).Enabled())
+	svcData, err := services.GenerateManifest(argsFromIgnition, apiServerEndpoint, port, platform,
+		ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, fmt.Errorf("error generating expected Windows service state: %w", err)
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -333,6 +333,11 @@ func (nc *NodeConfig) createBootstrapFiles(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	filePathsToContents[windows.BootstrapCaCertPath], err = nc.generateBootstrapCaCert(ctx)
+	if err != nil {
+		return err
+	}
 	filePathsToContents[windows.BootstrapKubeconfigPath], err = nc.generateBootstrapKubeconfig(ctx)
 	if err != nil {
 		return err
@@ -390,6 +395,21 @@ func (nc *NodeConfig) createFilesFromIgnition(ctx context.Context) (map[string]s
 
 	filePathsToContents[windows.K8sDir+"\\"+KubeletClientCAFilename] = string(ign.GetKubeletCAData())
 	return filePathsToContents, nil
+}
+
+// generateBootstrapCaCert returns the contents of the Root CA certificate
+func (nc *NodeConfig) generateBootstrapCaCert(ctx context.Context) (string, error) {
+	bootstrapSecret, err := nc.k8sclientset.CoreV1().Secrets(mcoNamespace).Get(ctx, mcoBootstrapSecret,
+		meta.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	rootCA := bootstrapSecret.Data[core.ServiceAccountRootCAKey]
+	if rootCA == nil {
+		return "", fmt.Errorf("unable to find %s CA cert in secret %s", core.ServiceAccountRootCAKey,
+			bootstrapSecret.GetName())
+	}
+	return string(rootCA), nil
 }
 
 // generateBootstrapKubeconfig returns contents of a kubeconfig for kubelet to initially communicate with the API server

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -26,8 +26,8 @@ const (
 
 // GenerateManifest returns the expected state of the Windows service configmap. If debug is true, debug logging
 // will be enabled for services that support it.
-func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort string, platform config.PlatformType,
-	debug bool) (*servicescm.Data, error) {
+func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoint string, vxlanPort string,
+	platform config.PlatformType, debug bool) (*servicescm.Data, error) {
 	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
 		"cpu,cs,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
 		windows.WindowsExporterPath, windows.TLSConfPath)
@@ -46,7 +46,7 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, vxlanPort strin
 	},
 		containerdConfiguration(debug),
 		kubeletConfiguration,
-		hybridOverlayConfiguration(vxlanPort, debug),
+		hybridOverlayConfiguration(apiServerEndpoint, vxlanPort, debug),
 		kubeProxyConfiguration(debug),
 		csiProxyConfiguration(debug),
 	}
@@ -104,13 +104,16 @@ func azureCloudNodeManagerConfiguration() servicescm.Service {
 }
 
 // hybridOverlayConfiguration returns the Service definition for hybrid-overlay
-func hybridOverlayConfiguration(vxlanPort string, debug bool) servicescm.Service {
+func hybridOverlayConfiguration(apiServerEndpoint, vxlanPort string, debug bool) servicescm.Service {
 	hybridOverlayServiceCmd := fmt.Sprintf("%s --node NODE_NAME --bootstrap-kubeconfig=%s --cert-dir=%s --cert-duration=24h "+
 		"--windows-service --logfile "+"%s\\hybrid-overlay.log", windows.HybridOverlayPath, windows.KubeconfigPath, windows.CniConfDir,
 		windows.HybridOverlayLogDir)
 
+	// append k8s apiserver option pointing to the api server URL
+	hybridOverlayServiceCmd = fmt.Sprintf("%s --k8s-apiserver=%s", hybridOverlayServiceCmd, apiServerEndpoint)
+
 	// append cacert option pointing to the trusted CA bundle path
-	hybridOverlayServiceCmd = fmt.Sprintf("%s --k8s-cacert %s", hybridOverlayServiceCmd, windows.TrustedCABundlePath)
+	hybridOverlayServiceCmd = fmt.Sprintf("%s --k8s-cacert %s", hybridOverlayServiceCmd, windows.BootstrapCaCertPath)
 
 	if len(vxlanPort) > 0 {
 		hybridOverlayServiceCmd = fmt.Sprintf("%s --hybrid-overlay-vxlan-port %s", hybridOverlayServiceCmd, vxlanPort)

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -48,15 +48,17 @@ func TestGetHostnameCmd(t *testing.T) {
 func TestHybridOverlayConfiguration(t *testing.T) {
 	tests := []struct {
 		name                   string
+		apiServerEndpoint      string
 		vxlanPort              string
 		debug                  bool
 		expectedCmdContains    []string
 		expectedCmdNotContains []string
 	}{
 		{
-			name:      "Basic configuration with no optional flags",
-			vxlanPort: "",
-			debug:     false,
+			name:              "Basic configuration with no optional flags",
+			apiServerEndpoint: "https://api-server.endpoint.local:6443",
+			vxlanPort:         "",
+			debug:             false,
 			expectedCmdContains: []string{
 				windows.HybridOverlayPath,
 				"--node NODE_NAME",
@@ -66,7 +68,7 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 				"--windows-service",
 				"--logfile",
 				windows.HybridOverlayLogDir + "\\hybrid-overlay.log",
-				"--k8s-cacert " + windows.TrustedCABundlePath,
+				"--k8s-cacert " + windows.BootstrapCaCertPath,
 			},
 			expectedCmdNotContains: []string{
 				"--hybrid-overlay-vxlan-port",
@@ -74,9 +76,10 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:      "Configuration with debug logging enabled",
-			vxlanPort: "",
-			debug:     true,
+			name:              "Configuration with debug logging enabled",
+			apiServerEndpoint: "https://api-server.endpoint.local:6443",
+			vxlanPort:         "",
+			debug:             true,
 			expectedCmdContains: []string{
 				windows.HybridOverlayPath,
 				"--node NODE_NAME",
@@ -86,7 +89,7 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 				"--windows-service",
 				"--logfile",
 				windows.HybridOverlayLogDir + "\\hybrid-overlay.log",
-				"--k8s-cacert " + windows.TrustedCABundlePath,
+				"--k8s-cacert " + windows.BootstrapCaCertPath,
 				"--loglevel 5",
 			},
 			expectedCmdNotContains: []string{
@@ -94,9 +97,10 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:      "Configuration with all optional flags enabled",
-			vxlanPort: "4789",
-			debug:     true,
+			name:              "Configuration with all optional flags enabled",
+			apiServerEndpoint: "https://api-server.endpoint.local:6443",
+			vxlanPort:         "4789",
+			debug:             true,
 			expectedCmdContains: []string{
 				windows.HybridOverlayPath,
 				"--node NODE_NAME",
@@ -106,7 +110,7 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 				"--windows-service",
 				"--logfile",
 				windows.HybridOverlayLogDir + "\\hybrid-overlay.log",
-				"--k8s-cacert " + windows.TrustedCABundlePath,
+				"--k8s-cacert " + windows.BootstrapCaCertPath,
 				"--hybrid-overlay-vxlan-port 4789",
 				"--loglevel 5",
 			},
@@ -116,7 +120,7 @@ func TestHybridOverlayConfiguration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := hybridOverlayConfiguration(test.vxlanPort, test.debug)
+			result := hybridOverlayConfiguration(test.apiServerEndpoint, test.vxlanPort, test.debug)
 
 			assert.Equal(t, windows.HybridOverlayServiceName, result.Name,
 				"Service name should match expected value")

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -87,6 +87,8 @@ const (
 	podManifestDirectory = K8sDir + "\\etc\\kubernetes\\manifests"
 	// BootstrapKubeconfigPath is the location of the bootstrap kubeconfig
 	BootstrapKubeconfigPath = K8sDir + "\\bootstrap-kubeconfig"
+	// BootstrapCaCertPath is the location of the bootstrap CA certificate
+	BootstrapCaCertPath = K8sDir + "\\bootstrap-ca.crt"
 	// KubeletPath is the location of the kubelet exe
 	KubeletPath = K8sDir + "\\kubelet.exe"
 	// KubeLogRunnerPath is the location of the kube-log-runner exe


### PR DESCRIPTION
This commit ensures the hybridOverlay service receives explicitly the address of the API Server Endpoint along with the cacert to enable certificate rotation.

 The --bootstrap-kubeconfig flag should be enough but there is a bug
 in OVN-K HybridOverlay [1] where the apiserver and cacert are not extracted
 from the bootstrap information, hence introducing the --k8s-apiserver and
 --k8s-cacert flags as part of the command.

 [1] https://issues.redhat.com/browse/OCPBUGS-65856


hybrid-overlay.log before:
```
I1124 15:56:01.961205    1104 config.go:2474] Kubernetes config: {BootstrapKubeconfig:C:\k\kubeconfig CertDir:C:\k\cni\config CertDuration:10m0s Kubeconfig: CACert: CAData:[] APIServer:  Token: TokenFile: CompatServiceCIDR: RawServiceCIDRs:172.16.1.0/24 ServiceCIDRs:[172.16.1.0/24] OVNConfigNamespace:ovn-kubernetes OVNEmptyLbEvents:false PodIP: RawNoHostSubnetNodes: NoHostSubnetNodes:<nil> HostNetworkNamespace: DisableRequestedChassis:false PlatformType: HealthzBindAddress: CompatMetricsBindAddress: CompatOVNMetricsBindAddress: CompatMetricsEnablePprof:false DNSServiceNamespace:kube-system DNSServiceName:kube-dns}

```

hybrid-overlay.log with proposed implementation, see the `APIServer` and `CACert` fields populated
```
I1124 15:56:01.961205    1104 config.go:2474] Kubernetes config: {BootstrapKubeconfig:C:\k\kubeconfig CertDir:C:\k\cni\config CertDuration:10m0s Kubeconfig: CACert:C:\k\bootstrap-ca.crt CAData:[] APIServer:https://api-int.jvaldes.vmc.devcluster.openshift.com:6443 Token: TokenFile: CompatServiceCIDR: RawServiceCIDRs:172.16.1.0/24 ServiceCIDRs:[172.16.1.0/24] OVNConfigNamespace:ovn-kubernetes OVNEmptyLbEvents:false PodIP: RawNoHostSubnetNodes: NoHostSubnetNodes:<nil> HostNetworkNamespace: DisableRequestedChassis:false PlatformType: HealthzBindAddress: CompatMetricsBindAddress: CompatOVNMetricsBindAddress: CompatMetricsEnablePprof:false DNSServiceNamespace:kube-system DNSServiceName:kube-dns}

```


