### PR TITLE
WINC-1949: Bump base image and dependencies to use go1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-5.0
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as build
 
 LABEL stage=build
 

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as image-replacer
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as image-replacer
 COPY bundle/manifests /manifests
 RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:73d6da5946a7179272464324685a746d4717281490c8b60675b4396e155f9f4a|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 RUN sed -i "s|REPLACE_DATE|$(date "+%Y-%m-%dT%H:%M:%SZ")|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
 LABEL stage=build
 
 # Silence go compliance shim output
@@ -194,7 +194,7 @@ mkdir /payload/generated && \
 chmod 0777 /payload/generated
 
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-5.0
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-5.0
 LABEL stage=operator
 
 WORKDIR /

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/hack/lint-gofmt.sh
+++ b/hack/lint-gofmt.sh
@@ -6,7 +6,7 @@ WMCO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.25') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.26') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from version 1.25.7 to 1.26.3 across all build and CI configurations, including CI operator settings, container builder images, build Dockerfiles, and development tools. All build stages, linting scripts, and deployment environments now consistently use Go 1.26 compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->