### PR TITLE
WINC-1869: Drop support for Windows Server 2019  in CI and machineset.sh script

### DIFF
--- a/hack/machineset.sh
+++ b/hack/machineset.sh
@@ -7,7 +7,7 @@
 #    machineset.sh
 # OPTIONS
 #    -b                      Set 'windowsmachineconfig.openshift.io/ignore' label for BYOH use case. Default: false
-#    -w                      Windows Server version (optional) 2019 or 2022. Default: 2022
+#    -w                      Windows Server version (optional) 2022 or 2025. Default: 2022
 #    $1/$2 (if -w is used)   Action                 (optional) apply/delete the MachineSet
 # PREREQUISITES
 #    oc                   to fetch cluster info and apply/delete MachineSets on the cluster(cluster should be logged in)
@@ -87,9 +87,6 @@ get_aws_ms() {
   # check Windows version and set AMI filter
   filter=""
   case "$winver" in
-    "2019")
-      filter="Windows_Server-2019-English-Core-Base-????.??.??"
-      ;;
     "2025")
       filter="Windows_Server-2025-English-Core-Base-????.??.??"
       ;;
@@ -167,11 +164,6 @@ get_azure_ms() {
   local sku=""
   local release="latest"
   case "$winver" in
-    "2019")
-      sku="2019-datacenter-smalldisk"
-      # TODO: remove when VM SSH issue is patched in Azure cloud
-      release="17763.6293.240905"
-      ;;
     "2025")
       sku="2025-datacenter-smalldisk"
       ;;
@@ -239,9 +231,6 @@ get_gcp_ms() {
   # check Windows version and set image family
   local image=""
   case "$winver" in
-    "2019")
-      image="projects/windows-cloud/global/images/family/windows-2019-core"
-      ;;
     "2025")
       image="projects/windows-cloud/global/images/family/windows-2025-core"
       ;;
@@ -306,9 +295,6 @@ get_vsphere_ms() {
 
   # set golden image template name based on Windows Server version
   case "$winver" in
-    "2019")
-      error-exit "No template available for Windows Server 2019 in DevQE vCenter"
-      ;;
     "2025")
       template="windows-golden-images/windows-server-2025-template-ipv6-disabled"
       ;;
@@ -430,10 +416,10 @@ winver="2022"
 byoh=false
 while getopts ":w:b" opt; do
   case ${opt} in
-    w ) # Windows Server version to use in the MachineSet. Defaults to 2022. Other option is 2019.
+    w ) # Windows Server version to use in the MachineSet. Defaults to 2022. Other option is 2025.
       winver="$OPTARG"
-      if [[ ! "$winver" =~ 2019|2022|2025$ ]]; then
-        echo "Invalid -w option $winver. Valid options are 2019, 2022 or 2025"
+      if [[ ! "$winver" =~ 2022|2025$ ]]; then
+        echo "Invalid -w option $winver. Valid options are 2022 or 2025"
         exit 1
       fi
       ;;
@@ -441,7 +427,7 @@ while getopts ":w:b" opt; do
       byoh=true
       ;;
     \? )
-      echo "Usage: $0 -w <2019/2022> -b apply/delete"
+      echo "Usage: $0 -w <2022/2025> -b apply/delete"
       exit 0
       ;;
   esac

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -167,7 +167,7 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&skipWorkloadDeletion, "skip-workload-deletion", false,
 		"skips deletion of workloads at the end of tests")
 	flag.Func("windows-server-version", "Windows Server version to test. "+
-		"Supported versions: 2019, 2022 or 2025 (default 2022)",
+		"Supported versions: 2022 or 2025 (default 2022)",
 		func(value string) error {
 			if len(value) == 0 {
 				windowsServerVersion = windows.Server2022

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -864,8 +864,6 @@ func (tc *testContext) getPodIP(selector metav1.LabelSelector) (string, error) {
 // getWindowsServerContainerImage gets the appropriate WindowsServer image based on the OS version
 func (tc *testContext) getWindowsServerContainerImage() string {
 	switch tc.windowsServerVersion {
-	case windows.Server2019:
-		return "mcr.microsoft.com/powershell:lts-nanoserver-1809"
 	case windows.Server2022:
 	case windows.Server2025:
 		// 2022-based container images are compatible with Windows Server 2025

--- a/test/e2e/providers/aws/aws.go
+++ b/test/e2e/providers/aws/aws.go
@@ -59,8 +59,6 @@ func newEC2Client(region string) (*ec2.EC2, error) {
 // pattern Windows_Server-$version-variant-YYYY.MM.DD and the filter will grab all AMIs that match the filter.
 func getWindowsAMIFilter(windowsServerVersion windows.ServerVersion) string {
 	switch windowsServerVersion {
-	case windows.Server2019:
-		return "Windows_Server-2019-English-Core-Base-????.??.??"
 	case windows.Server2025:
 		return "Windows_Server-2025-English-Core-Base-????.??.??"
 	case windows.Server2022:

--- a/test/e2e/providers/azure/azure.go
+++ b/test/e2e/providers/azure/azure.go
@@ -47,10 +47,6 @@ func New(clientset *clusterinfo.OpenShift, infraStatus *config.InfrastructureSta
 // newAzureMachineProviderSpec returns an AzureMachineProviderSpec generated from the inputs, or an error
 func (p *Provider) newAzureMachineProviderSpec(location, zone, vmSize, publicLoadBalancer string, windowsServerVersion windows.ServerVersion) (*mapi.AzureMachineProviderSpec, error) {
 	imageVersion := defaultImageVersion
-	if windowsServerVersion == windows.Server2019 {
-		// TODO: remove when VM SSH issue is patched in Azure cloud
-		imageVersion = "17763.6293.240905"
-	}
 	return &mapi.AzureMachineProviderSpec{
 		TypeMeta: meta.TypeMeta{
 			APIVersion: "azureproviderconfig.openshift.io/v1beta1",
@@ -345,8 +341,6 @@ func (p *Provider) ensureWindowsCSIDaemonSet(client client.Interface) error {
 // getImageSKU returns the SKU based on the Windows Server version
 func getImageSKU(windowsServerVersion windows.ServerVersion) string {
 	switch windowsServerVersion {
-	case windows.Server2019:
-		return "2019-datacenter-smalldisk"
 	case windows.Server2025:
 		return "2025-datacenter-smalldisk"
 	case windows.Server2022:

--- a/test/e2e/providers/gcp/gcp.go
+++ b/test/e2e/providers/gcp/gcp.go
@@ -106,8 +106,6 @@ func (p *Provider) CreatePVC(_ client.Interface, _ string, _ *core.PersistentVol
 // getImage returns the image based on the Windows Server version
 func getImage(windowsServerVersion windows.ServerVersion) string {
 	switch windowsServerVersion {
-	case windows.Server2019:
-		return "projects/windows-cloud/global/images/family/windows-2019-core"
 	case windows.Server2025:
 		return "projects/windows-cloud/global/images/family/windows-2025-core"
 	case windows.Server2022:

--- a/test/e2e/providers/nutanix/nutanix.go
+++ b/test/e2e/providers/nutanix/nutanix.go
@@ -32,9 +32,6 @@ func New(oc *clusterinfo.OpenShift, infraStatus *config.InfrastructureStatus) (*
 
 // GenerateMachineSet generates a Windows MachineSet which is Nutanix provider specific
 func (a *Provider) GenerateMachineSet(withIgnoreLabel bool, replicas int32, windowsServerVersion windows.ServerVersion) (*machinev1beta1.MachineSet, error) {
-	if windowsServerVersion == windows.Server2019 {
-		return nil, fmt.Errorf("Windows Server %s is not available in Nutanix CI", windowsServerVersion)
-	}
 
 	listOptions := meta.ListOptions{LabelSelector: "machine.openshift.io/cluster-api-machine-role=worker"}
 	machines, err := a.oc.Machine.Machines(clusterinfo.MachineAPINamespace).List(context.TODO(), listOptions)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/secrets"
 	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
-	e2e_windows "github.com/openshift/windows-machine-config-operator/test/e2e/windows"
 )
 
 const (
@@ -354,10 +353,7 @@ func (tc *testContext) ensureTestRunnerRBAC() error {
 func (tc *testContext) runPowerShellSSHJob(name, command, ip string) (string, error) {
 	// Modify command to work when default shell is the newer Powershell version present on Windows Server 2022 and
 	// later
-	powershellDefaultCommand := command
-	if tc.windowsServerVersion != e2e_windows.Server2019 {
-		powershellDefaultCommand = strings.ReplaceAll(command, "\\\"", "\"")
-	}
+	powershellDefaultCommand := strings.ReplaceAll(command, "\\\"", "\"")
 
 	keyMountDir := "/private-key"
 	sshOptions := "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/test/e2e/windows/version.go
+++ b/test/e2e/windows/version.go
@@ -3,8 +3,6 @@ package windows
 type ServerVersion string
 
 const (
-	// Server2019 represent Windows Server 2019
-	Server2019 ServerVersion = "2019"
 	// Server2022 represent Windows Server 2022
 	Server2022 ServerVersion = "2022"
 	// Server2025 represent Windows Server 2025
@@ -13,11 +11,10 @@ const (
 
 // SupportedVersions are the Windows Server versions supported by the e2e test.
 // "" implies the default which is Server2022
-var SupportedVersions = []ServerVersion{Server2019, Server2022, Server2025, ""}
+var SupportedVersions = []ServerVersion{Server2022, Server2025, ""}
 
 // BuildNumber returns the build for a given server version as defined by Microsoft
 var BuildNumber = map[ServerVersion]string{
-	Server2019: "10.0.17763",
 	Server2022: "10.0.20348",
 	Server2025: "10.0.26100",
 }


### PR DESCRIPTION
This PR removes Server2019 from supported versions, provider image
selectors,container image selection, and PowerShell compatibility workarounds.

All available Azure Marketplace images for the 2019-datacenter-smalldisk
SKU have the OpenSSH regression introduced in KB5044277 (Oct 2024, OS
Build 17763.6414). The previously pinned version 17763.6293.240905 has
been deprecated and removed. Windows Server 2019 mainstream support
ended January 2024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Windows Server 2019 support from machine configuration and end-to-end testing. Supported Windows Server versions are now limited to 2022 and 2025, with 2022 as the default. Windows Server 2019-specific image filters and configuration logic have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->