### PR TITLE
WINC-1954: Fix opaque error messages in  WICD cleanup

### DIFF
--- a/cmd/daemon/cleanup.go
+++ b/cmd/daemon/cleanup.go
@@ -48,6 +48,6 @@ func runCleanupCmd(cmd *cobra.Command, args []string) {
 	}
 	ctx := ctrl.SetupSignalHandler()
 	if err := cleanup.Deconfigure(cfg, ctx, namespace); err != nil {
-		klog.Exitf(err.Error())
+		klog.Exitf("error deconfiguring node: %v", err)
 	}
 }

--- a/pkg/daemon/cleanup/cleanup.go
+++ b/pkg/daemon/cleanup/cleanup.go
@@ -234,7 +234,11 @@ func removeServices(svcMgr manager.Manager, services []servicescm.Service, remov
 
 	klog.Infof("removed services: %q", servicesRemoved)
 	if len(failedRemovals) > 0 {
-		return fmt.Errorf("%#v", failedRemovals)
+		var msgs []string
+		for _, e := range failedRemovals {
+			msgs = append(msgs, e.Error())
+		}
+		return fmt.Errorf("failed to remove %d service(s): %s", len(failedRemovals), strings.Join(msgs, "; "))
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes two issues in the cleanup fatal to log useless output
- removeServices used fmt.Errorf("%#v", failedRemovals) which formats []error with Go struct syntax, printing memory addresses instead of the actual error messages. Replace with a readable joined string.

- runCleanupCmd passed err.Error() as the klog.Exitf format string. If the error string contains '%', those are treated as format verbs with no arguments. Use an explicit format string with %v instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during cleanup operations to display clearer feedback when configuration updates fail.
  * Enhanced service removal error reporting to present failures in a more readable, aggregated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->