### PR TITLE
OCPBUGS-65625: Clean up C:\var\lib\cni directory

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -49,6 +49,8 @@ const (
 	wicdLogDir = logDir + "\\wicd"
 	// cniDir is the directory for storing CNI binaries
 	cniDir = K8sDir + "\\cni"
+	// CniStateDir is the directory for storing CNI state/IPAM information
+	CniStateDir = "C:\\var\\lib\\cni"
 	// CniConfDir is the directory for storing CNI configuration
 	CniConfDir = cniDir + "\\config"
 	// ContainerdDir is the directory for storing Containerd binary
@@ -560,6 +562,11 @@ func (vm *windows) Bootstrap(ctx context.Context, desiredVer, watchNamespace, wi
 		return fmt.Errorf("unable to cleanup the Windows instance: %w", err)
 	}
 
+	// Remove stale CNI state from a previous configuration on a best-effort basis
+	if out, err := vm.Run(rmDirCmd(CniStateDir), true); err != nil {
+		vm.log.V(1).Error(err, "unable to remove directory", "dir", CniStateDir, "out", out)
+	}
+
 	if err := vm.ensureHostNameAndContainersFeature(ctx); err != nil {
 		return err
 	}
@@ -726,6 +733,10 @@ func (vm *windows) removeDirectories() error {
 	// At this point, we don't want to retry reconciliation again as the WICD files could have been deleted.
 	if out, err := vm.Run(rmDirCmd(K8sDir), true); err != nil {
 		vm.log.V(1).Error(err, "unable to remove directory", "dir", K8sDir, "out", out)
+	}
+	// Clean up CNI state directory on a best-effort basis
+	if out, err := vm.Run(rmDirCmd(CniStateDir), true); err != nil {
+		vm.log.V(1).Error(err, "unable to remove directory", "dir", CniStateDir, "out", out)
 	}
 	return nil
 }

--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -128,7 +128,10 @@ func (tc *testContext) getProxyCABundle() (string, error) {
 func (tc *testContext) checkDirsDoNotExist(address string) (bool, error) {
 	command := ""
 
-	for _, dir := range windows.RequiredDirectories {
+	dirs := make([]string, 0, len(windows.RequiredDirectories)+1)
+	dirs = append(dirs, windows.RequiredDirectories...)
+	dirs = append(dirs, windows.CniStateDir)
+	for _, dir := range dirs {
 		command += fmt.Sprintf("if ((Test-Path %s) -eq $true) { Write-Output %s exists}", dir, dir)
 	}
 	command += "exit 0"


### PR DESCRIPTION
The C:\var\lib\cni directory is created dynamically by CNI plugins (like host-local IPAM) but was left behind during node deconfiguration. Unlike C:\var\lib\kubelet (which is also left behind but contains active pod volume mounts that could result in data loss if deleted), the CNI state directory only contains transient network lease information and can be safely removed.

Fixes https://issues.redhat.com/browse/OCPBUGS-65625

For C:\var\lib\kubelet , I will  be filing a documentation bug so that administrators can review and clean them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows node teardown to also clean up leftover CNI state/IPAM data by removing the CNI state directory with best-effort handling.
  * Expanded end-to-end cleanup verification on Windows to ensure the CNI state directory is absent after deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->