### PR TITLE
[release-4.21]  move sebsoto to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,10 @@
 reviewers:
-  - sebsoto
   - mansikulkarni96
   - jrvaldes
 approvers:
-  - sebsoto
   - mansikulkarni96
   - jrvaldes
 emeritus_approvers:
+  - sebsoto
   - ravisantoshgudimetla
   - aravindhp


### PR DESCRIPTION
This stops sebsoto from being automatically requested as a reviewer/approver on future PRs