### PR TITLE
OCPBUGS-86246: Clean up old ovnkube-client certificates

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -310,6 +312,11 @@ func (sc *ServiceController) Reconcile(_ context.Context, req ctrl.Request) (res
 		return ctrl.Result{}, err
 	}
 
+	// Clean up old certificate files to prevent disk space issues
+	if err = sc.cleanupOldCertificates(); err != nil {
+		klog.Warningf("failed to cleanup old certificates: %v", err)
+	}
+
 	if err = sc.waitUntilNodeReady(); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error waiting for node to become ready")
 	}
@@ -402,6 +409,53 @@ func (sc *ServiceController) reconcileServices(services []servicescm.Service) er
 			return err
 		}
 	}
+	return nil
+}
+
+// cleanupOldCertificates removes old ovnkube-client certificate files from the CNI config directory,
+// keeping only the most recent ones to prevent disk space exhaustion.
+func (sc *ServiceController) cleanupOldCertificates() error {
+	return cleanupOldCertificatesInDir(windows.CniConfDir)
+}
+
+// cleanupOldCertificatesInDir removes old ovnkube-client certificate files from the specified directory,
+// keeping only the most recent ones to prevent disk space exhaustion.
+// Certificates are created by OVN Kubernetes with timestamp-based naming:
+// https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/go-controller/pkg/util/kube.go#L137
+// This function is separated for testability.
+func cleanupOldCertificatesInDir(certDir string) error {
+	certPattern := filepath.Join(certDir, "ovnkube-client-*.pem")
+
+	// Find all matching certificate files
+	matches, err := filepath.Glob(certPattern)
+	if err != nil {
+		return fmt.Errorf("failed to list certificate files in %s: %w", certDir, err)
+	}
+
+	// If we have 2 or fewer files, no cleanup needed
+	if len(matches) <= 2 {
+		return nil
+	}
+
+	// Sort files by timestamp in filename (newest first)
+	// Filename format: ovnkube-client-YYYY-MM-DD-HH-MM-SS.pem
+	// Lexicographical sorting works because of the ISO-8601-like timestamp format
+	sort.Slice(matches, func(i, j int) bool {
+		return filepath.Base(matches[i]) > filepath.Base(matches[j])
+	})
+
+	// Keep the 2 most recent certificates, delete the rest
+	filesToDelete := matches[2:]
+	klog.V(1).Infof("cleaning up %d old certificate files from %s", len(filesToDelete), certDir)
+
+	for _, file := range filesToDelete {
+		if err := os.Remove(file); err != nil {
+			klog.Warningf("failed to remove old certificate file %s: %v", file, err)
+			continue
+		}
+		klog.V(1).Infof("removed old certificate file: %s", file)
+	}
+
 	return nil
 }
 

--- a/pkg/daemon/controller/controller_test.go
+++ b/pkg/daemon/controller/controller_test.go
@@ -6,8 +6,12 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -991,4 +995,112 @@ func TestSlicesEquivalent(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCleanupOldCertificates(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Helper function to create test certificate files with specific modification times
+	createCertFile := func(t *testing.T, dir, name string, modTime time.Time) string {
+		filePath := filepath.Join(dir, name)
+		file, err := os.Create(filePath)
+		require.NoError(t, err)
+		file.Close()
+		err = os.Chtimes(filePath, modTime, modTime)
+		require.NoError(t, err)
+		return filePath
+	}
+
+	testCases := []struct {
+		name          string
+		numFiles      int
+		expectedKept  int
+		expectedError bool
+	}{
+		{
+			name:          "No files to clean up",
+			numFiles:      0,
+			expectedKept:  0,
+			expectedError: false,
+		},
+		{
+			name:          "2 files, no cleanup needed",
+			numFiles:      2,
+			expectedKept:  2,
+			expectedError: false,
+		},
+		{
+			name:          "3 files, cleanup 1",
+			numFiles:      3,
+			expectedKept:  2,
+			expectedError: false,
+		},
+		{
+			name:          "10 files, cleanup 8",
+			numFiles:      10,
+			expectedKept:  2,
+			expectedError: false,
+		},
+		{
+			name:          "150 files (like production), cleanup 148",
+			numFiles:      150,
+			expectedKept:  2,
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fresh subdirectory for this test case
+			testDir := filepath.Join(tempDir, tc.name)
+			err := os.MkdirAll(testDir, 0755)
+			require.NoError(t, err)
+
+			// Create certificate files with different timestamps
+			baseTime := time.Date(2026, time.January, 1, 22, 0, 0, 0, time.UTC)
+			for i := 0; i < tc.numFiles; i++ {
+				ts := baseTime.AddDate(0, 0, i).Format("2006-01-02-15-04-05")
+				fileName := fmt.Sprintf("ovnkube-client-%s.pem", ts)
+				// Older files have earlier timestamps
+				modTime := baseTime.Add(-time.Duration(tc.numFiles-i) * time.Hour)
+				createCertFile(t, testDir, fileName, modTime)
+			}
+
+			// Run the cleanup directly on the test directory
+			err = cleanupOldCertificatesInDir(testDir)
+			if tc.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify the correct number of files remain
+			matches, err := filepath.Glob(filepath.Join(testDir, "ovnkube-client-*.pem"))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKept, len(matches), "unexpected number of files remaining")
+
+			if tc.expectedKept > 0 {
+				// Verify that the most recent files were kept by checking filenames
+				// Sort matches to get them in descending order (newest first)
+				sort.Slice(matches, func(i, j int) bool {
+					return filepath.Base(matches[i]) > filepath.Base(matches[j])
+				})
+
+				// Verify we kept the files with the newest timestamps in their names
+				// Since we create files with dates incrementing from baseTime, the kept files
+				// should be from the end of the range (most recent dates)
+				for i, match := range matches {
+					baseName := filepath.Base(match)
+					// First kept file should be the most recent (highest date)
+					if i == 0 {
+						expectedPattern := fmt.Sprintf("ovnkube-client-%s",
+							baseTime.AddDate(0, 0, tc.numFiles-1).Format("2006-01-02-15-04-05"))
+						assert.Contains(t, baseName, expectedPattern,
+							"first kept file should be the most recent")
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Trying to address OCPBUGS-86246

WICD now periodically removes old ovnkube-client certificate files from the CNI config directory to prevent disk space exhaustion. The cleanup runs during the normal reconciliation loop (every 2 minutes) and keeps only the 3 most recent certificates, deleting older ones.

Without this cleanup, certificate files accumulate indefinitely as the hybrid-overlay service generates a new timestamped certificate daily. This can lead to hundreds of certificate files consuming disk space.

The cleanup logic is implemented in a separate function for testability, with comprehensive unit tests covering various scenarios including the production case of 150+ accumulated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of stale certificate files during Windows service reconciliation; keeps the 2 most recent files and removes older ones. Cleanup errors are logged as warnings and do not stop reconciliation.

* **Tests**
  * Added unit tests covering the certificate cleanup behavior and retention logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->