### PR TITLE
OCPBUGS-69902: Add panic recovery for SSH connection and signer validation

### DIFF
--- a/pkg/signer/signer_test.go
+++ b/pkg/signer/signer_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"fmt"
+	"io"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -90,4 +92,253 @@ func TestValidatePublicKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateKeyOperation tests the validateKeyOperation function with various key types
+func TestValidateKeyOperation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		signerFunc  func() (ssh.Signer, error)
+		expectError bool
+		description string
+	}{
+		{
+			name: "Valid Ed25519 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "Ed25519 key should pass validation",
+		},
+		{
+			name: "Valid RSA 2048 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				priv, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "RSA 2048-bit key should pass validation",
+		},
+		{
+			name: "Valid RSA 4096 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				priv, err := rsa.GenerateKey(rand.Reader, 4096)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "RSA 4096-bit key should pass validation",
+		},
+		{
+			name: "Valid ECDSA P-256 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "ECDSA P-256 key should pass validation",
+		},
+		{
+			name: "Valid ECDSA P-384 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "ECDSA P-384 key should pass validation",
+		},
+		{
+			name: "Valid ECDSA P-521 Key",
+			signerFunc: func() (ssh.Signer, error) {
+				priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return ssh.NewSignerFromKey(priv)
+			},
+			expectError: false,
+			description: "ECDSA P-521 key should pass validation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Log(tc.description)
+
+			signer, err := tc.signerFunc()
+			if err != nil {
+				t.Fatalf("Failed to create signer: %v", err)
+			}
+
+			err = validateKeyOperation(signer)
+			if tc.expectError && err == nil {
+				t.Errorf("validateKeyOperation() expected error but got none")
+			} else if !tc.expectError && err != nil {
+				t.Errorf("validateKeyOperation() unexpected error: %v", err)
+			}
+
+			if err == nil {
+				t.Logf("✓ Key type %s passed operation validation", signer.PublicKey().Type())
+			}
+		})
+	}
+}
+
+// TestValidateKeyOperationWithMockSigner tests validation behavior with a mock signer
+func TestValidateKeyOperationWithMockSigner(t *testing.T) {
+	// Create a valid Ed25519 key for the public key
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate Ed25519 key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("Failed to create SSH public key: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		signer      ssh.Signer
+		expectError bool
+		description string
+	}{
+		{
+			name: "Signer returns error on Sign",
+			signer: &mockSignerForTest{
+				publicKey: sshPub,
+				signFunc: func() (*ssh.Signature, error) {
+					return nil, fmt.Errorf("mock signing error")
+				},
+			},
+			expectError: true,
+			description: "Should fail when signer returns error",
+		},
+		{
+			name: "Signer returns nil signature",
+			signer: &mockSignerForTest{
+				publicKey: sshPub,
+				signFunc: func() (*ssh.Signature, error) {
+					return nil, nil
+				},
+			},
+			expectError: true,
+			description: "Should fail when signer returns nil signature",
+		},
+		{
+			name: "Signer returns signature with empty format",
+			signer: &mockSignerForTest{
+				publicKey: sshPub,
+				signFunc: func() (*ssh.Signature, error) {
+					return &ssh.Signature{
+						Format: "",
+						Blob:   []byte("test"),
+					}, nil
+				},
+			},
+			expectError: true,
+			description: "Should fail when signature format is empty",
+		},
+		{
+			name: "Signer returns signature with empty blob",
+			signer: &mockSignerForTest{
+				publicKey: sshPub,
+				signFunc: func() (*ssh.Signature, error) {
+					return &ssh.Signature{
+						Format: "ssh-ed25519",
+						Blob:   []byte{},
+					}, nil
+				},
+			},
+			expectError: true,
+			description: "Should fail when signature blob is empty",
+		},
+		{
+			name: "Ed25519 signer with wrong signature format",
+			signer: &mockSignerForTest{
+				publicKey: sshPub,
+				signFunc: func() (*ssh.Signature, error) {
+					return &ssh.Signature{
+						Format: "ssh-rsa",
+						Blob:   []byte("test-signature-blob"),
+					}, nil
+				},
+			},
+			expectError: true,
+			description: "Should fail when Ed25519 key produces wrong signature format",
+		},
+		{
+			name: "Public key that fails to marshal",
+			signer: &mockSignerForTest{
+				publicKey: &mockPublicKeyCannotMarshal{},
+				signFunc: func() (*ssh.Signature, error) {
+					return &ssh.Signature{
+						Format: "ssh-ed25519",
+						Blob:   []byte("test-signature-blob"),
+					}, nil
+				},
+			},
+			expectError: true,
+			description: "Should fail when public key cannot be marshaled (returns empty slice)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Log(tc.description)
+			err := validateKeyOperation(tc.signer)
+			if tc.expectError && err == nil {
+				t.Error("expected error but got none")
+			} else if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if err != nil {
+				t.Logf("success: %v", err)
+			}
+		})
+	}
+}
+
+// mockSignerForTest is a mock implementation of ssh.Signer for testing
+type mockSignerForTest struct {
+	publicKey ssh.PublicKey
+	signFunc  func() (*ssh.Signature, error)
+}
+
+func (m *mockSignerForTest) PublicKey() ssh.PublicKey {
+	return m.publicKey
+}
+
+func (m *mockSignerForTest) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return m.signFunc()
+}
+
+type mockPublicKeyCannotMarshal struct{}
+
+func (m *mockPublicKeyCannotMarshal) Type() string {
+	return "ssh-ed25519"
+}
+
+func (m *mockPublicKeyCannotMarshal) Marshal() []byte {
+	// Return empty slice to simulate marshal failure
+	return []byte{}
+}
+
+func (m *mockPublicKeyCannotMarshal) Verify(data []byte, sig *ssh.Signature) error {
+	return nil
 }

--- a/pkg/windows/connectivity_test.go
+++ b/pkg/windows/connectivity_test.go
@@ -1,0 +1,79 @@
+package windows
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// mockSigner is a mock implementation of ssh.Signer that can be configured with malformed keys
+type mockSigner struct {
+	publicKey  ssh.PublicKey
+	signMethod func(rand io.Reader, data []byte) (*ssh.Signature, error)
+}
+
+func (m *mockSigner) PublicKey() ssh.PublicKey {
+	return m.publicKey
+}
+
+func (m *mockSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return m.signMethod(rand, data)
+}
+
+// createMalformedEd25519Signer creates a signer with a malformed Ed25519 key
+// This simulates the condition that causes the panic: curve25519: internal error: scalarBaseMult was not 32 bytes
+func createMalformedEd25519Signer(t *testing.T) ssh.Signer {
+	// create a valid Ed25519 key first
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err, "Failed to generate Ed25519 key")
+
+	// create a malformed private key by truncating it
+	malformedPriv := priv[:30] // Truncate to 30 bytes instead of 64
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	require.NoError(t, err, "Failed to create SSH public key")
+
+	// create a mock signer that will cause issues during key exchange
+	mockSigner := &mockSigner{
+		publicKey: sshPub,
+		signMethod: func(rnd io.Reader, data []byte) (*ssh.Signature, error) {
+			// Use the malformed private key for signing
+			sig := ed25519.Sign(malformedPriv[:ed25519.PrivateKeySize], data)
+			return &ssh.Signature{
+				Format: "ssh-ed25519",
+				Blob:   sig,
+			}, nil
+		},
+	}
+
+	return mockSigner
+}
+
+func TestPanicRecoveryWithSimulatedPanic(t *testing.T) {
+	conn := &sshConnectivity{
+		username:  "username",
+		ipAddress: "127.0.0.1",
+		signer:    createMalformedEd25519Signer(t),
+	}
+
+	config := &ssh.ClientConfig{
+		User: conn.username,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(conn.signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Second * 2,
+	}
+
+	client, err := conn.dialWithPanicRecovery(config)
+
+	assert.Error(t, err, "Expected connection error")
+	assert.Nil(t, client, "Client should be nil")
+	t.Logf("No panic occurred, error handled gracefully: %v", err)
+}


### PR DESCRIPTION
This pull request introduces  validation and error handling for SSH private keys, aiming to prevent cryptographic panics (such as those caused by corrupted or malformed keys) and to improve the reliability of SSH connectivity. 

The changes include adding a key operation validation step during signer creation, implementing panic recovery during SSH dial operations, and providing comprehensive unit tests for these scenarios.
