### PR TITLE
WINC-1690: Collect debug info for wmco namespace in e2e tests

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -191,6 +191,10 @@ if [[ "$TEST" = "upgrade-test" ]]; then
   go test ./test/e2e/... -run=TestUpgrade -v -timeout=30m -args $GO_TEST_ARGS
 fi
 
+# Collect debug data for namespace, this will be helpful for debugging any issues in CI cluster
+mkdir -p ${ARTIFACT_DIR}/inspect
+oc --insecure-skip-tls-verify adm inspect namespace/"${WMCO_DEPLOY_NAMESPACE}" \
+  --dest-dir "${ARTIFACT_DIR}/inspect" > "${ARTIFACT_DIR}/inspect/inspect.log" 2>&1 || echo "Warning: failed to collect namespace inspect data"
 
 # Run the deletion tests while testing operator restart functionality. This will clean up VMs created
 # in the previous step


### PR DESCRIPTION
Ensure namespace resources are collected before test cleanup.

Currently, the standard `must-gather` collection runs after the E2E test script completes. When tests succeed, the script deletes Windows nodes and cleans up WMCO resources before exiting, leaving the namespace empty for subsequent data collection.

This commit adds `oc adm inspect` collection executing immediately after test completion but before the cleanup phase.
The inspection data is saved to `${ARTIFACT_DIR}/inspect`, ensuring debug artifacts are available in CI