### PR TITLE
WINC-1950: Declare NetworkPolicy RBAC permissions

### DIFF
--- a/bundle/manifests/prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -14,7 +14,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "discovery.k8s.io"
+  - discovery.k8s.io
   resources:
   - endpointslices
   verbs:

--- a/bundle/manifests/system-wicd-nodes_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/system-wicd-nodes_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -14,7 +14,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -387,6 +387,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
           - operators.coreos.com
           resources:
           - operatorconditions

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -265,7 +265,6 @@ spec:
           resources:
           - certificatesigningrequests
           verbs:
-          - create
           - get
           - list
           - watch

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,9 @@ import (
 // ServiceAccount permissions used to watch operator on secrets.
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
 
+// NetworkPolicy permissions used by WMCO operands.
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update;patch
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -227,6 +227,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
   - operators.coreos.com
   resources:
   - operatorconditions


### PR DESCRIPTION
This pull request updates RBAC permissions enabling the operator and its operands to create, update, patch, and delete `networkpolicies`,  and makes some minor adjustments to other RBAC rules. 