### PR TITLE
[release-4.17] Update version to 10.17.2

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -209,4 +209,7 @@ RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
+# Used to tag the released image. Should be a semver.
+LABEL version="v10.17.2"
+
 USER ${USER_UID}


### PR DESCRIPTION
Adds the 10.17.2 tag to the Containerfile, which prevents it from getting tagged as 9.7