### PR TITLE
OCPBUGS-85061: inverts prometheus CPU utilization

### DIFF
--- a/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/windows-prometheus-k8s-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -10,7 +10,7 @@ spec:
   - name: windows.rules
     rules:
     - expr: |
-        avg without (core, mode)(rate(windows_cpu_time_total{mode="idle"}[1m]))
+        1 - avg without (core, mode)(rate(windows_cpu_time_total{mode="idle"}[1m]))
       record: instance:node_cpu_utilisation:rate1m
     - expr: |
         sum(rate(windows_cpu_time_total{mode="idle",mode!="iowait"}[3m])) BY (instance)

--- a/config/windows-exporter/prometheusRule.yaml
+++ b/config/windows-exporter/prometheusRule.yaml
@@ -10,7 +10,7 @@ spec:
     - name: windows.rules
       rules:
         - expr: |
-            avg without (core, mode)(rate(windows_cpu_time_total{mode="idle"}[1m]))
+            1 - avg without (core, mode)(rate(windows_cpu_time_total{mode="idle"}[1m]))
           record: instance:node_cpu_utilisation:rate1m
         - expr: |
             sum(rate(windows_cpu_time_total{mode="idle",mode!="iowait"}[3m])) BY (instance)


### PR DESCRIPTION
very simple fix, just inverts the metric :+1: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted CPU utilization reporting so it now reflects actual usage rather than idle time, improving the accuracy of Windows exporter alerts and dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->