### PR TITLE
WINC-1437: Remove deprecated `cs` collector from windows_exporter service

### DIFF
--- a/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -34,7 +34,7 @@ spec:
         windows_memory_available_bytes
       record: node_memory_MemAvailable_bytes
     - expr: |
-        windows_cs_physical_memory_bytes
+        windows_memory_physical_total_bytes
       record: node_memory_MemTotal_bytes
     - expr: |
         windows_cpu_info

--- a/config/windows-exporter/prometheusRule.yaml
+++ b/config/windows-exporter/prometheusRule.yaml
@@ -34,7 +34,7 @@ spec:
             windows_memory_available_bytes
           record: node_memory_MemAvailable_bytes
         - expr: |
-            windows_cs_physical_memory_bytes
+            windows_memory_physical_total_bytes
           record: node_memory_MemTotal_bytes
         - expr: |
             windows_cpu_info

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -39,7 +39,7 @@ const (
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoint string, vxlanPort string,
 	platform config.PlatformType, debug bool) (*servicescm.Data, error) {
 	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
-		"cpu,cs,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
+		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
 		windows.WindowsExporterPath, windows.TLSConfPath)
 	kubeletConfiguration, err := getKubeletServiceConfiguration(kubeletArgsFromIgnition, debug, platform)
 	if err != nil {


### PR DESCRIPTION
This PR removes the deprecated cs collector in the windows_exporter configuration, the recommended metric is exported by  memory collector as windows_memory_physical_total_bytes

see  https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.memory.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows memory metric collection source for enhanced compatibility
  * Removed deprecated collector from Windows exporter configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->