### PR TITLE
WINC-1955: Add a wait for process exit on Windows service removal

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -860,6 +860,12 @@ func (vm *windows) ensureServiceIsRemoved(svcName string) error {
 	if err := vm.deleteService(svc); err != nil {
 		return fmt.Errorf("error deleting %s Windows service: %w", svc.name, err)
 	}
+	// On Windows, the SCM entry being removed does not guarantee the process has exited.
+	// The process holds an open file handle to its binary until fully terminated, blocking
+	// replacement. Wait here so callers have a complete "service gone" guarantee.
+	if err := vm.waitForProcessToExit(svcName); err != nil {
+		return fmt.Errorf("timed out waiting for %s process to exit: %w", svcName, err)
+	}
 	vm.log.Info("deconfigured", "service", svc.name)
 	return nil
 }
@@ -1069,6 +1075,27 @@ func (vm *windows) deconfigureWICD() error {
 		return fmt.Errorf("error ensuring %s Windows service is removed: %w", WicdServiceName, err)
 	}
 	return nil
+}
+
+// waitForProcessToExit polls until the named process is no longer present on the Windows instance.
+// This is needed because on Windows, a service can be STOPPED in SCM while the underlying process
+// is still running and holding file handles to its executable.
+func (vm *windows) waitForProcessToExit(processName string) error {
+	return wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
+		// by piping to Where-Object filters all processes by name ensures that when no process matches,
+		// it returns an empty result without throwing an error, keeping $? as $true and
+		// exit code as 0. Get-Process exits 1 when not found even with -ErrorAction
+		// SilentlyContinue, and try/catch leaves $? as $false after a caught terminating
+		// error, both causing exit code 1 which vm.Run treats as an error and makes the
+		// poller retry indefinitely.
+		out, err := vm.Run(fmt.Sprintf("Get-Process | Where-Object Name -eq '%s'", processName), true)
+		if err != nil {
+			// log error as debug
+			vm.log.V(1).Error(err, "unable to check if process is running", "process", processName)
+			return false, nil
+		}
+		return strings.TrimSpace(out) == "", nil
+	})
 }
 
 // Generic helper methods


### PR DESCRIPTION
This PR adds waitForProcessToExit and call it from ensureServiceIsRemoved after deleteService. On Windows, sc.exe stop transitions a service to STOPPED in the SCM but the underlying process may still be running, holding a file handle to its executablem where overwriting the binary during this period during an upgrade fails with "Can't unlink already-existing object" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows service removal reliability by adding verification that processes fully exit and release file handles after service deletion, preventing potential issues from lingering processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->