### PR TITLE
[e2e] unblock CI by using AMIs up to 2025-09-11

### DIFF
--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -78,8 +78,12 @@ func getLatestWindowsAMI(region string, windowsServerVersion windows.ServerVersi
 	windowsAMIFilterValue := getWindowsAMIFilter(windowsServerVersion)
 	searchFilter := ec2.Filter{Name: aws.String("name"), Values: []*string{&windowsAMIFilterValue}}
 
+	winDateFilterName := "creation-date"
+	winDateFilterVal := "2025-09-11T*"
+	dateFilter := ec2.Filter{Name: &winDateFilterName, Values: []*string{&winDateFilterVal}}
+
 	describedImages, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{&searchFilter},
+		Filters: []*ec2.Filter{&searchFilter, &dateFilter},
 		Owners:  []*string{aws.String("amazon")},
 	})
 	if err != nil {


### PR DESCRIPTION
This commit addresses CI failures on AWS platform. The EC2Lunch agent versions 2.3.56 (November 4, 2025) and 2.3.5 (September 15, 2025) introduced conflicts between instance metadata and HNS networks.

See OCPBUGS-65903

As a workaround we will be pointing to the older AMI image until we figure out what is the real issue with the new AMI.

As an example, for us-east-1 targeting
name: Windows_Server-2022-English-Core-Base-2025.09.10 id: ami-03cb36b00c0be8d29
creation_date: 2025-09-11T05:25:34.000Z