### PR TITLE
Add support for OLMv1 when enabling debug logging in  e2e test

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -110,6 +110,9 @@ if  ! oc get deploy/windows-machine-config-operator -n $WMCO_DEPLOY_NAMESPACE > 
       retries+=1
   done
   wmco_deployed_by_script=true
+else
+  echo "operator installed in $WMCO_DEPLOY_NAMESPACE, skipping deployment step"
+  oc get pods -n $WMCO_DEPLOY_NAMESPACE
 fi
 
 enable_debug_logging


### PR DESCRIPTION
This PR adds detection logic to differentiate between OLMv0 and OLMv1 installations
when enabling debug logging for WMCO.

- OLMv0: Patch subscription and delete deployment to pick up changes
- OLMv1: Patch deployment directly and scale down/up to apply env vars

This ensures debug logging can be enabled correctly regardless of which
OLM version is managing the operator installation.