### PR TITLE
Add CodeRabbit inheritance for org-wide rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
+inheritance: true
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 # see https://docs.coderabbit.ai/reference/configuration for details


### PR DESCRIPTION
Adds `inheritance: true` to `.coderabbit.yaml` so this repo inherits the org-wide review rules from [openshift/coderabbit](https://github.com/openshift/coderabbit).

Without this setting, the repo's custom `.coderabbit.yaml` overrides the org-level configuration entirely, meaning org-wide review instructions and path-based rules are not applied.