### PR TITLE
OCPBUGS-86704: Fix MaxParallelUpgrades bypass in userData deletion path

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/ssh"
@@ -355,13 +356,34 @@ func (r *SecretReconciler) updateUserData(ctx context.Context, keySigner ssh.Sig
 				nodeconfig.PubKeyHashAnnotation: expectedPubKeyAnno,
 			}
 		} else {
-			// For Nodes associated with Machines, clear the public key annotation, as the clearing of the
-			// annotation is used solely to kick off the deletion and recreation of Machines, causing them to be
+			// For Nodes associated with Machines, check cluster-wide upgrade limit before clearing annotation
+
+			// Check if we can mark this node as upgrading
+			if err := markNodeAsUpgrading(ctx, r.client, &node); err != nil {
+				var upgradeErr *UpgradeLimitExceededError
+				if errors.As(err, &upgradeErr) {
+					// Upgrade limit reached - defer this node
+					r.log.Info("deferring userData update due to upgrade limit",
+						"node", node.GetName(), "reason", upgradeErr.Error())
+					continue
+				}
+				return err
+			}
+
+			// Safe to clear annotation now (cluster-wide lock acquired)
+			// The clearing of the annotation is used solely to kick off the deletion and recreation
+			// of Machines, causing them to be
 			// provisioned with the new userdata
 			annotationsToApply = map[string]string{nodeconfig.PubKeyHashAnnotation: ""}
 		}
 
 		if err := metadata.ApplyLabelsAndAnnotations(ctx, r.client, node, nil, annotationsToApply); err != nil {
+			// Best-effort rollback of upgrading label if annotation patch fails for Machine nodes
+			if annotationsToApply[nodeconfig.PubKeyHashAnnotation] == "" {
+				if rollbackErr := metadata.RemoveUpgradingLabel(ctx, r.client, &node); rollbackErr != nil {
+					r.log.Error(rollbackErr, "failed to rollback upgrading label", "node", node.GetName())
+				}
+			}
 			return fmt.Errorf("error updating annotations on node %s: %w", node.GetName(), err)
 		}
 		r.log.V(1).Info("patched node object", "node", node.GetName(), "patch", annotationsToApply)

--- a/controllers/windowsmachine_controller.go
+++ b/controllers/windowsmachine_controller.go
@@ -280,12 +280,32 @@ func (r *WindowsMachineReconciler) Reconcile(ctx context.Context,
 			// If the private key used to configure the machine is out of date, the machine should be deleted
 			if node.Annotations[nodeconfig.PubKeyHashAnnotation] !=
 				nodeconfig.CreatePubKeyHashAnnotation(r.signer.PublicKey()) {
-				log.Info("deleting machine")
+				log.Info("deleting machine due to public key mismatch", "machine", machine.Name)
+
+				// Check cluster-wide upgrade limit before deletion (defense in depth)
+				if err := markNodeAsUpgrading(ctx, r.client, node); err != nil {
+					var upgradeErr *UpgradeLimitExceededError
+					if !errors.As(err, &upgradeErr) {
+						return ctrl.Result{}, err
+					}
+					// Upgrade limit reached - log and requeue
+					r.log.Info(upgradeErr.Error())
+					r.recorder.Eventf(machine, core.EventTypeWarning, "MachineDeletionDeferred",
+						"Machine %v deletion deferred: %v", machine.Name, upgradeErr.Error())
+					return ctrl.Result{Requeue: true}, nil
+				}
+
 				deletionAllowed, err := r.isAllowedDeletion(ctx, machine)
 				if err != nil {
+					if rbErr := metadata.RemoveUpgradingLabel(ctx, r.client, node); rbErr != nil {
+						r.log.Error(rbErr, "failed to rollback upgrading label", "node", node.GetName())
+					}
 					return ctrl.Result{}, fmt.Errorf("unable to determine if Machine can be deleted: %w", err)
 				}
 				if !deletionAllowed {
+					if rbErr := metadata.RemoveUpgradingLabel(ctx, r.client, node); rbErr != nil {
+						r.log.Error(rbErr, "failed to rollback upgrading label", "node", node.GetName())
+					}
 					log.Info("machine deletion restricted", "maxUnhealthyCount", maxUnhealthyCount)
 					r.recorder.Eventf(machine, core.EventTypeWarning, "MachineDeletionRestricted",
 						"Machine %v deletion restricted as the maximum unhealthy machines can`t exceed %v count",

--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -161,6 +161,11 @@ if [[ "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
 fi
 
 if [[ "$TEST" = "basic" ]]; then
+  # Deploy parallel upgrade checker before tests that trigger the MaxParallelUpgrades path
+  createParallelUpgradeCheckerResources
+  trap deleteParallelUpgradeCheckerResources EXIT
+  printf "\n####### Testing userdata tamper #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  go test ./test/e2e/... -run=TestWMCO/userdata_tamper -v -timeout=30m -args $GO_TEST_ARGS
   printf "\n####### Testing image mirroring #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/image_mirroring -v -timeout=10m -args $GO_TEST_ARGS
   printf "\n####### Testing network #######\n" >> "$ARTIFACT_DIR"/wmco.log
@@ -175,6 +180,11 @@ if [[ "$TEST" = "basic" ]]; then
   go test ./test/e2e/... -run=TestWMCO/cluster-wide_proxy -v -timeout=20m -args $GO_TEST_ARGS
   printf "\n####### Testing reconfiguration #######\n" >> "$ARTIFACT_DIR"/wmco.log
   go test ./test/e2e/... -run=TestWMCO/reconfigure -v -timeout=40m -args $GO_TEST_ARGS
+  # Verify parallel upgrade checker results and clean up
+  printf "\n####### Testing parallel upgrades checker #######\n" >> "$ARTIFACT_DIR"/wmco.log
+  go test ./test/e2e/... -run=TestWMCO/parallel_upgrades_checker -v -timeout=10m -args $GO_TEST_ARGS
+  deleteParallelUpgradeCheckerResources
+  trap - EXIT
 fi
 
 if [[ "$TEST" = "upgrade-setup" ]]; then

--- a/test/e2e/secrets_test.go
+++ b/test/e2e/secrets_test.go
@@ -74,6 +74,11 @@ func (tc *testContext) testUserData(t *testing.T) {
 	require.NoError(t, err, "could not retrieve userdata contents")
 	assert.Contains(t, userData, string(ssh.MarshalAuthorizedKey(pubKey)), "public key not found within Windows userdata")
 	t.Run("Delete the userdata secret", tc.testUserDataRegeneration)
+}
+
+func userDataTamperTestSuite(t *testing.T) {
+	tc, err := NewTestContext()
+	require.NoError(t, err)
 	t.Run("Update the userdata secret with invalid data", tc.testUserDataTamper)
 }
 

--- a/test/e2e/wmco_test.go
+++ b/test/e2e/wmco_test.go
@@ -53,6 +53,7 @@ func TestWMCO(t *testing.T) {
 	// individual test suites after the operator is running
 	t.Run("operator deployed without private key secret", testOperatorDeployed)
 	t.Run("create", creationTestSuite)
+	t.Run("userdata tamper", userDataTamperTestSuite)
 	t.Run("image mirroring", testImageMirroring)
 	t.Run("network", testNetwork)
 	t.Run("storage", testStorage)
@@ -63,6 +64,7 @@ func TestWMCO(t *testing.T) {
 	// added/moved in between these two suites may fail.
 	// This limitation will be removed with https://issues.redhat.com/browse/WINC-655
 	t.Run("reconfigure", reconfigurationTestSuite)
+	t.Run("parallel upgrades checker", tc.testParallelUpgradesChecker)
 	t.Run("destroy", deletionTestSuite)
 }
 


### PR DESCRIPTION
Trying to address JIRA OCPBUGS-86704

The MaxParallelUpgrades=1 protection is bypassed during userData template changes, causing simultaneous machine deletions across MachineSets during normal WMCO upgrades.

This adds cluster-wide upgrade limit checking at two layers:
1. Before clearing pub-key-hash annotations (source prevention)
2. Before machine deletion (deletion path protection)

Root cause: When userData template changes (e.g., AWS routes, SSH retry logic, firewall rules), SecretReconciler cleared pub-key-hash annotations on ALL Machine nodes simultaneously. WindowsMachine Reconciler then used per-MachineSet isAllowedDeletion() check instead of cluster-wide markNodeAsUpgrading() lock, allowing N MachineSets = N simultaneous deletions.

Defense in depth approach:
- SecretReconciler: Check upgrade limit before clearing each node's annotation (prevents simultaneous clearing)
- WindowsMachineReconciler: Check upgrade limit before deletion (catches any edge cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster-wide upgrade limit enforcement to prevent excessive concurrent upgrade operations. When limits are reached, the system defers node updates and machine deletions, automatically retrying on the next reconciliation cycle.
  * Enhanced logging and event recording for upgrade-related operations to improve operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->