### PR TITLE
[release-4.22] WINC-1923: Update version to 10.22.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -217,7 +217,7 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v10.22.0"
-LABEL release="v10.22.0"
+LABEL version="v10.22.1"
+LABEL release="v10.22.1"
 
 USER ${USER_UID}

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -16,7 +16,7 @@ LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
     io.openshift.tags=""
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v10.22.0"
+LABEL version="v10.22.1"
 # Component to file bugs against
 LABEL com.redhat.component="Windows Containers"
 LABEL cpe="cpe:/a:redhat:windows_machine_config:10.22::el9"
@@ -33,8 +33,8 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 LABEL distribution-scope=public
-LABEL release="10.22.0"
-LABEL url="https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/index"
+LABEL release="10.22.1"
+LABEL url="https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/windows_container_support_for_openshift/index"
 LABEL vendor="Red Hat, Inc."
 
 # create licenses directory

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 10.22.0
+WMCO_VERSION ?= 10.22.1
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.21.0 <10.22.0'
+    olm.skipRange: '>=10.21.0 <10.22.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -27,7 +27,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v10.22.0
+  name: windows-machine-config-operator.v10.22.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -540,4 +540,4 @@ spec:
   minKubeVersion: 1.35.0
   provider:
     name: Red Hat
-  version: 10.22.0
+  version: 10.22.1

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v10.22.0
+  - currentCSV: windows-machine-config-operator.v10.22.1
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.21.0 <10.22.0'
+    olm.skipRange: '>=10.21.0 <10.22.1'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows


### PR DESCRIPTION
  This commit was generated by hack/pre-release.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Windows Machine Config Operator version updated from v10.22.0 to v10.22.1 across all manifests and package configurations
  * Build version variable and container image metadata updated accordingly
  * Documentation references updated for OpenShift 4.22 compatibility
  * Operator upgrade skip range adjusted for proper patch release migration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->