### PR TITLE
[release-4.22] WINC-1873: set target_branch in tekton files  with corresponding release

### DIFF
--- a/.tekton/windows-machine-config-operator-bundle-release-4-22-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-22-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
-      && target_branch == "master"
+      && target_branch == "release-4.22"
       && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/windows-machine-config-operator-bundle-release-4-22-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-22-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "master"
+      && target_branch == "release-4.22"
       && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp:
   labels:

--- a/.tekton/windows-machine-config-operator-release-4-22-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-22-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
-      && target_branch == "master"
+      && target_branch == "release-4.22"
       && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:

--- a/.tekton/windows-machine-config-operator-release-4-22-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-22-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "master"
+      && target_branch == "release-4.22"
       && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:


### PR DESCRIPTION
This pull request updates Tekton pipeline configuration files to target the new `release-4.22` branch instead of `master` for both push and pull request events. This ensures that pipeline runs are triggered appropriately for changes intended for the `release-4.22` branch.
