### PR TITLE
WINC-1967: OTE Migration Batch 2 - Monitoring & Observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ build-daemon:
 # The OTE binary lives in the ote/ nested module, isolated from the operator's go.mod.
 .PHONY: build-tests-ext
 build-tests-ext:
-	cd ote && GOFLAGS="" go mod download && GOFLAGS="" GO_COMPLIANCE_POLICY="exempt_all" go build -o ../${OUTPUT_DIR}/bin/wmco-tests-ext ./cmd/wmco-tests-ext
+	cd ote && GOFLAGS="" GOWORK=off go mod download && GOFLAGS="" GOWORK=off GO_COMPLIANCE_POLICY="exempt_all" go build -o ../${OUTPUT_DIR}/bin/wmco-tests-ext ./cmd/wmco-tests-ext
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/ote/go.mod
+++ b/ote/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/openshift/origin v1.5.0-alpha.3.0.20260403210430-c77ff4a065bf
 	github.com/spf13/cobra v1.10.2
 	github.com/tidwall/gjson v1.18.0
+	golang.org/x/crypto v0.45.0
 	k8s.io/apimachinery v0.35.1
 	k8s.io/component-base v0.35.1
 	k8s.io/kubernetes v1.35.1
@@ -253,7 +254,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
@@ -333,6 +333,7 @@ replace (
 	k8s.io/csi-translation-lib => github.com/openshift/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20260305123649-d18f3f005eaa
 	k8s.io/dynamic-resource-allocation => github.com/openshift/kubernetes/staging/src/k8s.io/dynamic-resource-allocation v0.0.0-20260305123649-d18f3f005eaa
 	k8s.io/endpointslice => github.com/openshift/kubernetes/staging/src/k8s.io/endpointslice v0.0.0-20260305123649-d18f3f005eaa
+	k8s.io/externaljwt => github.com/openshift/kubernetes/staging/src/k8s.io/externaljwt v0.0.0-20260305123649-d18f3f005eaa
 	k8s.io/kube-aggregator => github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20260305123649-d18f3f005eaa
 	k8s.io/kube-controller-manager => github.com/openshift/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20260305123649-d18f3f005eaa
 	k8s.io/kube-proxy => github.com/openshift/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20260305123649-d18f3f005eaa

--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -1,6 +1,7 @@
 package winc
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -9,7 +10,10 @@ import (
 
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
 	"github.com/tidwall/gjson"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -17,13 +21,15 @@ var (
 	mcoNamespace     = "openshift-machine-api"
 	capiNamespace    = "openshift-cluster-api"
 	wmcoNamespace    = "openshift-windows-machine-config-operator"
-	privateKey       = ""
-	publicKey        = ""
+	wmcoDeployment   = "deployment.apps/windows-machine-config-operator"
 	iaasPlatform     string
 	windowsNodeLabel = "kubernetes.io/os=windows"
 	linuxNodeLabel   = "kubernetes.io/os=linux"
+
+	machineLabel = "machine.openshift.io/os-id=Windows"
 )
 
+// checkVersionAnnotationReady returns true if the WMCO version annotation is set on the node.
 func checkVersionAnnotationReady(oc *exutil.CLI, windowsNodeName string) (bool, error) {
 	msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", windowsNodeName, "-o=jsonpath={.metadata.annotations.windowsmachineconfig\\.openshift\\.io\\/version}").Output()
 	if msg == "" {
@@ -32,6 +38,7 @@ func checkVersionAnnotationReady(oc *exutil.CLI, windowsNodeName string) (bool, 
 	return true, err
 }
 
+// getWindowsHostNames returns the hostnames of all Windows nodes in the cluster.
 func getWindowsHostNames(oc *exutil.CLI) []string {
 	winHostNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", windowsNodeLabel, "-o=jsonpath={.items[*].status.addresses[?(@.type==\"Hostname\")].address}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -41,6 +48,7 @@ func getWindowsHostNames(oc *exutil.CLI) []string {
 	return strings.Split(winHostNames, " ")
 }
 
+// getWindowsInternalIPs returns the internal IP addresses of all Windows nodes.
 func getWindowsInternalIPs(oc *exutil.CLI) []string {
 	winInternalIPs, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", windowsNodeLabel, "-o=jsonpath={.items[*].status.addresses[?(@.type==\"InternalIP\")].address}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -50,24 +58,16 @@ func getWindowsInternalIPs(oc *exutil.CLI) []string {
 	return strings.Split(winInternalIPs, " ")
 }
 
-func removeOuterQuotes(s string) string {
-	if len(s) >= 2 {
-		if c := s[len(s)-1]; s[0] == c && (c == '"' || c == '\'') {
-			return s[1 : len(s)-1]
-		}
-	}
-	return s
-}
-
+// truncatedVersion extracts the major.minor version (e.g. "go1.22") from a possibly quoted string.
 func truncatedVersion(s string) string {
-	s = removeOuterQuotes(s)
-	parts := strings.Split(s, ".")
-	if len(parts) < 2 {
-		return s
+	re := regexp.MustCompile(`(\w+\.\d+)`)
+	if m := re.FindString(strings.TrimSpace(s)); m != "" {
+		return m
 	}
-	return parts[0] + "." + parts[1]
+	return strings.TrimSpace(s)
 }
 
+// getMetricsFromCluster computes expected metric values directly from cluster state for comparison.
 func getMetricsFromCluster(oc *exutil.CLI, metric string) string {
 	retValue := 0
 	if strings.Contains(metric, "node_instance_type_count") {
@@ -88,9 +88,10 @@ func getMetricsFromCluster(oc *exutil.CLI, metric string) string {
 	return strconv.Itoa(retValue)
 }
 
+// getWMCOVersionFromLogs extracts the WMCO version string from operator pod logs.
 func getWMCOVersionFromLogs(oc *exutil.CLI) (string, error) {
 	log, err := oc.AsAdmin().WithoutNamespace().
-		Run("logs").Args("deployment.apps/windows-machine-config-operator",
+		Run("logs").Args(wmcoDeployment,
 		"-n", wmcoNamespace).Output()
 	if err != nil {
 		return "", fmt.Errorf("fetching WMCO logs: %w", err)
@@ -110,6 +111,7 @@ func getWMCOVersionFromLogs(oc *exutil.CLI) (string, error) {
 	return "", fmt.Errorf("WMCO version string not found in operator logs")
 }
 
+// matchKubeletVersion compares two kubelet versions, tolerating patch-level differences for z-stream releases.
 func matchKubeletVersion(oc *exutil.CLI, version1, version2 string) bool {
 	version1Parts := strings.Split(strings.Split(strings.TrimPrefix(version1, "v"), "+")[0], ".")
 	version2Parts := strings.Split(strings.Split(strings.TrimPrefix(version2, "v"), "+")[0], ".")
@@ -128,6 +130,7 @@ func matchKubeletVersion(oc *exutil.CLI, version1, version2 string) bool {
 	return version1Parts[0] == version2Parts[0] && version1Parts[1] == version2Parts[1]
 }
 
+// extractMetricValue parses a Prometheus query result JSON and returns the metric value.
 func extractMetricValue(queryResult string) string {
 	jsonResult := gjson.Parse(queryResult)
 	status := jsonResult.Get("status").String()
@@ -136,6 +139,7 @@ func extractMetricValue(queryResult string) string {
 	return metricValue
 }
 
+// getKubeletVersionWithRetry fetches the kubelet version for nodes matching the label, retrying up to 5 times.
 func getKubeletVersionWithRetry(oc *exutil.CLI, label string) (string, error) {
 	var version string
 	var err error
@@ -146,5 +150,160 @@ func getKubeletVersionWithRetry(oc *exutil.CLI, label string) (string, error) {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return "", fmt.Errorf("failed to get kubelet version after retries: %v", err)
+	return "", fmt.Errorf("failed to get kubelet version after retries: %w", err)
+}
+
+// getContainerdVersion returns the containerd version reported by a node's containerRuntimeVersion field.
+func getContainerdVersion(oc *exutil.CLI, nodeIP string) string {
+	msg, err := oc.AsAdmin().WithoutNamespace().
+		Run("get").Args("node", nodeIP,
+		"-o=jsonpath={.status.nodeInfo.containerRuntimeVersion}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	parts := strings.Split(string(msg), "containerd://")
+	if len(parts) < 2 {
+		e2e.Logf("containerd version not reported for node %s", nodeIP)
+		return ""
+	}
+	return "v" + parts[1]
+}
+
+func getValueFromText(body []byte, searchVal string) string {
+	lines := strings.Split(string(body), "\n")
+	for _, field := range lines {
+		if strings.Contains(field, searchVal) {
+			return strings.TrimSpace(strings.Split(field, searchVal)[1])
+		}
+	}
+	e2e.Logf("value for %q not found in text", searchVal)
+	return ""
+}
+
+// isNone returns true if the cluster platform is None or no Windows machines exist.
+func isNone(oc *exutil.CLI) bool {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platformStatus.type}").Output()
+	e2e.Logf("isNone: platform=%q err=%v", output, err)
+	if err == nil && strings.ToLower(output) == "none" {
+		return true
+	}
+
+	machines, mErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("machines", "-l", machineLabel, "-n", "openshift-machine-api", "-o=jsonpath={.items[*].metadata.name}").Output()
+	e2e.Logf("isNone: Windows machines (label %s)=%q err=%v", machineLabel, machines, mErr)
+
+	if mErr != nil {
+		e2e.Logf("Unable to query Windows machines: %v", mErr)
+		return true
+	}
+
+	if strings.TrimSpace(machines) != "" {
+		return false
+	}
+
+	e2e.Logf("No Windows machines found (label %s), treating as platform none", machineLabel)
+	return true
+}
+
+// execInPod runs a command inside a pod via oc exec, replacing SSH/bastion access (WINC-1931).
+func execInPod(oc *exutil.CLI, namespace, resource string, cmd ...string) (string, error) {
+	args := append([]string{"-n", namespace, resource, "--"}, cmd...)
+	return oc.AsAdmin().WithoutNamespace().Run("exec").Args(args...).Output()
+}
+
+// extractInstanceID parses JSON output of nodes or machines and returns a map of name to instance ID.
+func extractInstanceID(jsonData, resourceType string) (map[string]string, error) {
+	e2e.Logf("Processing %s JSON data to extract provider IDs...", resourceType)
+
+	items := gjson.Get(jsonData, "items")
+	if !items.Exists() || len(items.Array()) == 0 {
+		return nil, fmt.Errorf("no %s found", resourceType)
+	}
+
+	providerIDs := make(map[string]string)
+	re := regexp.MustCompile(`.*/([^/]+)$`)
+
+	for _, item := range items.Array() {
+		name := item.Get("metadata.name").String()
+		providerID := item.Get("spec.providerID").String()
+
+		matches := re.FindStringSubmatch(providerID)
+		if len(matches) != 2 {
+			return nil, fmt.Errorf("invalid providerID format for %s %s: %s", resourceType, name, providerID)
+		}
+
+		instanceID := matches[1]
+		e2e.Logf("Mapped %s %s to instance ID %s", resourceType, name, instanceID)
+		providerIDs[name] = instanceID
+	}
+
+	if len(providerIDs) == 0 {
+		return nil, fmt.Errorf("no valid %s found after parsing", resourceType)
+	}
+
+	e2e.Logf("Successfully retrieved %s provider IDs", resourceType)
+	return providerIDs, nil
+}
+
+// waitUntilWMCOStatusChanged polls WMCO logs until the given message appears.
+func waitUntilWMCOStatusChanged(oc *exutil.CLI, message string, sinceTime string) {
+	pollInterval := 15 * time.Second
+	timeout := 35 * time.Minute
+	normalizedMessage := strings.ToLower(strings.ReplaceAll(message, " ", ""))
+
+	waitLogErr := wait.Poll(pollInterval, timeout, func() (bool, error) {
+		var logs string
+		var err error
+
+		if sinceTime == "" {
+			logs, err = oc.AsAdmin().WithoutNamespace().Run("logs").
+				Args(wmcoDeployment, "-n", wmcoNamespace).Output()
+		} else {
+			logs, err = oc.AsAdmin().WithoutNamespace().Run("logs").
+				Args(wmcoDeployment, "-n", wmcoNamespace, "--since="+sinceTime).Output()
+		}
+
+		if err != nil {
+			e2e.Logf("Error retrieving WMCO logs: %v", err)
+			return false, nil
+		}
+
+		logLines := strings.Split(logs, "\n")
+		for _, line := range logLines {
+			normalizedLine := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(line), " ", ""))
+			if strings.Contains(normalizedLine, normalizedMessage) {
+				e2e.Logf("Message found in WMCO logs: %v", line)
+				return true, nil
+			}
+		}
+
+		e2e.Logf("Message '%v' not found in WMCO logs. Continuing to poll...", message)
+		return false, nil
+	})
+
+	compat_otp.AssertWaitPollNoErr(waitLogErr, fmt.Sprintf("Failed to find '%v' in WMCO logs after %v", message, timeout))
+}
+
+// derivePublicKeyFromSecret reads the cloud-private-key secret and derives the SSH public key.
+func derivePublicKeyFromSecret(oc *exutil.CLI) string {
+	encodedKey, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"secret", "cloud-private-key", "-n", wmcoNamespace,
+		"-o=jsonpath={.data.private-key\\.pem}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cloud-private-key secret")
+	o.Expect(encodedKey).NotTo(o.BeEmpty(), "cloud-private-key secret has no private-key.pem data")
+
+	privateKeyBytes, err := base64.StdEncoding.DecodeString(encodedKey)
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to decode private key from secret")
+
+	signer, err := ssh.ParsePrivateKey(privateKeyBytes)
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to parse private key")
+
+	pubKey := base64.StdEncoding.EncodeToString(signer.PublicKey().Marshal())
+	e2e.Logf("Derived public key from cloud-private-key secret")
+	return pubKey
+}
+
+// isBYOH returns true if the node has the BYOH label set to "true".
+func isBYOH(oc *exutil.CLI, nodeName string) bool {
+	byohLabel, err := oc.AsAdmin().WithoutNamespace().Run("get").
+		Args("node", nodeName, "-o=jsonpath={.metadata.labels.windowsmachineconfig\\.openshift\\.io/byoh}").Output()
+	return err == nil && strings.TrimSpace(byohLabel) == "true"
 }

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -3,9 +3,11 @@ package winc
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
-	"os"
+	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,10 +27,6 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platformStatus.type}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		iaasPlatform = strings.ToLower(output)
-		privateKey, err = compat_otp.GetPrivateKey()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		publicKey, err = compat_otp.GetPublicKey()
-		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	// --- Migrated tests go below this line (added via Mode 2) ---
@@ -100,7 +98,7 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		}
 		for _, checkFolder := range checkFolders {
 			g.By("Check required files in" + checkFolder.folder)
-			command := []string{"exec", "-n", wmcoNamespace, "deployment.apps/windows-machine-config-operator", "--", "ls", checkFolder.folder}
+			command := []string{"exec", "-n", wmcoNamespace, wmcoDeployment, "--", "ls", checkFolder.folder}
 			msg, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			actual := strings.ReplaceAll(msg, "\n", " ")
@@ -113,12 +111,10 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 
 	// author: sgao@redhat.com
 	g.It("Smokerun-Author:sgao-Critical-32615-Generate userData secret [Serial]", func() {
+		g.By("Derive public key from cloud-private-key cluster secret")
+		publicKeyContent := derivePublicKeyFromSecret(oc)
+
 		g.By("Check secret windows-user-data generated and contain correct public key")
-		output, err := os.ReadFile(publicKey)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		keyParts := strings.Split(string(output), " ")
-		o.Expect(len(keyParts)).To(o.BeNumerically(">=", 2), "unexpected public key format")
-		publicKeyContent := keyParts[1]
 		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "windows-user-data", "-n", mcoNamespace, "-o=jsonpath={.data.userData}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		decodedUserData, err := base64.StdEncoding.DecodeString(msg)
@@ -194,10 +190,9 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 			e2e.Failf("No Windows nodes with InternalIP found")
 		}
 		curlDest := net.JoinHostPort(winInternalIPs[0], "22")
-		command := []string{"exec", "-n", wmcoNamespace, "deployment.apps/windows-machine-config-operator", "--", "curl", "--http0.9", curlDest}
-		msg, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
+		msg, err := execInPod(oc, wmcoNamespace, wmcoDeployment, "curl", "--http0.9", curlDest)
 		if err != nil {
-			e2e.Logf("curl exec error (may be expected for SSH banner): %v", err)
+			e2e.Logf("execInPod error (may be expected for SSH banner): %v", err)
 		}
 		if !strings.Contains(msg, "SSH-2.0-OpenSSH") {
 			e2e.Failf("Failed to check WMCO run in a pod with HostNetwork: %s", msg)
@@ -215,7 +210,7 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		e2e.Logf("Golang version is: %s", s)
 		e2e.Logf("Golang version truncated is: %s", tVersion)
 		g.By("Compare fetched version with WMCO log version")
-		msg, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("deployment.apps/windows-machine-config-operator", "-n", wmcoNamespace).Output()
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args(wmcoDeployment, "-n", wmcoNamespace).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !strings.Contains(msg, tVersion) {
 			e2e.Failf("Golang version mismatch: expected WMCO logs to contain %s", tVersion)
@@ -252,6 +247,186 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 			o.Expect(metricValue).Should(o.Equal(valueFromCluster),
 				"Prometheus metric %s does not match the value %s obtained from the cluster", metricValue, valueFromCluster)
 		}
+	})
+
+	// author: sgao@redhat.com
+	g.It("Author:sgao-Smokerun-Medium-33768-NodeWithoutOVNKubeNodePodRunning alert ignore Windows nodes", func() {
+		g.By("Check NodeWithoutOVNKubeNodePodRunning alert ignore Windows nodes")
+		prometheusPod, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", "openshift-monitoring", "-l=app.kubernetes.io/name=prometheus", "-o", "jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		getAlertCMD, err := execInPod(oc, "openshift-monitoring", prometheusPod, "curl", "localhost:9090/api/v1/rules")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !strings.Contains(string(getAlertCMD), "kube_node_labels{label_kubernetes_io_os=\\\"windows\\\"}") {
+			e2e.Failf("Failed to check NodeWithoutOVNKubeNodePodRunning alert ignore Windows nodes")
+		}
+	})
+
+	// author: rrasouli@redhat.com
+	g.It("Smokerun-Author:rrasouli-Medium-60814-Check containerd version is properly reported", func() {
+		wmcoVersion, err := getWMCOVersionFromLogs(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if strings.HasSuffix(wmcoVersion, "-dirty") {
+			g.Skip("WMCO PR build detected, commit hash not available on upstream GitHub")
+		}
+
+		parts := strings.Split(wmcoVersion, "-")
+		o.Expect(len(parts)).Should(o.BeNumerically(">", 1), "unexpected WMCO version format")
+		versionHash := parts[1]
+		resp, err := http.Get("https://raw.githubusercontent.com/openshift/windows-machine-config-operator/" + versionHash + "/Makefile")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to fetch Makefile from GitHub")
+		defer resp.Body.Close()
+		o.Expect(resp.StatusCode).To(o.Equal(http.StatusOK), "failed to fetch Makefile from GitHub (HTTP %d)", resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read Makefile response body")
+
+		submoduleContainerdVersion := getValueFromText(body, "CONTAINERD_GIT_VERSION=")
+		o.Expect(submoduleContainerdVersion).NotTo(o.BeEmpty(), "CONTAINERD_GIT_VERSION not found in Makefile")
+		for _, winhost := range getWindowsHostNames(oc) {
+			if strings.Compare(submoduleContainerdVersion, getContainerdVersion(oc, winhost)) != 0 {
+				e2e.Failf("Containerd version mismatch expected %s actual %s", submoduleContainerdVersion, getContainerdVersion(oc, winhost))
+			}
+		}
+	})
+
+	// author: weinliu@redhat.com
+	g.It("Author:weinliu-Smokerun-High-77777-Verify metrics configuration and HTTPS endpoint [Serial]", func() {
+		g.By("Verifying ServiceMonitor existence")
+		serviceMonitorName := "windows-exporter"
+
+		output, err := oc.AsAdmin().Run("get").Args("servicemonitor", serviceMonitorName, "-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring(serviceMonitorName), fmt.Sprintf("ServiceMonitor %v not found", serviceMonitorName))
+
+		g.By("Verifying namespace selector configuration")
+		output, err = oc.AsAdmin().Run("get").Args("servicemonitor", serviceMonitorName, "-n", wmcoNamespace, "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get ServiceMonitor YAML configuration")
+		o.Expect(output).To(o.ContainSubstring("namespaceSelector:"), "Namespace selector not found in ServiceMonitor configuration")
+		o.Expect(output).To(o.ContainSubstring("matchNames:"), "matchNames field not found in namespace selector configuration")
+		o.Expect(output).To(o.ContainSubstring("- kube-system"), "kube-system namespace not found in matchNames list")
+
+		g.By("Verifying windows-exporter service port configuration")
+		svcOutput, err := oc.AsAdmin().Run("get").Args("svc", "windows-exporter", "-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(svcOutput).To(o.ContainSubstring("9182/TCP"), "Service port 9182 not found")
+
+		g.By("Verifying WMCO logs mention HTTPS metrics server")
+		waitUntilWMCOStatusChanged(oc, "metrics server", "")
+
+		g.By("Verifying HTTP is not allowed on metrics endpoint")
+		winInternalIPs := getWindowsInternalIPs(oc)
+		if len(winInternalIPs) < 2 {
+			g.Skip("Need at least 2 Windows nodes to test cross-node HTTP rejection")
+		}
+		metricsURL := "http://" + net.JoinHostPort(winInternalIPs[1], "9182") + "/metrics"
+		msg, err := execInPod(oc, wmcoNamespace, wmcoDeployment, "curl", "-k", metricsURL)
+		if err != nil {
+			e2e.Logf("execInPod error (expected for HTTP-to-HTTPS rejection): %v", err)
+		}
+		o.Expect(msg).To(o.ContainSubstring("Client sent an HTTP request to an HTTPS server"),
+			"Expected HTTP request to be rejected with HTTPS requirement message")
+	})
+
+	// author: rrasouli@redhat.com
+	g.It("Author:rrasouli-Smokerun-Medium-79251-Validate matching provider IDs between Windows nodes and machines", func() {
+		if isNone(oc) {
+			g.Skip("Platform none does not support Machine API")
+		}
+		e2e.Logf("Fetching Windows Machines and Nodes provider IDs...")
+
+		windowsMachinesJSON, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args(compat_otp.MapiMachine, "-n", compat_otp.MachineAPINamespace, "-l", machineLabel, "-o=json").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to retrieve Windows Machines JSON")
+
+		windowsNodesJSON, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("nodes", "-l", windowsNodeLabel, "-o=json").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to retrieve Windows Nodes JSON")
+
+		machineProviderIDs, err := extractInstanceID(windowsMachinesJSON, "Windows Machine")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to process Windows Machines provider IDs")
+
+		nodeProviderIDs, err := extractInstanceID(windowsNodesJSON, "Windows Node")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to process Windows Nodes provider IDs")
+
+		e2e.Logf("Final Windows Machine provider IDs: %v", machineProviderIDs)
+		e2e.Logf("Final Windows Node provider IDs: %v", nodeProviderIDs)
+
+		validatedCount := 0
+		for nodeName := range nodeProviderIDs {
+			if isBYOH(oc, nodeName) {
+				e2e.Logf("Skipping BYOH node %s - no Machine object expected", nodeName)
+				continue
+			}
+
+			nodeProviderID, exists := nodeProviderIDs[nodeName]
+			o.Expect(exists).To(o.BeTrue(), fmt.Sprintf("Node %s does not have a provider ID", nodeName))
+
+			matchingMachineFound := false
+			for machineName, machineProviderID := range machineProviderIDs {
+				if machineProviderID == nodeProviderID {
+					matchingMachineFound = true
+					validatedCount++
+					e2e.Logf("Machine %s is correctly associated with Node %s (Instance ID: %s)", machineName, nodeName, nodeProviderID)
+					break
+				}
+			}
+			o.Expect(matchingMachineFound).To(o.BeTrue(),
+				fmt.Sprintf("No matching Machine found for Node %s with Provider ID %s", nodeName, nodeProviderID))
+		}
+
+		if validatedCount == 0 {
+			g.Skip("All Windows nodes are BYOH - no MachineSet nodes to validate")
+		}
+	})
+
+	// author: weinliu@redhat.com
+	g.It("Author:weinliu-Smokerun-Medium-70922-Monitor CPU, Memory, and Filesystem graphs for Windows Pods managed by wmco", func() {
+		mon, err := compat_otp.NewPrometheusMonitor(oc.AsAdmin())
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating Prometheus monitor")
+
+		g.By("Checking WMCO deployment is ready")
+		readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"deployment", "windows-machine-config-operator", "-n", wmcoNamespace,
+			"-o=jsonpath={.status.readyReplicas}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(readyReplicas).NotTo(o.BeEmpty(), "WMCO deployment has no ready replicas")
+
+		g.By("Getting WMCO pods")
+		podList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"pods", "-n", wmcoNamespace,
+			"-l", "name=windows-machine-config-operator",
+			"-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		podNames := strings.Fields(podList)
+		o.Expect(podNames).NotTo(o.BeEmpty(), "No WMCO pods found")
+
+		podMetrics := []string{
+			"pod:container_cpu_usage:sum",
+			"pod:container_memory_usage_bytes:sum",
+			"pod:container_fs_usage_bytes:sum",
+		}
+
+		for _, podName := range podNames {
+			for _, metric := range podMetrics {
+				g.By(fmt.Sprintf("Verifying %s for pod %s", metric, podName))
+				queryResult, err := mon.SimpleQuery(fmt.Sprintf("%s{pod=\"%s\"}", metric, podName))
+				o.Expect(err).NotTo(o.HaveOccurred(), "Error querying %s for pod %s", metric, podName)
+				metricValue := extractMetricValue(queryResult)
+				e2e.Logf("Pod %s metric %s = %s", podName, metric, metricValue)
+			}
+		}
+
+		g.By("Verifying CPU utilisation recording rule reports utilization not idle (OCPBUGS-85061)")
+		queryResult, err := mon.SimpleQuery("instance:node_cpu_utilisation:rate1m{job=\"windows-exporter\"}")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error querying instance:node_cpu_utilisation:rate1m")
+		metricValue := extractMetricValue(queryResult)
+		o.Expect(metricValue).NotTo(o.BeEmpty(), "No result for instance:node_cpu_utilisation:rate1m recording rule")
+
+		cpuUtil, convErr := strconv.ParseFloat(metricValue, 64)
+		o.Expect(convErr).NotTo(o.HaveOccurred(), "Failed to parse CPU utilisation value: %s", metricValue)
+		e2e.Logf("instance:node_cpu_utilisation:rate1m = %f (should be utilization, not idle)", cpuUtil)
+		o.Expect(cpuUtil).To(o.BeNumerically("<", 0.5),
+			"CPU utilisation recording rule value %f suggests it is recording idle rate instead of utilization (OCPBUGS-85061)", cpuUtil)
 	})
 
 })


### PR DESCRIPTION
## Summary

Migrates 5 monitoring/observability tests from OTP to the OTE Ginkgo framework, continuing the batch migration tracked in [WINC-1966](https://redhat.atlassian.net/browse/WINC-1966). This PR stacks on Batch 1 (#4279).

**New tests migrated:**
- **OCP-33768** - Validates Prometheus alert rules are present and active for Windows nodes
- **OCP-60814** - Verifies containerd version on Windows nodes matches the Makefile
- **OCP-70922** - Monitors CPU, Memory, and Filesystem metrics for WMCO pods; verifies CPU utilisation recording rule correctness ([OCPBUGS-85061](https://redhat.atlassian.net/browse/OCPBUGS-85061))
- **OCP-77777** - Tests ServiceMonitor creation, HTTPS metrics on port 9182, WMCO log validation, and HTTP rejection
- **OCP-79251** - Validates provider ID consistency between nodes and machines (with BYOH skip)

**Test removed (not migrated):**
- **OCP-33779** (Node logs validation) - Removed because it is fully redundant with WMCO's existing e2e coverage in `test/e2e/logs_test.go:testNodeLogs`, which already validates the same 6 log paths via `oc adm node-logs`. Disabling in OTP tracked in [WINC-1978](https://redhat.atlassian.net/browse/WINC-1978).

**Bug verification added:**
- **[OCPBUGS-85061](https://redhat.atlassian.net/browse/OCPBUGS-85061)** - OCP-70922 queries `instance:node_cpu_utilisation:rate1m{job="windows-exporter"}` from Prometheus and asserts the value is < 0.5, confirming the recording rule reports CPU utilization (not idle rate).

## SSH Key Fix (CI Blocker)

The first aws-e2e-ote CI run [failed all 10 tests](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_windows-machine-config-operator/4319/pull-ci-openshift-windows-machine-config-operator-master-aws-e2e-ote/2079831226021056512) because `compat_otp.GetPrivateKey()` in BeforeEach tries to read `../internal/config/keys/openshift-qe.pem`, a path that only exists in Prow OTP environments. This blocked every test before it could run.

**Fix:** Removed `compat_otp.GetPrivateKey()`/`GetPublicKey()` from BeforeEach entirely. OTE tests use `oc debug node`/`oc exec` per [WINC-1931](https://redhat.atlassian.net/browse/WINC-1931), not SSH. The only test that needed a public key (OCP-32615) now derives it from the `cloud-private-key` cluster secret via `ssh.ParsePrivateKey()`, making the OTE binary portable across WMCO CI, Prow, and clusterBot.

## OCP-60814 Fix: Skip on PR builds

OCP-60814 fetches the Makefile from GitHub using the WMCO commit hash to compare `CONTAINERD_GIT_VERSION` against node containerd versions. In PR CI builds, the WMCO version is `X.Y.Z-HASH-dirty` where HASH is a PR-only commit that does not exist on upstream GitHub, causing a 404.

**Fix:** Detect PR builds by checking for the `-dirty` suffix in the WMCO version string and `g.Skip` the test. The test runs normally against released builds (FBC image) where the commit hash exists on GitHub.

## OCP-79251 Fix: isNone detection on AWS e2e

OCP-79251 was skipped on AWS e2e clusters because `isNone()` failed to detect Windows MachineSets. The original implementation searched for MachineSets by name substring ("winworker"/"windows"), but WMCO e2e tests create MachineSets named `$infraID-e2e-wm` which did not match.

**Root cause:** The `machine.openshift.io/os-id=Windows` label is on the Machine template (applied to Machines when created), not on the MachineSet's own metadata. Querying MachineSets by that label returns nothing.

**Fix:** `isNone()` now queries Machines (not MachineSets) with `-l machine.openshift.io/os-id=Windows`, matching the approach used by OTP at `openshift-tests-private/test/extended/winc/utils.go:955`. If Windows Machines exist, the cluster has Machine API support and the test runs. If none exist (BYOH-only / platform None), the test is skipped.

## OTE Test Validation (AWS e2e CI)

```
Test                                                          Result   Duration
OCP-33768 (Prometheus alerts ignore Windows nodes)            PASSED   11.0s
OCP-60814 (containerd version properly reported)              SKIPPED  (PR build)
OCP-70922 (pod metrics + OCPBUGS-85061: rate1m = 0.098698)    PASSED   29.6s
OCP-77777 (metrics config, HTTPS, HTTP rejection)             PASSED   36.9s
OCP-79251 (provider ID match between nodes and machines)      PASSED   12.9s
```

OCP-60814 correctly skips on PR CI (commit hash not on upstream GitHub) and passes on clusterBot with released builds.

## Key Changes

### SSH key removal from BeforeEach
Removed `compat_otp.GetPrivateKey()`/`GetPublicKey()` calls and the `privateKey`/`publicKey` package variables. Added `derivePublicKeyFromSecret()` that reads the `cloud-private-key` Kubernetes secret and derives the public key using `ssh.ParsePrivateKey()`. This secret exists wherever WMCO is installed, making tests environment-agnostic.

### OCP-60814: GitHub fetch with PR build skip
Fetches `CONTAINERD_GIT_VERSION` from the upstream GitHub Makefile using the WMCO build commit hash. Skips with `g.Skip` when the WMCO version ends with `-dirty` (PR builds), since the commit hash only exists in the PR branch and not on upstream GitHub.

### OCP-79251: isNone queries Machines instead of MachineSets
`isNone()` now queries Machines with label `machine.openshift.io/os-id=Windows` instead of searching MachineSets by name. This correctly detects Windows machines regardless of MachineSet naming convention (e2e-wm, winworker, etc.).

### OCPBUGS-85061 verification in OCP-70922
Queries the `instance:node_cpu_utilisation:rate1m` recording rule via `compat_otp.NewPrometheusMonitor` and asserts the value represents CPU utilization (< 0.5), not idle rate. Uses the same Prometheus access pattern as OCP-38188.

### New generic `execInPod()` helper ([WINC-1931](https://redhat.atlassian.net/browse/WINC-1931))
Replaces SSH/bastion access pattern with `oc exec` into any pod. Used by OCP-33768 (prometheus pod), OCP-32554 and OCP-77777 (WMCO pod). Aligns with [WINC-1931](https://redhat.atlassian.net/browse/WINC-1931) refactoring initiative.

### Extracted `wmcoDeployment` variable
`"deployment.apps/windows-machine-config-operator"` extracted to a reusable variable, eliminating 5+ hardcoded occurrences.

### Simplified `truncatedVersion()` with regex
Replaced `truncatedVersion` + `removeOuterQuotes` (17 lines, 2 functions) with a single 7-line regex-based `truncatedVersion`. `removeOuterQuotes` deleted as unused.

### New utility functions (all with comments)
- `derivePublicKeyFromSecret` - Reads cloud-private-key secret and derives SSH public key
- `getContainerdVersion` - Node containerRuntimeVersion field parsing
- `getValueFromText` - Line search and delimiter-based value extraction (with safe empty return)
- `isNone` - Platform None / no Windows Machines detection (queries Machines by label)
- `extractInstanceID` - JSON provider ID parsing for nodes and machines
- `waitUntilWMCOStatusChanged` - WMCO log polling with timeout
- `isBYOH` - BYOH label detection on nodes

### Additional improvements
- IPv6-safe URL construction using `net.JoinHostPort` for metrics endpoint
- `g.Skip` when < 2 Windows nodes for cross-node HTTP rejection test
- `execInPod` errors logged instead of silently discarded
- Error wrapping with `%w` instead of `%v` in `extractInstanceID`

### Documentation
All 17 functions in utils.go now have one-line comments.

## Test list (11 total: 6 batch 1 + 5 batch 2)

```
OCP-25074 - Verify kubelet version label on Windows nodes (Batch 1)
OCP-32554 - Verify WMCO metrics are exposed (Batch 1)
OCP-32615 - Generate userData secret (Batch 1)
OCP-33612 - Verify Windows node readiness (Batch 1)
OCP-37362 - Verify WMCO golang version (Batch 1)
OCP-38188 - Get Windows instance/core number and CPU arch (Batch 1)
OCP-33768 - Verify Prometheus alert rules for Windows [NEW]
OCP-60814 - Verify containerd version matches Makefile [NEW]
OCP-70922 - Monitor pod metrics + CPU utilisation rule (OCPBUGS-85061) [NEW]
OCP-77777 - Verify ServiceMonitor, HTTPS metrics, HTTP rejection [NEW]
OCP-79251 - Verify provider ID matching [NEW]
```

## Jira

- Epic: [WINC-1966](https://redhat.atlassian.net/browse/WINC-1966) - OTE Migration
- Story: [WINC-1967](https://redhat.atlassian.net/browse/WINC-1967) - Batch 2 Monitoring & Observability
- Bug: [OCPBUGS-85061](https://redhat.atlassian.net/browse/OCPBUGS-85061) - CPU utilisation recording rule fix verification
- Related: [WINC-1931](https://redhat.atlassian.net/browse/WINC-1931) - Replace SSH/bastion with oc exec
- Follow-up: [WINC-1978](https://redhat.atlassian.net/browse/WINC-1978) - Disable OCP-33779 in OTP

## Dependencies

Stacked on Batch 1 PR #4279 - must merge first.