### PR TITLE
[release-4.17] Update version to 10.17.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 10.17.2
+WMCO_VERSION ?= 10.17.3
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.16.0 <10.17.2'
+    olm.skipRange: '>=10.16.0 <10.17.3'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -27,7 +27,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v10.17.2
+  name: windows-machine-config-operator.v10.17.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -521,4 +521,4 @@ spec:
   minKubeVersion: 1.30.0
   provider:
     name: Red Hat
-  version: 10.17.2
+  version: 10.17.3

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v10.17.2
+  - currentCSV: windows-machine-config-operator.v10.17.3
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.16.0 <10.17.2'
+    olm.skipRange: '>=10.16.0 <10.17.3'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows


### PR DESCRIPTION
  This commit was generated by hack/pre-release.sh
  
  This technically doesn't need to be merged because we'll never do a 10.17.3 release, but I think it might be a good idea to merge this for good luck 