### PR TITLE
Substitutes empty string for external cluster

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4.19-pull-request.yaml
@@ -369,6 +369,8 @@ spec:
         values:
         - "false"
       params:
+      - name: KFP_GIT_URL
+        value: ""
       - name: image-digest
         value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: image-url


### PR DESCRIPTION
This fixes the sast-snyk-check-oci-ta konflux failures