### PR TITLE
[release-4.21] upgrades golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.24.8
-
-toolchain go1.24.12
+go 1.24.13
 
 replace (
 	// fix CVE-2025-30204 transitive deps still using older v4. Remove once `go mod graph` shows only 4.5.2 or higher


### PR DESCRIPTION
this golang bump should fix this bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version requirement to a newer patch release.
  * Removed the pinned Go toolchain setting, allowing the project to use the configured local toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->