### PR TITLE
OCPBUGS-90077: Fix infinite reboot on SSH exit command status

### DIFF
--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -540,7 +540,9 @@ func (vm *windows) Run(cmd string, psCmd bool) (string, error) {
 // RebootAndReinitialize restarts the Windows instance and re-initializes the SSH connection for further configuration
 func (vm *windows) RebootAndReinitialize(ctx context.Context) error {
 	vm.log.Info("rebooting instance")
-	if _, err := vm.Run("Restart-Computer -Force", true); err != nil {
+	// SSH connection may terminate during reboot before returning exit status - this is expected
+	// The real validation is waitUntilUnreachable() and reinitialize(), so we only fail on unexpected errors
+	if _, err := vm.Run("Restart-Computer -Force", true); err != nil && !strings.Contains(err.Error(), cmdExitNoStatus) {
 		return fmt.Errorf("error rebooting the Windows VM: %w", err)
 	}
 	// Wait for instance to be unreachable via SSH, implies reboot is underway


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nodes now track reboot attempts and stop retrying after a limit is reached.

* **Bug Fixes**
  * Improved reboot handling so an expected SSH disconnect during restart is no longer treated as a failure.
  * When reboot attempts are exhausted, the reboot request is cleared and a warning is recorded.
  * Reboot-related cleanup now removes both the reboot request and any stored attempt count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->