### PR TITLE
WINC-1988: TLS profile adherence

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -309,6 +309,14 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - clusteroperators
           verbs:
           - get

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	openshiftconfig "github.com/openshift/api/config/v1"
 	mapi "github.com/openshift/api/machine/v1beta1"
 	mcfg "github.com/openshift/api/machineconfiguration/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	operators "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/operator-framework/operator-lib/leader"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -45,6 +50,9 @@ import (
 
 // ServiceAccount permissions used to watch operator on secrets.
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
+
+// RBAC for reading APIServer configuration to fetch TLS security profile
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 
 var (
 	scheme   = runtime.NewScheme()
@@ -113,8 +121,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// get cluster configuration
-	ctx := ctrl.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+
 	clusterConfig, err := cluster.NewConfig(ctx, cfg)
 	if err != nil {
 		setupLog.Error(err, "failed to get cluster configuration")
@@ -125,6 +134,27 @@ func main() {
 	if err := clusterConfig.Validate(ctx); err != nil {
 		setupLog.Error(err, "failed to validate required cluster configuration")
 		os.Exit(1)
+	}
+
+	// Get TLS configuration from cluster config (fetched from APIServer during NewConfig)
+	tlsProfile := clusterConfig.TLSProfileSpec()
+	tlsAdherence := clusterConfig.TLSAdherencePolicy()
+
+	// Gate TLS profile enforcement on the adherence policy. WMCO was not previously honoring the
+	// cluster TLS profile, so per the centralized TLS config enhancement (StrictAllComponents mode)
+	// it should only enforce when ShouldHonorClusterTLSProfile returns true.
+	var metricsServerTLSOpts []func(*tls.Config)
+	if libgocrypto.ShouldHonorClusterTLSProfile(tlsAdherence) {
+		tlsConfigFn, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(tlsProfile)
+		if len(unsupportedCiphers) > 0 {
+			setupLog.Info("some cipher suites are not supported by Go and will be ignored",
+				"unsupportedCiphers", unsupportedCiphers)
+		}
+		metricsServerTLSOpts = []func(*tls.Config){tlsConfigFn}
+		setupLog.Info("TLS configuration loaded",
+			"minVersion", tlsProfile.MinTLSVersion,
+			"cipherSuites", len(tlsProfile.Ciphers)-len(unsupportedCiphers),
+			"adherencePolicy", tlsAdherence)
 	}
 
 	setupLog.Info("platform", "type", clusterConfig.Platform())
@@ -184,6 +214,7 @@ func main() {
 			BindAddress:    metricsAddr,
 			SecureServing:  true,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
+			TLSOpts:        metricsServerTLSOpts,
 		},
 	})
 	if err != nil {
@@ -304,6 +335,30 @@ func main() {
 	}
 	if err = mReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Metrics")
+		os.Exit(1)
+	}
+
+	// Setup TLS security profile watcher
+	// Watches for TLS profile or adherence policy changes and restarts pod to reload config
+	tlsWatcher := &tlspkg.SecurityProfileWatcher{
+		Client:                    mgr.GetClient(),
+		InitialTLSProfileSpec:     tlsProfile,
+		InitialTLSAdherencePolicy: tlsAdherence,
+		OnProfileChange: func(ctx context.Context, oldProfile, newProfile configv1.TLSProfileSpec) {
+			setupLog.Info("TLS security profile changed, initiating shutdown to reload configuration",
+				"oldProfile", oldProfile,
+				"newProfile", newProfile)
+			cancel()
+		},
+		OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy configv1.TLSAdherencePolicy) {
+			setupLog.Info("TLS adherence policy changed, initiating shutdown to reload configuration",
+				"oldPolicy", oldPolicy,
+				"newPolicy", newPolicy)
+			cancel()
+		},
+	}
+	if err := tlsWatcher.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup TLS security profile watcher")
 		os.Exit(1)
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,6 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: windows-machine-config-operator
 rules:
 - apiGroups:
@@ -147,6 +148,14 @@ rules:
   - signers
   verbs:
   - approve
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/openshift/api v0.0.0-20260729135743-72624b98ff3d
 	github.com/openshift/client-go v0.0.0-20260728123811-92b24dd0dd1f
+	github.com/openshift/controller-runtime-common v0.0.0-20260804161605-f9e4228f21e6
 	github.com/openshift/library-go v0.0.0-20260729082949-ed1b43415e01
 	github.com/operator-framework/api v0.41.0
 	github.com/operator-framework/operator-lib v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/openshift/api v0.0.0-20260729135743-72624b98ff3d h1:gCzFGzkzLaUX988DC
 github.com/openshift/api v0.0.0-20260729135743-72624b98ff3d/go.mod h1:k6qH5QOVa5GDln2VVm8Jz4NV3Z7R2SATHFLwGS6Wh3M=
 github.com/openshift/client-go v0.0.0-20260728123811-92b24dd0dd1f h1:dP7eA8s2WZWQNom5DDG7zHvl3FkcBVhtWUVXznr0Ezw=
 github.com/openshift/client-go v0.0.0-20260728123811-92b24dd0dd1f/go.mod h1:pqFNk7AzeRdbhI1Ox7fFPhUTxcaeIXVLYjraSiig/ZM=
+github.com/openshift/controller-runtime-common v0.0.0-20260804161605-f9e4228f21e6 h1:x6dgBCAlXd8yv40g87NFBgUZ+uBWOcGhDNIIzJTwLjs=
+github.com/openshift/controller-runtime-common v0.0.0-20260804161605-f9e4228f21e6/go.mod h1:YVDrbC4muEYMejrIZkaQHhlH0bcBusL1UUBkPBxeVrI=
 github.com/openshift/library-go v0.0.0-20260729082949-ed1b43415e01 h1:ZLF7koDByg791uXhb9WnQjQPmbwBqZrd0T/gpGM5m7g=
 github.com/openshift/library-go v0.0.0-20260729082949-ed1b43415e01/go.mod h1:iahMN6YoNSRG1xyRj03YYU5iboJzv+UZFu9S0grJmQc=
 github.com/operator-framework/api v0.5.2/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=

--- a/hack/update_submodules.sh
+++ b/hack/update_submodules.sh
@@ -32,6 +32,7 @@ function update_libraries() {
   go get github.com/openshift/api@$base_branch
   go get github.com/openshift/client-go@$base_branch
   go get github.com/openshift/library-go@$base_branch
+  go get github.com/openshift/controller-runtime-common@$base_branch
   # react to main branch change in machine-config-operator
   if [ "$base_branch" == "master" ]; then
     go get github.com/openshift/machine-config-operator@main

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -12,6 +12,7 @@ import (
 	oconfig "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	operatorv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	"golang.org/x/mod/semver"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -54,6 +55,10 @@ type Config interface {
 	Platform() oconfig.PlatformType
 	// Network returns network configuration for the OpenShift cluster
 	Network() Network
+	// TLSProfileSpec returns the TLS profile spec fetched from the APIServer
+	TLSProfileSpec() oconfig.TLSProfileSpec
+	// TLSAdherencePolicy returns the TLS adherence policy fetched from the APIServer
+	TLSAdherencePolicy() oconfig.TLSAdherencePolicy
 }
 
 // networkType holds information for a required network type
@@ -75,6 +80,10 @@ type config struct {
 	// platform indicates the cloud on which OpenShift cluster is running
 	// TODO: Remove this once we figure out how to be provider agnostic
 	platform oconfig.PlatformType
+	// tlsProfileSpec is the TLS profile spec fetched from the APIServer during startup
+	tlsProfileSpec oconfig.TLSProfileSpec
+	// tlsAdherencePolicy is the TLS adherence policy fetched from the APIServer during startup
+	tlsAdherencePolicy oconfig.TLSAdherencePolicy
 }
 
 func (c *config) Platform() oconfig.PlatformType {
@@ -83,6 +92,14 @@ func (c *config) Platform() oconfig.PlatformType {
 
 func (c *config) Network() Network {
 	return c.network
+}
+
+func (c *config) TLSProfileSpec() oconfig.TLSProfileSpec {
+	return c.tlsProfileSpec
+}
+
+func (c *config) TLSAdherencePolicy() oconfig.TLSAdherencePolicy {
+	return c.tlsAdherencePolicy
 }
 
 // NewConfig returns a Config struct pertaining to the cluster configuration
@@ -117,11 +134,24 @@ func NewConfig(ctx context.Context, restConfig *rest.Config) (Config, error) {
 	if len(platformStatus.Type) == 0 {
 		return nil, fmt.Errorf("error getting platform type")
 	}
+
+	// Fetch TLS configuration from APIServer
+	apiServer, err := oclient.ConfigV1().APIServers().Get(ctx, "cluster", meta.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting APIServer configuration: %w", err)
+	}
+	tlsProfileSpec, err := tlspkg.GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return nil, fmt.Errorf("error getting TLS profile from APIServer: %w", err)
+	}
+
 	return &config{
-		oclient:        oclient,
-		operatorClient: operatorClient,
-		network:        network,
-		platform:       platformStatus.Type,
+		oclient:            oclient,
+		operatorClient:     operatorClient,
+		network:            network,
+		platform:           platformStatus.Type,
+		tlsProfileSpec:     tlsProfileSpec,
+		tlsAdherencePolicy: apiServer.Spec.TLSAdherence,
 	}, nil
 }
 

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -10,6 +10,7 @@ import (
 	fakeconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
 	fakeoperatorclient "github.com/openshift/client-go/operator/clientset/versioned/fake"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -232,6 +233,88 @@ func TestGetDNS(t *testing.T) {
 				assert.Errorf(t, err, "error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTLSProfileFromAPIServer tests that TLS profile and adherence policy are correctly fetched from the APIServer
+func TestTLSProfileFromAPIServer(t *testing.T) {
+	tests := []struct {
+		name              string
+		tlsProfile        *oconfig.TLSSecurityProfile
+		tlsAdherence      oconfig.TLSAdherencePolicy
+		wantMinTLSVersion oconfig.TLSProtocolVersion
+		wantAdherence     oconfig.TLSAdherencePolicy
+		wantErr           bool
+	}{
+		{
+			name:              "nil profile returns intermediate defaults",
+			tlsProfile:        nil,
+			tlsAdherence:      "",
+			wantMinTLSVersion: oconfig.TLSProfiles[oconfig.TLSProfileIntermediateType].MinTLSVersion,
+			wantAdherence:     "",
+		},
+		{
+			name: "old profile type",
+			tlsProfile: &oconfig.TLSSecurityProfile{
+				Type: oconfig.TLSProfileOldType,
+			},
+			tlsAdherence:      oconfig.TLSAdherencePolicyStrictAllComponents,
+			wantMinTLSVersion: oconfig.TLSProfiles[oconfig.TLSProfileOldType].MinTLSVersion,
+			wantAdherence:     oconfig.TLSAdherencePolicyStrictAllComponents,
+		},
+		{
+			name: "modern profile type",
+			tlsProfile: &oconfig.TLSSecurityProfile{
+				Type: oconfig.TLSProfileModernType,
+			},
+			tlsAdherence:      oconfig.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+			wantMinTLSVersion: oconfig.TLSProfiles[oconfig.TLSProfileModernType].MinTLSVersion,
+			wantAdherence:     oconfig.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+		},
+		{
+			name: "custom profile with nil Custom field returns error",
+			tlsProfile: &oconfig.TLSSecurityProfile{
+				Type: oconfig.TLSProfileCustomType,
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom profile with valid spec",
+			tlsProfile: &oconfig.TLSSecurityProfile{
+				Type: oconfig.TLSProfileCustomType,
+				Custom: &oconfig.CustomTLSProfile{
+					TLSProfileSpec: oconfig.TLSProfileSpec{
+						MinTLSVersion: oconfig.VersionTLS13,
+					},
+				},
+			},
+			wantMinTLSVersion: oconfig.VersionTLS13,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiServer := &oconfig.APIServer{
+				ObjectMeta: meta.ObjectMeta{Name: "cluster"},
+				Spec: oconfig.APIServerSpec{
+					TLSSecurityProfile: tt.tlsProfile,
+					TLSAdherence:       tt.tlsAdherence,
+				},
+			}
+			fakeClient := fakeconfigclient.NewSimpleClientset(apiServer)
+
+			got, err := fakeClient.ConfigV1().APIServers().Get(context.Background(), "cluster", meta.GetOptions{})
+			require.NoError(t, err)
+
+			profileSpec, err := tlspkg.GetTLSProfileSpec(got.Spec.TLSSecurityProfile)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMinTLSVersion, profileSpec.MinTLSVersion)
+			assert.Equal(t, tt.wantAdherence, got.Spec.TLSAdherence)
 		})
 	}
 }

--- a/vendor/github.com/openshift/controller-runtime-common/LICENSE
+++ b/vendor/github.com/openshift/controller-runtime-common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecurityProfileWatcher watches the APIServer object for TLS profile changes
+// and triggers a graceful shutdown when the profile changes.
+type SecurityProfileWatcher struct {
+	client.Client
+
+	// InitialTLSProfileSpec is the TLS profile spec that was configured when the operator started.
+	InitialTLSProfileSpec configv1.TLSProfileSpec
+
+	// InitialTLSAdherencePolicy is the TLS adherence policy that was configured when the operator started.
+	InitialTLSAdherencePolicy configv1.TLSAdherencePolicy
+
+	// OnProfileChange is a function that will be called when the TLS profile changes.
+	// It receives the reconcile context, old and new TLS profile specs.
+	// This allows the caller to make decisions based on the actual profile changes.
+	//
+	// The most common use case for this callback is
+	// to trigger a graceful shutdown of the operator
+	// to make it pick up the new configuration.
+	//
+	// Example:
+	//
+	// 	// Create a context that can be cancelled when there is a need to shut down the manager.
+	//  ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	//  defer cancel()
+	//
+	//  watcher := &SecurityProfileWatcher{
+	// 	  OnProfileChange: func(ctx context.Context, old, new configv1.TLSProfileSpec) {
+	//      logger.Infof("TLS profile has changed, initiating a shutdown to reload it. %q: %+v, %q: %+v",
+	//        "old profile", old,
+	//        "new profile", new,
+	//      )
+	//      // Cancel the outer context to trigger a graceful shutdown of the manager.
+	//      cancel()
+	//    },
+	//  }
+	OnProfileChange func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec configv1.TLSProfileSpec)
+
+	// OnAdherencePolicyChange is a function that will be called when the TLS adherence policy changes.
+	OnAdherencePolicyChange func(ctx context.Context, oldTLSAdherencePolicy, newTLSAdherencePolicy configv1.TLSAdherencePolicy)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecurityProfileWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("tlssecurityprofilewatcher").
+		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
+		For(&configv1.APIServer{}, builder.WithPredicates(
+			predicate.Funcs{
+				// Only watch the "cluster" APIServer object.
+				CreateFunc: func(e event.CreateEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return e.ObjectNew.GetName() == APIServerName
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+			},
+		)).
+		// Override the default log constructor as it makes the logs very chatty.
+		WithLogConstructor(func(_ *reconcile.Request) logr.Logger {
+			return mgr.GetLogger().WithValues(
+				"controller", "tlssecurityprofilewatcher",
+			)
+		}).
+		Complete(r); err != nil {
+		return fmt.Errorf("could not set up controller for TLS security profile watcher: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile watches for changes to the APIServer TLS profile and triggers a shutdown
+// when the profile changes from the initial configuration.
+func (r *SecurityProfileWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx, "name", req.Name)
+
+	logger.V(1).Info("Reconciling APIServer TLS profile")
+	defer logger.V(1).Info("Finished reconciling APIServer TLS profile")
+
+	// Fetch the APIServer object.
+	apiServer := &configv1.APIServer{}
+	if err := r.Get(ctx, req.NamespacedName, apiServer); err != nil {
+		if apierrors.IsNotFound(err) {
+			// If the APIServer object is not found, we don't need to do anything.
+			// This could happen if the object was deleted.
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Get the current TLS profile spec.
+	currentTLSProfileSpec, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get TLS profile from APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Compare the current TLS profile spec with the initial one.
+	if tlsProfileChanged := !reflect.DeepEqual(r.InitialTLSProfileSpec, currentTLSProfileSpec); tlsProfileChanged {
+		// TLS profile has changed, invoke the callback if it is set.
+		if r.OnProfileChange != nil {
+			r.OnProfileChange(ctx, r.InitialTLSProfileSpec, currentTLSProfileSpec)
+		}
+
+		// Persist the new profile for future change detection.
+		r.InitialTLSProfileSpec = currentTLSProfileSpec
+	}
+
+	// Compare the current TLS adherence policy with the initial one.
+	if tlsAdherencePolicyChanged := r.InitialTLSAdherencePolicy != apiServer.Spec.TLSAdherence; tlsAdherencePolicyChanged {
+		// TLS adherence policy has changed, invoke the callback if it is set.
+		if r.OnAdherencePolicyChange != nil {
+			r.OnAdherencePolicyChange(ctx, r.InitialTLSAdherencePolicy, apiServer.Spec.TLSAdherence)
+		}
+
+		// Persist the new adherence policy for future change detection.
+		r.InitialTLSAdherencePolicy = apiServer.Spec.TLSAdherence
+	}
+
+	// No need to requeue, as the callback will handle further actions.
+	return ctrl.Result{}, nil
+}

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tls provides utilities for working with OpenShift TLS profiles.
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// APIServerName is the name of the APIServer resource in the cluster.
+	APIServerName = "cluster"
+)
+
+var (
+	// ErrCustomProfileNil is returned when a custom TLS profile is specified but the Custom field is nil.
+	ErrCustomProfileNil = errors.New("custom TLS profile specified but Custom field is nil")
+
+	// DefaultTLSCiphers are the default TLS ciphers for API servers.
+	DefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers //nolint:gochecknoglobals
+	// DefaultMinTLSVersion is the default minimum TLS version for API servers.
+	DefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion //nolint:gochecknoglobals
+
+	// HTTP2NextProtos are the ALPN protocols advertised when HTTP/2 is enabled,
+	// with HTTP/1.1 fallback.
+	HTTP2NextProtos = []string{"h2", "http/1.1"} //nolint:gochecknoglobals
+
+	// HTTP1NextProtos are the ALPN protocols advertised when HTTP/2 is disabled,
+	// restricting negotiation to HTTP/1.1 only. This provides defense-in-depth
+	// against HTTP/2 Rapid Reset (CVE-2023-44487, CVE-2023-39325) alongside
+	// the primary fixes in Go 1.21.3+ and golang.org/x/net v0.17.0+.
+	HTTP1NextProtos = []string{"http/1.1"} //nolint:gochecknoglobals
+)
+
+// FetchAPIServerTLSProfile fetches the TLS profile spec configured in APIServer.
+// If no profile is configured, the default profile is returned.
+func FetchAPIServerTLSProfile(ctx context.Context, k8sClient client.Client) (configv1.TLSProfileSpec, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+
+	if err := k8sClient.Get(ctx, key, apiServer); err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+	}
+
+	profile, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get TLS profile from APIServer %q: %w", key.String(), err)
+	}
+
+	return profile, nil
+}
+
+// FetchAPIServerTLSAdherencePolicy fetches the TLS adherence policy configured in APIServer.
+// If no policy is configured, the default policy is returned.
+func FetchAPIServerTLSAdherencePolicy(ctx context.Context, k8sClient client.Client) (configv1.TLSAdherencePolicy, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+
+	if err := k8sClient.Get(ctx, key, apiServer); err != nil {
+		return configv1.TLSAdherencePolicyNoOpinion, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+	}
+
+	return apiServer.Spec.TLSAdherence, nil
+}
+
+// GetTLSProfileSpec returns TLSProfileSpec for the given profile.
+// If no profile is configured, the default profile is returned.
+func GetTLSProfileSpec(profile *configv1.TLSSecurityProfile) (configv1.TLSProfileSpec, error) {
+	// Define the default profile (at the time of writing, this is the intermediate profile).
+	defaultProfile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	// If the profile is nil or the type is empty, return the default profile.
+	if profile == nil || profile.Type == "" {
+		return defaultProfile, nil
+	}
+
+	// Get the profile type.
+	profileType := profile.Type
+
+	// If the profile type is not custom, return the profile from the map.
+	if profileType != configv1.TLSProfileCustomType {
+		if tlsConfig, ok := configv1.TLSProfiles[profileType]; ok {
+			return *tlsConfig, nil
+		}
+
+		// If the profile type is not found, return the default profile.
+		return defaultProfile, nil
+	}
+
+	if profile.Custom == nil {
+		// If the custom profile is nil, return an error.
+		return configv1.TLSProfileSpec{}, ErrCustomProfileNil
+	}
+
+	// Return the custom profile spec.
+	return profile.Custom.TLSProfileSpec, nil
+}
+
+// NewTLSConfigFromProfile returns a function that configures a tls.Config based on the provided TLSProfileSpec,
+// along with any cipher names from the profile that are not supported by the library-go crypto package.
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Note: CipherSuites are only set when MinVersion is below TLS 1.3, as Go's TLS 1.3 implementation
+// does not allow configuring cipher suites - all TLS 1.3 ciphers are always enabled.
+// See: https://github.com/golang/go/issues/29349
+func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*tls.Config), unsupportedCiphers []string) {
+	minVersion := libgocrypto.TLSVersionOrDie(string(profile.MinTLSVersion))
+	cipherSuites, unsupportedCiphers := cipherCodes(profile.Ciphers)
+
+	return func(tlsConf *tls.Config) {
+		tlsConf.MinVersion = minVersion
+		// TODO: add curve preferences from profile once https://github.com/openshift/api/pull/2583 merges.
+		// tlsConf.CurvePreferences <<<<<< profile.Curves
+
+		// TLS 1.3 cipher suites are not configurable in Go (https://github.com/golang/go/issues/29349), so only set CipherSuites accordingly.
+		// TODO: revisit this once we get an answer on the best way to handle this here:
+		// https://docs.google.com/document/d/1cMc9E8psHfnoK06ntR8kHSWB8d3rMtmldhnmM4nImjs/edit?disco=AAABu_nPcYg
+		if minVersion != tls.VersionTLS13 {
+			tlsConf.CipherSuites = cipherSuites
+		}
+	}, unsupportedCiphers
+}
+
+// SetNextProtos returns a TLS configuration function that sets the ALPN
+// protocol negotiation list on a tls.Config. Empty strings are silently
+// ignored, which allows conditional protocol inclusion.
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Example:
+//
+//	// Disable HTTP/2:
+//	openshifttls.SetNextProtos("http/1.1")
+//
+//	// Enable HTTP/2 with fallback:
+//	openshifttls.SetNextProtos("h2", "http/1.1")
+//
+//	// Using the well-known protocol lists:
+//	openshifttls.SetNextProtos(openshifttls.HTTP1NextProtos...)
+//	openshifttls.SetNextProtos(openshifttls.HTTP2NextProtos...)
+func SetNextProtos(protos ...string) func(*tls.Config) {
+	var p []string
+	for _, proto := range protos {
+		if proto != "" {
+			p = append(p, proto)
+		}
+	}
+	return func(c *tls.Config) {
+		c.NextProtos = p
+	}
+}
+
+// cipherCode returns the TLS cipher code for an OpenSSL or IANA cipher name.
+// Returns 0 if the cipher is not supported.
+func cipherCode(cipher string) uint16 {
+	// First try as IANA name directly.
+	if code, err := libgocrypto.CipherSuite(cipher); err == nil {
+		return code
+	}
+
+	// Try converting from OpenSSL name to IANA name.
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites([]string{cipher})
+	if len(ianaCiphers) == 1 {
+		if code, err := libgocrypto.CipherSuite(ianaCiphers[0]); err == nil {
+			return code
+		}
+	}
+
+	// Return 0 if the cipher is not supported.
+	return 0
+}
+
+// cipherCodes converts a list of cipher names (OpenSSL or IANA format) to their uint16 codes.
+// Returns the converted codes and a list of any unsupported cipher names.
+func cipherCodes(ciphers []string) (codes []uint16, unsupportedCiphers []string) {
+	for _, cipher := range ciphers {
+		code := cipherCode(cipher)
+		if code == 0 {
+			unsupportedCiphers = append(unsupportedCiphers, cipher)
+			continue
+		}
+
+		codes = append(codes, code)
+	}
+
+	return codes, unsupportedCiphers
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stlaz
+approvers:
+  - stlaz

--- a/vendor/github.com/openshift/library-go/pkg/crypto/cert_config.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/cert_config.go
@@ -1,0 +1,225 @@
+package crypto
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// KeyPairGenerator generates a cryptographic key pair.
+type KeyPairGenerator interface {
+	GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error)
+}
+
+// NewSigningCertificate creates a CA certificate.
+// By default it creates a self-signed root CA. Use WithSigner to create an
+// intermediate CA signed by a parent CA.
+// The name parameter is used as the CommonName unless overridden with WithSubject.
+// Optional: WithSigner, WithSubject, WithLifetime (defaults to DefaultCACertificateLifetimeDuration).
+func NewSigningCertificate(name string, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCACertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	subject := pkix.Name{CommonName: name}
+	if o.subject != nil {
+		subject = *o.subject
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	if o.signer != nil {
+		// Intermediate CA signed by the provided signer.
+		authorityKeyId := o.signer.Config.Certs[0].SubjectKeyId
+		template := newSigningCertificateTemplateForDuration(subject, o.lifetime, time.Now, authorityKeyId, subjectKeyId)
+		template.SignatureAlgorithm = 0
+		template.KeyUsage = KeyUsageForPublicKey(publicKey) | x509.KeyUsageCertSign
+
+		cert, err := o.signer.SignCertificate(template, publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign certificate: %w", err)
+		}
+
+		return &TLSCertificateConfig{
+			Certs: append([]*x509.Certificate{cert}, o.signer.Config.Certs...),
+			Key:   privateKey,
+		}, nil
+	}
+
+	// Self-signed root CA. AuthorityKeyId and SubjectKeyId match.
+	template := newSigningCertificateTemplateForDuration(subject, o.lifetime, time.Now, subjectKeyId, subjectKeyId)
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey) | x509.KeyUsageCertSign
+
+	cert, err := signCertificate(template, publicKey, template, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: []*x509.Certificate{cert},
+		Key:   privateKey,
+	}, nil
+}
+
+// NewServerCertificate creates a server/serving certificate signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration), WithExtensions.
+func (ca *CA) NewServerCertificate(hostnames sets.Set[string], keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	sortedHostnames := sets.List(hostnames)
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	template := newServerCertificateTemplateForDuration(
+		pkix.Name{CommonName: sortedHostnames[0]},
+		sortedHostnames,
+		o.lifetime,
+		time.Now,
+		authorityKeyId,
+		subjectKeyId,
+	)
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	for _, fn := range o.extensionFns {
+		if err := fn(template); err != nil {
+			return nil, fmt.Errorf("failed to apply certificate extension: %w", err)
+		}
+	}
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}
+
+// NewClientCertificate creates a client certificate signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration).
+func (ca *CA) NewClientCertificate(u user.Info, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	template := NewClientCertificateTemplateForDuration(UserToSubject(u), o.lifetime, time.Now)
+	template.AuthorityKeyId = authorityKeyId
+	template.SubjectKeyId = subjectKeyId
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}
+
+// NewPeerCertificate creates a peer certificate (both server and client auth)
+// signed by this CA.
+// Optional: WithLifetime (defaults to DefaultCertificateLifetimeDuration), WithExtensions.
+func (ca *CA) NewPeerCertificate(hostnames sets.Set[string], u user.Info, keyGen KeyPairGenerator, opts ...CertificateOption) (*TLSCertificateConfig, error) {
+	o := &CertificateOptions{
+		lifetime: DefaultCertificateLifetimeDuration,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	publicKey, privateKey, err := keyGen.GenerateKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key pair: %w", err)
+	}
+	subjectKeyId, err := SubjectKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute subject key ID: %w", err)
+	}
+
+	sortedHostnames := sets.List(hostnames)
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+
+	// Start from a server certificate template for the hostnames.
+	template := newServerCertificateTemplateForDuration(
+		pkix.Name{CommonName: sortedHostnames[0]},
+		sortedHostnames,
+		o.lifetime,
+		time.Now,
+		authorityKeyId,
+		subjectKeyId,
+	)
+	// Let x509.CreateCertificate auto-detect the signature algorithm from the CA's key.
+	template.SignatureAlgorithm = 0
+	template.KeyUsage = KeyUsageForPublicKey(publicKey)
+
+	// Set subject from user info for client authentication.
+	template.Subject = UserToSubject(u)
+
+	// Enable both server and client authentication.
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+
+	for _, fn := range o.extensionFns {
+		if err := fn(template); err != nil {
+			return nil, fmt.Errorf("failed to apply certificate extension: %w", err)
+		}
+	}
+
+	cert, err := ca.SignCertificate(template, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign certificate: %w", err)
+	}
+
+	return &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{cert}, ca.Config.Certs...),
+		Key:   privateKey,
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -1,0 +1,1258 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	mathrand "math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/util/cert"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TLS configuration
+//
+// The OpenShift API defines TLS profiles using OpenSSL cipher suite names.
+// Go's crypto/tls uses IANA-standard cipher suite names (which happen to
+// match the Go constant names). This package bridges the two naming schemes:
+// OpenSSLToIANACipherSuites translates API-level OpenSSL names into the IANA
+// names that Go understands, silently dropping any cipher that Go's crypto/tls
+// cannot negotiate. This silent narrowing is by design: Go literally cannot
+// serve those ciphers, so listing them would be misleading.
+
+// goTLSVersions lists all TLS versions that Go's crypto/tls can negotiate.
+// Kept in sync with the crypto/tls package by TestConstantMaps.
+var goTLSVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// enabledTLSVersions is the subset of goTLSVersions that OpenShift allows
+// in TLS configurations. Remove an entry here (not from goTLSVersions) to
+// phase out a version while still being able to parse legacy references.
+var enabledTLSVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLSVersionToNameOrDie given a tls version as an int, return its readable name
+func TLSVersionToNameOrDie(intVal uint16) string {
+	matches := []string{}
+	for key, version := range goTLSVersions {
+		if version == intVal {
+			matches = append(matches, key)
+		}
+	}
+
+	if len(matches) == 0 {
+		panic(fmt.Sprintf("no name found for %d", intVal))
+	}
+	if len(matches) > 1 {
+		panic(fmt.Sprintf("multiple names found for %d: %v", intVal, matches))
+	}
+	return matches[0]
+}
+
+func TLSVersion(versionName string) (uint16, error) {
+	if len(versionName) == 0 {
+		return DefaultTLSVersion(), nil
+	}
+	if version, ok := goTLSVersions[versionName]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+func TLSVersionOrDie(versionName string) uint16 {
+	version, err := TLSVersion(versionName)
+	if err != nil {
+		panic(err)
+	}
+	return version
+}
+
+// GolangTLSVersions returns all TLS versions known to this Go build.
+//
+// Deprecated: Use ValidTLSVersions instead.
+func GolangTLSVersions() []string {
+	supported := []string{}
+	for k := range goTLSVersions {
+		supported = append(supported, k)
+	}
+	sort.Strings(supported)
+	return supported
+}
+
+// ValidTLSVersions returns the TLS versions that OpenShift allows in configurations.
+func ValidTLSVersions() []string {
+	validVersions := []string{}
+	for k := range enabledTLSVersions {
+		validVersions = append(validVersions, k)
+	}
+	sort.Strings(validVersions)
+	return validVersions
+}
+func DefaultTLSVersion() uint16 {
+	// Can't use SSLv3 because of POODLE and BEAST
+	// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+	// Can't use TLSv1.1 because of RC4 cipher usage
+	return tls.VersionTLS12
+}
+
+// goCipherSuites lists all cipher suites recognized by Go's crypto/tls, keyed
+// by IANA name. Kept in sync with the crypto/tls package by TestConstantMaps.
+var goCipherSuites = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
+}
+
+// openSSLToIANACiphers maps OpenSSL cipher suite names to IANA names for
+// every cipher that Go's crypto/tls can negotiate.
+// Ref: https://www.iana.org/assignments/tls-parameters/tls-parameters.xml
+// Ciphers defined in the API but absent from Go are tracked in
+// ciphersUnsupportedByGo (below) so tests detect when Go gains support.
+var openSSLToIANACiphers = map[string]string{
+	// TLS 1.3 ciphers - always negotiated by Go; not individually configurable.
+	"TLS_AES_128_GCM_SHA256":       "TLS_AES_128_GCM_SHA256",       // 0x13,0x01
+	"TLS_AES_256_GCM_SHA384":       "TLS_AES_256_GCM_SHA384",       // 0x13,0x02
+	"TLS_CHACHA20_POLY1305_SHA256": "TLS_CHACHA20_POLY1305_SHA256", // 0x13,0x03
+
+	// TLS 1.2
+	"ECDHE-ECDSA-AES128-GCM-SHA256": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",       // 0xC0,0x2B
+	"ECDHE-RSA-AES128-GCM-SHA256":   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",         // 0xC0,0x2F
+	"ECDHE-ECDSA-AES256-GCM-SHA384": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",       // 0xC0,0x2C
+	"ECDHE-RSA-AES256-GCM-SHA384":   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",         // 0xC0,0x30
+	"ECDHE-ECDSA-CHACHA20-POLY1305": "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", // 0xCC,0xA9
+	"ECDHE-RSA-CHACHA20-POLY1305":   "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",   // 0xCC,0xA8
+	"ECDHE-ECDSA-AES128-SHA256":     "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",       // 0xC0,0x23
+	"ECDHE-RSA-AES128-SHA256":       "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",         // 0xC0,0x27
+	"AES128-GCM-SHA256":             "TLS_RSA_WITH_AES_128_GCM_SHA256",               // 0x00,0x9C
+	"AES256-GCM-SHA384":             "TLS_RSA_WITH_AES_256_GCM_SHA384",               // 0x00,0x9D
+	"AES128-SHA256":                 "TLS_RSA_WITH_AES_128_CBC_SHA256",               // 0x00,0x3C
+
+	// Ciphers defined in the API but not supported by Go are listed in
+	// ciphersUnsupportedByGo below.
+
+	// TLS 1
+	"ECDHE-ECDSA-AES128-SHA": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", // 0xC0,0x09
+	"ECDHE-RSA-AES128-SHA":   "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",   // 0xC0,0x13
+	"ECDHE-ECDSA-AES256-SHA": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", // 0xC0,0x0A
+	"ECDHE-RSA-AES256-SHA":   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",   // 0xC0,0x14
+
+	// SSL 3
+	"AES128-SHA":             "TLS_RSA_WITH_AES_128_CBC_SHA",        // 0x00,0x2F
+	"AES256-SHA":             "TLS_RSA_WITH_AES_256_CBC_SHA",        // 0x00,0x35
+	"DES-CBC3-SHA":           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",       // 0x00,0x0A
+	"ECDHE-RSA-DES-CBC3-SHA": "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", // 0xC0,0x12
+}
+
+// ciphersUnsupportedByGo lists cipher suites that are defined in the OpenShift API
+// TLS profiles (from the Mozilla guidelines) but are not supported by Go's crypto/tls.
+// These are intentionally excluded from openSSLToIANACiphers and silently filtered
+// out during profile translation. The IANA names come from the IANA TLS Cipher Suite
+// Registry (https://www.iana.org/assignments/tls-parameters/) and are retained so
+// TestCiphersUnsupportedByGoAreActuallyUnsupported can detect if a future Go
+// release adds support.
+var ciphersUnsupportedByGo = map[string]string{
+	"ECDHE-ECDSA-AES256-SHA384": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+	"ECDHE-RSA-AES256-SHA384":   "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+	"AES256-SHA256":             "TLS_RSA_WITH_AES_256_CBC_SHA256",
+}
+
+// CipherSuitesToNamesOrDie given a list of cipher suites as ints, return their readable names
+func CipherSuitesToNamesOrDie(intVals []uint16) []string {
+	ret := []string{}
+	for _, intVal := range intVals {
+		ret = append(ret, CipherSuiteToNameOrDie(intVal))
+	}
+
+	return ret
+}
+
+// CipherSuiteToNameOrDie given a cipher suite as an int, return its readable name
+func CipherSuiteToNameOrDie(intVal uint16) string {
+	// The following suite ids appear twice in the cipher map (with
+	// and without the _SHA256 suffix) for the purposes of backwards
+	// compatibility. Always return the current rather than the legacy
+	// name.
+	switch intVal {
+	case tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
+		return "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+	case tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
+		return "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+	}
+
+	matches := []string{}
+	for key, version := range goCipherSuites {
+		if version == intVal {
+			matches = append(matches, key)
+		}
+	}
+
+	if len(matches) == 0 {
+		panic(fmt.Sprintf("no name found for %d", intVal))
+	}
+	if len(matches) > 1 {
+		panic(fmt.Sprintf("multiple names found for %d: %v", intVal, matches))
+	}
+	return matches[0]
+}
+
+func CipherSuite(cipherName string) (uint16, error) {
+	if cipher, ok := goCipherSuites[cipherName]; ok {
+		return cipher, nil
+	}
+
+	return 0, fmt.Errorf("unknown cipher name %q", cipherName)
+}
+
+func CipherSuitesOrDie(cipherNames []string) []uint16 {
+	if len(cipherNames) == 0 {
+		return DefaultCiphers()
+	}
+	cipherValues := []uint16{}
+	for _, cipherName := range cipherNames {
+		cipher, err := CipherSuite(cipherName)
+		if err != nil {
+			panic(err)
+		}
+		cipherValues = append(cipherValues, cipher)
+	}
+	return cipherValues
+}
+func ValidCipherSuites() []string {
+	validCipherSuites := []string{}
+	for k := range goCipherSuites {
+		validCipherSuites = append(validCipherSuites, k)
+	}
+	sort.Strings(validCipherSuites)
+	return validCipherSuites
+}
+
+// DefaultTLSProfileType is the intermediate profile type.
+const DefaultTLSProfileType = configv1.TLSProfileIntermediateType
+
+// DefaultCiphers returns the default cipher suites for TLS connections.
+//
+// RECOMMENDATION: Instead of relying on this function directly, consumers should respect
+// TLSSecurityProfile settings from one of the OpenShift API configuration resources:
+//   - For API servers: Use apiserver.config.openshift.io/cluster Spec.TLSSecurityProfile
+//   - For ingress controllers: Use operator.openshift.io/v1 IngressController Spec.TLSSecurityProfile
+//   - For kubelet: Use machineconfiguration.openshift.io/v1 KubeletConfig Spec.TLSSecurityProfile
+//
+// These API resources allow cluster administrators to choose between Old, Intermediate,
+// Modern, or Custom TLS profiles. Components should observe these settings.
+func DefaultCiphers() []uint16 {
+	// Aligned with intermediate profile of the 5.7 version of the Mozilla Server
+	// Side TLS guidelines found at: https://ssl-config.mozilla.org/guidelines/5.7.json
+	//
+	// Latest guidelines: https://ssl-config.mozilla.org/guidelines/latest.json
+	//
+	// This profile provides strong security with wide compatibility.
+	// It requires TLS 1.2+ and uses only AEAD cipher suites (GCM, ChaCha20-Poly1305)
+	// with ECDHE key exchange for perfect forward secrecy.
+	//
+	// All CBC-mode ciphers have been removed due to padding oracle vulnerabilities.
+	// All RSA key exchange ciphers have been removed due to lack of perfect forward secrecy.
+	//
+	// HTTP/2 compliance: All ciphers are compliant with RFC7540, section 9.2.
+	return []uint16{
+		// TLS 1.2 cipher suites with ECDHE + AEAD
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // required by HTTP/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+
+		// TLS 1.3 cipher suites (negotiated automatically, not configurable)
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+}
+
+// SecureTLSConfig enforces the default minimum security settings for the cluster.
+func SecureTLSConfig(config *tls.Config) *tls.Config {
+	if config.MinVersion == 0 {
+		config.MinVersion = DefaultTLSVersion()
+	}
+
+	config.PreferServerCipherSuites = true
+	if len(config.CipherSuites) == 0 {
+		config.CipherSuites = DefaultCiphers()
+	}
+	return config
+}
+
+// OpenSSLToIANACipherSuites maps input OpenSSL Cipher Suite names to their
+// IANA counterparts.
+// Ciphers that Go's crypto/tls cannot negotiate are silently dropped and
+// logged at V(4).
+func OpenSSLToIANACipherSuites(ciphers []string) []string {
+	ianaCiphers := make([]string, 0, len(ciphers))
+
+	for _, c := range ciphers {
+		ianaCipher, found := openSSLToIANACiphers[c]
+		if found {
+			ianaCiphers = append(ianaCiphers, ianaCipher)
+		} else {
+			klog.V(4).Infof("Dropping cipher %q: not supported by Go's crypto/tls", c)
+		}
+	}
+
+	return ianaCiphers
+}
+
+type TLSCertificateConfig struct {
+	Certs []*x509.Certificate
+	Key   crypto.PrivateKey
+}
+
+type TLSCARoots struct {
+	Roots []*x509.Certificate
+}
+
+func (c *TLSCertificateConfig) WriteCertConfigFile(certFile, keyFile string) error {
+	// ensure parent dir
+	if err := os.MkdirAll(filepath.Dir(certFile), os.FileMode(0755)); err != nil {
+		return err
+	}
+	certFileWriter, err := os.OpenFile(certFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyFile), os.FileMode(0755)); err != nil {
+		return err
+	}
+	keyFileWriter, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+
+	if err := writeCertificates(certFileWriter, c.Certs...); err != nil {
+		return err
+	}
+	if err := writeKeyFile(keyFileWriter, c.Key); err != nil {
+		return err
+	}
+
+	if err := certFileWriter.Close(); err != nil {
+		return err
+	}
+	if err := keyFileWriter.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *TLSCertificateConfig) WriteCertConfig(certFile, keyFile io.Writer) error {
+	if err := writeCertificates(certFile, c.Certs...); err != nil {
+		return err
+	}
+	if err := writeKeyFile(keyFile, c.Key); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *TLSCertificateConfig) GetPEMBytes() ([]byte, []byte, error) {
+	certBytes, err := EncodeCertificates(c.Certs...)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBytes, err := EncodeKey(c.Key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certBytes, keyBytes, nil
+}
+
+func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, error) {
+	if len(certFile) == 0 {
+		return nil, errors.New("certFile missing")
+	}
+	if len(keyFile) == 0 {
+		return nil, errors.New("keyFile missing")
+	}
+
+	certPEMBlock, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := cert.ParseCertsPEM(certPEMBlock)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", certFile, err)
+	}
+
+	keyPEMBlock, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	keyPairCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return nil, err
+	}
+	key := keyPairCert.PrivateKey
+
+	return &TLSCertificateConfig{certs, key}, nil
+}
+
+func GetTLSCertificateConfigFromBytes(certBytes, keyBytes []byte) (*TLSCertificateConfig, error) {
+	if len(certBytes) == 0 {
+		return nil, errors.New("certFile missing")
+	}
+	if len(keyBytes) == 0 {
+		return nil, errors.New("keyFile missing")
+	}
+
+	certs, err := cert.ParseCertsPEM(certBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error reading cert: %s", err)
+	}
+
+	keyPairCert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+	key := keyPairCert.PrivateKey
+
+	return &TLSCertificateConfig{certs, key}, nil
+}
+
+const (
+	DefaultCertificateLifetimeDuration   = time.Hour * 24 * 365 * 2 // 2 years
+	DefaultCACertificateLifetimeDuration = time.Hour * 24 * 365 * 5 // 5 years
+
+	// Default keys are 2048 bits
+	keyBits = 2048
+)
+
+type CA struct {
+	Config *TLSCertificateConfig
+
+	SerialGenerator SerialGenerator
+}
+
+// SerialGenerator is an interface for getting a serial number for the cert.  It MUST be thread-safe.
+type SerialGenerator interface {
+	Next(template *x509.Certificate) (int64, error)
+}
+
+// SerialFileGenerator returns a unique, monotonically increasing serial number and ensures the CA on disk records that value.
+type SerialFileGenerator struct {
+	SerialFile string
+
+	// lock guards access to the Serial field
+	lock   sync.Mutex
+	Serial int64
+}
+
+func NewSerialFileGenerator(serialFile string) (*SerialFileGenerator, error) {
+	// read serial file, it must already exist
+	serial, err := fileToSerial(serialFile)
+	if err != nil {
+		return nil, err
+	}
+
+	generator := &SerialFileGenerator{
+		Serial:     serial,
+		SerialFile: serialFile,
+	}
+
+	// 0 is unused and 1 is reserved for the CA itself
+	// Thus we need to guarantee that the first external call to SerialFileGenerator.Next returns 2+
+	// meaning that SerialFileGenerator.Serial must not be less than 1 (it is guaranteed to be non-negative)
+	if generator.Serial < 1 {
+		// fake a call to Next so the file stays in sync and Serial is incremented
+		if _, err := generator.Next(&x509.Certificate{}); err != nil {
+			return nil, err
+		}
+	}
+
+	return generator, nil
+}
+
+// Next returns a unique, monotonically increasing serial number and ensures the CA on disk records that value.
+func (s *SerialFileGenerator) Next(template *x509.Certificate) (int64, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// do a best effort check to make sure concurrent external writes are not occurring to the underlying serial file
+	serial, err := fileToSerial(s.SerialFile)
+	if err != nil {
+		return 0, err
+	}
+	if serial != s.Serial {
+		return 0, fmt.Errorf("serial file %s out of sync ram=%d disk=%d", s.SerialFile, s.Serial, serial)
+	}
+
+	next := s.Serial + 1
+	s.Serial = next
+
+	// Output in hex, padded to multiples of two characters for OpenSSL's sake
+	serialText := fmt.Sprintf("%X", next)
+	if len(serialText)%2 == 1 {
+		serialText = "0" + serialText
+	}
+	// always add a newline at the end to have a valid file
+	serialText += "\n"
+
+	if err := os.WriteFile(s.SerialFile, []byte(serialText), os.FileMode(0640)); err != nil {
+		return 0, err
+	}
+	return next, nil
+}
+
+func fileToSerial(serialFile string) (int64, error) {
+	serialData, err := os.ReadFile(serialFile)
+	if err != nil {
+		return 0, err
+	}
+
+	// read the file as a single hex number after stripping any whitespace
+	serial, err := strconv.ParseInt(string(bytes.TrimSpace(serialData)), 16, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	if serial < 0 {
+		return 0, fmt.Errorf("invalid negative serial %d in serial file %s", serial, serialFile)
+	}
+
+	return serial, nil
+}
+
+// RandomSerialGenerator returns a serial based on time.Now and the subject
+type RandomSerialGenerator struct {
+}
+
+func (s *RandomSerialGenerator) Next(template *x509.Certificate) (int64, error) {
+	return randomSerialNumber(), nil
+}
+
+// randomSerialNumber returns a random int64 serial number based on
+// time.Now. It is defined separately from the generator interface so
+// that the caller doesn't have to worry about an input template or
+// error - these are unnecessary when creating a random serial.
+func randomSerialNumber() int64 {
+	r := mathrand.New(mathrand.NewSource(time.Now().UTC().UnixNano()))
+	return r.Int63()
+}
+
+// EnsureCA returns a CA, whether it was created (as opposed to pre-existing), and any error
+// if serialFile is empty, a RandomSerialGenerator will be used
+func EnsureCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, bool, error) {
+	if ca, err := GetCA(certFile, keyFile, serialFile); err == nil {
+		return ca, false, err
+	}
+	ca, err := MakeSelfSignedCA(certFile, keyFile, serialFile, name, lifetime)
+	return ca, true, err
+}
+
+// if serialFile is empty, a RandomSerialGenerator will be used
+func GetCA(certFile, keyFile, serialFile string) (*CA, error) {
+	caConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		SerialGenerator: serialGenerator,
+		Config:          caConfig,
+	}, nil
+}
+
+func GetCAFromBytes(certBytes, keyBytes []byte) (*CA, error) {
+	caConfig, err := GetTLSCertificateConfigFromBytes(certBytes, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CA{
+		SerialGenerator: &RandomSerialGenerator{},
+		Config:          caConfig,
+	}, nil
+}
+
+// if serialFile is empty, a RandomSerialGenerator will be used
+func MakeSelfSignedCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, error) {
+	klog.V(2).Infof("Generating new CA for %s cert, and key in %s, %s", name, certFile, keyFile)
+
+	caConfig, err := MakeSelfSignedCAConfig(name, lifetime)
+	if err != nil {
+		return nil, err
+	}
+	if err := caConfig.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		// create / overwrite the serial file with a zero padded hex value (ending in a newline to have a valid file)
+		if err := os.WriteFile(serialFile, []byte("00\n"), 0644); err != nil {
+			return nil, err
+		}
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		SerialGenerator: serialGenerator,
+		Config:          caConfig,
+	}, nil
+}
+
+func MakeSelfSignedCAConfig(name string, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return MakeSelfSignedCAConfigForSubject(subject, lifetime)
+}
+
+func MakeSelfSignedCAConfigForSubject(subject pkix.Name, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	if lifetime <= 0 {
+		lifetime = DefaultCACertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCACertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCACertificateLifetimeDuration)
+	}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, time.Now, lifetime)
+}
+
+func MakeSelfSignedCAConfigForDuration(name string, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, time.Now, caLifetime)
+}
+
+func UnsafeMakeSelfSignedCAConfigForDurationAtTime(name string, currentTime func() time.Time, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	subject := pkix.Name{CommonName: name}
+	return makeSelfSignedCAConfigForSubjectAndDuration(subject, currentTime, caLifetime)
+}
+
+func makeSelfSignedCAConfigForSubjectAndDuration(subject pkix.Name, currentTime func() time.Time, caLifetime time.Duration) (*TLSCertificateConfig, error) {
+	// Create CA cert
+	rootcaPublicKey, rootcaPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+	// AuthorityKeyId and SubjectKeyId should match for a self-signed CA
+	authorityKeyId := publicKeyHash
+	subjectKeyId := publicKeyHash
+	rootcaTemplate := newSigningCertificateTemplateForDuration(subject, caLifetime, currentTime, authorityKeyId, subjectKeyId)
+	rootcaCert, err := signCertificate(rootcaTemplate, rootcaPublicKey, rootcaTemplate, rootcaPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	caConfig := &TLSCertificateConfig{
+		Certs: []*x509.Certificate{rootcaCert},
+		Key:   rootcaPrivateKey,
+	}
+	return caConfig, nil
+}
+
+func MakeCAConfigForDuration(name string, caLifetime time.Duration, issuer *CA) (*TLSCertificateConfig, error) {
+	// Create CA cert
+	signerPublicKey, signerPrivateKey, publicKeyHash, err := newKeyPairWithHash()
+	if err != nil {
+		return nil, err
+	}
+	authorityKeyId := issuer.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	signerTemplate := newSigningCertificateTemplateForDuration(pkix.Name{CommonName: name}, caLifetime, time.Now, authorityKeyId, subjectKeyId)
+	signerCert, err := issuer.SignCertificate(signerTemplate, signerPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	signerConfig := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{signerCert}, issuer.Config.Certs...),
+		Key:   signerPrivateKey,
+	}
+	return signerConfig, nil
+}
+
+// EnsureSubCA returns a subCA signed by the `ca`, whether it was created
+// (as opposed to pre-existing), and any error that might occur during the subCA
+// creation.
+// If serialFile is an empty string, a RandomSerialGenerator will be used.
+func (ca *CA) EnsureSubCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, bool, error) {
+	if subCA, err := GetCA(certFile, keyFile, serialFile); err == nil {
+		return subCA, false, err
+	}
+	subCA, err := ca.MakeAndWriteSubCA(certFile, keyFile, serialFile, name, lifetime)
+	return subCA, true, err
+}
+
+// MakeAndWriteSubCA returns a new sub-CA configuration. New cert/key pair is generated
+// while using this function.
+// If serialFile is an empty string, a RandomSerialGenerator will be used.
+func (ca *CA) MakeAndWriteSubCA(certFile, keyFile, serialFile, name string, lifetime time.Duration) (*CA, error) {
+	klog.V(4).Infof("Generating sub-CA certificate in %s, key in %s, serial in %s", certFile, keyFile, serialFile)
+
+	subCAConfig, err := MakeCAConfigForDuration(name, lifetime, ca)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := subCAConfig.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return nil, err
+	}
+
+	var serialGenerator SerialGenerator
+	if len(serialFile) > 0 {
+		// create / overwrite the serial file with a zero padded hex value (ending in a newline to have a valid file)
+		if err := os.WriteFile(serialFile, []byte("00\n"), 0644); err != nil {
+			return nil, err
+		}
+
+		serialGenerator, err = NewSerialFileGenerator(serialFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		serialGenerator = &RandomSerialGenerator{}
+	}
+
+	return &CA{
+		Config:          subCAConfig,
+		SerialGenerator: serialGenerator,
+	}, nil
+}
+
+func (ca *CA) EnsureServerCert(certFile, keyFile string, hostnames sets.Set[string], lifetime time.Duration) (*TLSCertificateConfig, bool, error) {
+	certConfig, err := GetServerCert(certFile, keyFile, hostnames)
+	if err != nil {
+		certConfig, err = ca.MakeAndWriteServerCert(certFile, keyFile, hostnames, lifetime)
+		return certConfig, true, err
+	}
+
+	return certConfig, false, nil
+}
+
+func GetServerCert(certFile, keyFile string, hostnames sets.Set[string]) (*TLSCertificateConfig, error) {
+	server, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	cert := server.Certs[0]
+	certNames := sets.New[string]()
+	for _, ip := range cert.IPAddresses {
+		certNames.Insert(ip.String())
+	}
+	certNames.Insert(cert.DNSNames...)
+	if hostnames.Equal(certNames) {
+		klog.V(4).Infof("Found existing server certificate in %s", certFile)
+		return server, nil
+	}
+
+	return nil, fmt.Errorf("existing server certificate in %s does not match required hostnames", certFile)
+}
+
+func (ca *CA) MakeAndWriteServerCert(certFile, keyFile string, hostnames sets.Set[string], lifetime time.Duration) (*TLSCertificateConfig, error) {
+	klog.V(4).Infof("Generating server certificate in %s, key in %s", certFile, keyFile)
+
+	server, err := ca.MakeServerCert(hostnames, lifetime)
+	if err != nil {
+		return nil, err
+	}
+	if err := server.WriteCertConfigFile(certFile, keyFile); err != nil {
+		return server, err
+	}
+	return server, nil
+}
+
+// CertificateExtensionFunc is passed a certificate that it may extend, or return an error
+// if the extension attempt failed.
+type CertificateExtensionFunc func(*x509.Certificate) error
+
+func (ca *CA) MakeServerCert(hostnames sets.Set[string], lifetime time.Duration, fns ...CertificateExtensionFunc) (*TLSCertificateConfig, error) {
+	serverPublicKey, serverPrivateKey, publicKeyHash, _ := newKeyPairWithHash()
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	serverTemplate := newServerCertificateTemplate(pkix.Name{CommonName: sets.List(hostnames)[0]}, sets.List(hostnames), lifetime, time.Now, authorityKeyId, subjectKeyId)
+	for _, fn := range fns {
+		if err := fn(serverTemplate); err != nil {
+			return nil, err
+		}
+	}
+	serverCrt, err := ca.SignCertificate(serverTemplate, serverPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	server := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{serverCrt}, ca.Config.Certs...),
+		Key:   serverPrivateKey,
+	}
+	return server, nil
+}
+
+func (ca *CA) MakeServerCertForDuration(hostnames sets.Set[string], lifetime time.Duration, fns ...CertificateExtensionFunc) (*TLSCertificateConfig, error) {
+	serverPublicKey, serverPrivateKey, publicKeyHash, _ := newKeyPairWithHash()
+	authorityKeyId := ca.Config.Certs[0].SubjectKeyId
+	subjectKeyId := publicKeyHash
+	serverTemplate := newServerCertificateTemplateForDuration(pkix.Name{CommonName: sets.List(hostnames)[0]}, sets.List(hostnames), lifetime, time.Now, authorityKeyId, subjectKeyId)
+	for _, fn := range fns {
+		if err := fn(serverTemplate); err != nil {
+			return nil, err
+		}
+	}
+	serverCrt, err := ca.SignCertificate(serverTemplate, serverPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	server := &TLSCertificateConfig{
+		Certs: append([]*x509.Certificate{serverCrt}, ca.Config.Certs...),
+		Key:   serverPrivateKey,
+	}
+	return server, nil
+}
+
+func (ca *CA) EnsureClientCertificate(certFile, keyFile string, u user.Info, lifetime time.Duration) (*TLSCertificateConfig, bool, error) {
+	certConfig, err := GetClientCertificate(certFile, keyFile, u)
+	if err != nil {
+		certConfig, err = ca.MakeClientCertificate(certFile, keyFile, u, lifetime)
+		return certConfig, true, err // true indicates we wrote the files.
+	}
+	return certConfig, false, nil
+}
+
+func GetClientCertificate(certFile, keyFile string, u user.Info) (*TLSCertificateConfig, error) {
+	certConfig, err := GetTLSCertificateConfig(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if subject := certConfig.Certs[0].Subject; subjectChanged(subject, UserToSubject(u)) {
+		return nil, fmt.Errorf("existing client certificate in %s was issued for a different Subject (%s)",
+			certFile, subject)
+	}
+
+	return certConfig, nil
+}
+
+func subjectChanged(existing, expected pkix.Name) bool {
+	sort.Strings(existing.Organization)
+	sort.Strings(expected.Organization)
+
+	return existing.CommonName != expected.CommonName ||
+		existing.SerialNumber != expected.SerialNumber ||
+		!reflect.DeepEqual(existing.Organization, expected.Organization)
+}
+
+func (ca *CA) MakeClientCertificate(certFile, keyFile string, u user.Info, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	klog.V(4).Infof("Generating client cert in %s and key in %s", certFile, keyFile)
+	// ensure parent dirs
+	if err := os.MkdirAll(filepath.Dir(certFile), os.FileMode(0755)); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyFile), os.FileMode(0755)); err != nil {
+		return nil, err
+	}
+
+	clientPublicKey, clientPrivateKey, _ := NewKeyPair()
+	clientTemplate := NewClientCertificateTemplate(UserToSubject(u), lifetime, time.Now)
+	clientCrt, err := ca.SignCertificate(clientTemplate, clientPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certData, err := EncodeCertificates(clientCrt)
+	if err != nil {
+		return nil, err
+	}
+	keyData, err := EncodeKey(clientPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = os.WriteFile(certFile, certData, os.FileMode(0644)); err != nil {
+		return nil, err
+	}
+	if err = os.WriteFile(keyFile, keyData, os.FileMode(0600)); err != nil {
+		return nil, err
+	}
+
+	return GetTLSCertificateConfig(certFile, keyFile)
+}
+
+func (ca *CA) MakeClientCertificateForDuration(u user.Info, lifetime time.Duration) (*TLSCertificateConfig, error) {
+	clientPublicKey, clientPrivateKey, _ := NewKeyPair()
+	clientTemplate := NewClientCertificateTemplateForDuration(UserToSubject(u), lifetime, time.Now)
+	clientCrt, err := ca.SignCertificate(clientTemplate, clientPublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	certData, err := EncodeCertificates(clientCrt)
+	if err != nil {
+		return nil, err
+	}
+	keyData, err := EncodeKey(clientPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetTLSCertificateConfigFromBytes(certData, keyData)
+}
+
+type sortedForDER []string
+
+func (s sortedForDER) Len() int {
+	return len(s)
+}
+func (s sortedForDER) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortedForDER) Less(i, j int) bool {
+	l1 := len(s[i])
+	l2 := len(s[j])
+	if l1 == l2 {
+		return s[i] < s[j]
+	}
+	return l1 < l2
+}
+
+func UserToSubject(u user.Info) pkix.Name {
+	// Ok we are going to order groups in a peculiar way here to workaround a
+	// 2 bugs, 1 in golang (https://github.com/golang/go/issues/24254) which
+	// incorrectly encodes Multivalued RDNs and another in GNUTLS clients
+	// which are too picky (https://gitlab.com/gnutls/gnutls/issues/403)
+	// and try to "correct" this issue when reading client certs.
+	//
+	// This workaround should be killed once Golang's pkix module is fixed to
+	// generate a correct DER encoding.
+	//
+	// The workaround relies on the fact that the first octect that differs
+	// between the encoding of two group RDNs will end up being the encoded
+	// length which is directly related to the group name's length. So we'll
+	// sort such that shortest names come first.
+	ugroups := u.GetGroups()
+	groups := make([]string, len(ugroups))
+	copy(groups, ugroups)
+	sort.Sort(sortedForDER(groups))
+
+	return pkix.Name{
+		CommonName:   u.GetName(),
+		SerialNumber: u.GetUID(),
+		Organization: groups,
+	}
+}
+
+func (ca *CA) SignCertificate(template *x509.Certificate, requestKey crypto.PublicKey) (*x509.Certificate, error) {
+	// Increment and persist serial
+	serial, err := ca.SerialGenerator.Next(template)
+	if err != nil {
+		return nil, err
+	}
+	template.SerialNumber = big.NewInt(serial)
+	return signCertificate(template, requestKey, ca.Config.Certs[0], ca.Config.Key)
+}
+
+func NewKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	return newRSAKeyPair()
+}
+
+func newKeyPairWithHash() (crypto.PublicKey, crypto.PrivateKey, []byte, error) {
+	publicKey, privateKey, err := newRSAKeyPair()
+	var publicKeyHash []byte
+	if err == nil {
+		hash := sha1.New()
+		hash.Write(publicKey.N.Bytes())
+		publicKeyHash = hash.Sum(nil)
+	}
+	return publicKey, privateKey, publicKeyHash, err
+}
+
+func newRSAKeyPair() (*rsa.PublicKey, *rsa.PrivateKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, keyBits)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+// Can be used for CA or intermediate signing certs
+func newSigningCertificateTemplateForDuration(subject pkix.Name, caLifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore: currentTime().Add(-1 * time.Second),
+		NotAfter:  currentTime().Add(caLifetime),
+
+		// Specify a random serial number to avoid the same issuer+serial
+		// number referring to different certs in a chain of trust if the
+		// signing certificate is ever rotated.
+		SerialNumber: big.NewInt(randomSerialNumber()),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+}
+
+// Can be used for ListenAndServeTLS
+func newServerCertificateTemplate(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	if lifetime <= 0 {
+		lifetime = DefaultCertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeDuration)
+	}
+
+	return newServerCertificateTemplateForDuration(subject, hosts, lifetime, currentTime, authorityKeyId, subjectKeyId)
+}
+
+// Can be used for ListenAndServeTLS
+func newServerCertificateTemplateForDuration(subject pkix.Name, hosts []string, lifetime time.Duration, currentTime func() time.Time, authorityKeyId, subjectKeyId []byte) *x509.Certificate {
+	template := &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    currentTime().Add(-1 * time.Second),
+		NotAfter:     currentTime().Add(lifetime),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+
+		AuthorityKeyId: authorityKeyId,
+		SubjectKeyId:   subjectKeyId,
+	}
+
+	template.IPAddresses, template.DNSNames = IPAddressesDNSNames(hosts)
+
+	return template
+}
+
+func IPAddressesDNSNames(hosts []string) ([]net.IP, []string) {
+	ips := []net.IP{}
+	dns := []string{}
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			ips = append(ips, ip)
+		} else {
+			dns = append(dns, host)
+		}
+	}
+
+	// Include IP addresses as DNS subjectAltNames in the cert as well, for the sake of Python, Windows (< 10), and unnamed other libraries
+	// Ensure these technically invalid DNS subjectAltNames occur after the valid ones, to avoid triggering cert errors in Firefox
+	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1148766
+	for _, ip := range ips {
+		dns = append(dns, ip.String())
+	}
+
+	return ips, dns
+}
+
+func CertsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
+	ok := false
+	certs := []*x509.Certificate{}
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return certs, err
+		}
+
+		certs = append(certs, cert)
+		ok = true
+	}
+
+	if !ok {
+		return certs, errors.New("could not read any certificates")
+	}
+	return certs, nil
+}
+
+// Can be used as a certificate in http.Transport TLSClientConfig
+func NewClientCertificateTemplate(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
+	if lifetime <= 0 {
+		lifetime = DefaultCertificateLifetimeDuration
+		fmt.Fprintf(os.Stderr, "Validity period of the certificate for %q is unset, resetting to %s!\n", subject.CommonName, lifetime.String())
+	}
+
+	if lifetime > DefaultCertificateLifetimeDuration {
+		warnAboutCertificateLifeTime(subject.CommonName, DefaultCertificateLifetimeDuration)
+	}
+
+	return NewClientCertificateTemplateForDuration(subject, lifetime, currentTime)
+}
+
+// Can be used as a certificate in http.Transport TLSClientConfig
+func NewClientCertificateTemplateForDuration(subject pkix.Name, lifetime time.Duration, currentTime func() time.Time) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: subject,
+
+		SignatureAlgorithm: x509.SHA256WithRSA,
+
+		NotBefore:    currentTime().Add(-1 * time.Second),
+		NotAfter:     currentTime().Add(lifetime),
+		SerialNumber: big.NewInt(1),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+}
+
+func warnAboutCertificateLifeTime(name string, defaultLifetimeDuration time.Duration) {
+	defaultLifetimeInYears := defaultLifetimeDuration / 365 / 24
+	fmt.Fprintf(os.Stderr, "WARNING: Validity period of the certificate for %q is greater than %d years!\n", name, defaultLifetimeInYears)
+	fmt.Fprintln(os.Stderr, "WARNING: By security reasons it is strongly recommended to change this period and make it smaller!")
+}
+
+func signCertificate(template *x509.Certificate, requestKey crypto.PublicKey, issuer *x509.Certificate, issuerKey crypto.PrivateKey) (*x509.Certificate, error) {
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuer, requestKey, issuerKey)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) != 1 {
+		return nil, errors.New("expected a single certificate")
+	}
+	return certs[0], nil
+}
+
+func EncodeCertificates(certs ...*x509.Certificate) ([]byte, error) {
+	b := bytes.Buffer{}
+	for _, cert := range certs {
+		if err := pem.Encode(&b, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return []byte{}, err
+		}
+	}
+	return b.Bytes(), nil
+}
+func EncodeKey(key crypto.PrivateKey) ([]byte, error) {
+	b := bytes.Buffer{}
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		keyBytes, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			return []byte{}, err
+		}
+		if err := pem.Encode(&b, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}); err != nil {
+			return b.Bytes(), err
+		}
+	case *rsa.PrivateKey:
+		if err := pem.Encode(&b, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errors.New("unrecognized key type")
+
+	}
+	return b.Bytes(), nil
+}
+
+func writeCertificates(f io.Writer, certs ...*x509.Certificate) error {
+	bytes, err := EncodeCertificates(certs...)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+func writeKeyFile(f io.Writer, key crypto.PrivateKey) error {
+	bytes, err := EncodeKey(key)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/keygen.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/keygen.go
@@ -1,0 +1,118 @@
+package crypto
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+)
+
+// KeyAlgorithm identifies the key generation algorithm.
+type KeyAlgorithm string
+
+const (
+	// RSAKeyAlgorithm specifies RSA key generation.
+	RSAKeyAlgorithm KeyAlgorithm = "RSA"
+	// ECDSAKeyAlgorithm specifies ECDSA key generation.
+	ECDSAKeyAlgorithm KeyAlgorithm = "ECDSA"
+)
+
+// ECDSACurve identifies a named ECDSA curve.
+type ECDSACurve string
+
+const (
+	// P256 specifies the NIST P-256 curve (secp256r1), providing 128-bit security.
+	P256 ECDSACurve = "P256"
+	// P384 specifies the NIST P-384 curve (secp384r1), providing 192-bit security.
+	P384 ECDSACurve = "P384"
+	// P521 specifies the NIST P-521 curve (secp521r1), providing 256-bit security.
+	P521 ECDSACurve = "P521"
+)
+
+// RSAKeyPairGenerator generates RSA key pairs.
+type RSAKeyPairGenerator struct {
+	// Bits is the RSA key size in bits. Must be >= 2048.
+	Bits int
+}
+
+func (g RSAKeyPairGenerator) GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	bits := g.Bits
+	if bits == 0 {
+		bits = keyBits
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+// ECDSAKeyPairGenerator generates ECDSA key pairs.
+type ECDSAKeyPairGenerator struct {
+	// Curve is the named ECDSA curve.
+	Curve ECDSACurve
+}
+
+func (g ECDSAKeyPairGenerator) GenerateKeyPair() (crypto.PublicKey, crypto.PrivateKey, error) {
+	curve, err := g.ellipticCurve()
+	if err != nil {
+		return nil, nil, err
+	}
+	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &privateKey.PublicKey, privateKey, nil
+}
+
+func (g ECDSAKeyPairGenerator) ellipticCurve() (elliptic.Curve, error) {
+	switch g.Curve {
+	case P256:
+		return elliptic.P256(), nil
+	case P384:
+		return elliptic.P384(), nil
+	case P521:
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unsupported ECDSA curve: %q", g.Curve)
+	}
+}
+
+// KeyUsageForPublicKey returns the x509.KeyUsage flags appropriate for the
+// given public key type. ECDSA keys use DigitalSignature only; RSA keys also
+// include KeyEncipherment.
+func KeyUsageForPublicKey(pub crypto.PublicKey) x509.KeyUsage {
+	switch pub.(type) {
+	case *ecdsa.PublicKey:
+		return x509.KeyUsageDigitalSignature
+	default:
+		return x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	}
+}
+
+// SubjectKeyIDFromPublicKey computes a truncated SHA-256 hash suitable for
+// use as a certificate SubjectKeyId from any supported public key type.
+// This uses the first 160 bits of the SHA-256 hash per RFC 7093, consistent
+// with the Go standard library since Go 1.25 (go.dev/issue/71746) and
+// Let's Encrypt. Prior Go versions used SHA-1 which is not FIPS-compatible.
+func SubjectKeyIDFromPublicKey(pub crypto.PublicKey) ([]byte, error) {
+	var rawBytes []byte
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		rawBytes = pub.N.Bytes()
+	case *ecdsa.PublicKey:
+		ecdhKey, err := pub.ECDH()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert ECDSA public key: %w", err)
+		}
+		rawBytes = ecdhKey.Bytes()
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", pub)
+	}
+	hash := sha256.Sum256(rawBytes)
+	return hash[:20], nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/options.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/options.go
@@ -1,0 +1,49 @@
+package crypto
+
+import (
+	"crypto/x509/pkix"
+	"time"
+)
+
+// CertificateOptions holds optional configuration collected from functional options.
+type CertificateOptions struct {
+	lifetime     time.Duration
+	subject      *pkix.Name
+	extensionFns []CertificateExtensionFunc
+	signer       *CA
+}
+
+// CertificateOption is a functional option for certificate creation.
+type CertificateOption func(*CertificateOptions)
+
+// WithLifetime sets the certificate lifetime duration.
+func WithLifetime(d time.Duration) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.lifetime = d
+	}
+}
+
+// WithSubject overrides the certificate subject. For signing certificates,
+// this overrides the default subject derived from the name parameter.
+func WithSubject(s pkix.Name) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.subject = &s
+	}
+}
+
+// WithSigner specifies a CA to sign the certificate. When used with
+// NewSigningCertificate, this creates an intermediate CA signed by the
+// given CA instead of a self-signed root CA.
+func WithSigner(ca *CA) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.signer = ca
+	}
+}
+
+// WithExtensions adds certificate extension functions that are called
+// to modify the certificate template before signing.
+func WithExtensions(fns ...CertificateExtensionFunc) CertificateOption {
+	return func(o *CertificateOptions) {
+		o.extensionFns = append(o.extensionFns, fns...)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/rotation.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/rotation.go
@@ -1,0 +1,20 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+// FilterExpiredCerts checks are all certificates in the bundle valid, i.e. they have not expired.
+// The function returns new bundle with only valid certificates or error if no valid certificate is found.
+func FilterExpiredCerts(certs ...*x509.Certificate) []*x509.Certificate {
+	currentTime := time.Now()
+	var validCerts []*x509.Certificate
+	for _, c := range certs {
+		if c.NotAfter.After(currentTime) {
+			validCerts = append(validCerts, c)
+		}
+	}
+
+	return validCerts
+}

--- a/vendor/github.com/openshift/library-go/pkg/crypto/tls_adherence.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/tls_adherence.go
@@ -1,0 +1,23 @@
+package crypto
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ShouldHonorClusterTLSProfile returns true if the component should honor the
+// cluster-wide TLS security profile settings from apiserver.config.openshift.io/cluster.
+//
+// When this returns true (StrictAllComponents mode), components must honor the
+// cluster-wide TLS profile unless they have a component-specific TLS configuration
+// that overrides it.
+//
+// Unknown enum values are treated as StrictAllComponents for forward compatibility
+// and to default to the more secure behavior.
+func ShouldHonorClusterTLSProfile(tlsAdherence configv1.TLSAdherencePolicy) bool {
+	switch tlsAdherence {
+	case configv1.TLSAdherencePolicyNoOpinion, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly:
+		return false
+	default:
+		return true
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -351,8 +351,12 @@ github.com/openshift/client-go/route/applyconfigurations/internal
 github.com/openshift/client-go/route/applyconfigurations/route/v1
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
+# github.com/openshift/controller-runtime-common v0.0.0-20260804161605-f9e4228f21e6
+## explicit; go 1.26.0
+github.com/openshift/controller-runtime-common/pkg/tls
 # github.com/openshift/library-go v0.0.0-20260729082949-ed1b43415e01
 ## explicit; go 1.26.0
+github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/image/imageutil
 github.com/openshift/library-go/pkg/image/internal/digest
 github.com/openshift/library-go/pkg/image/internal/reference


### PR DESCRIPTION
Add TLS strict obedience for PQC readiness
Fetch TLS configuration from cluster APIServer and apply to metrics server. 
Watch for TLS profile changes and restart pod to reload config.
Uses SecurityProfileWatcher from controller-runtime-common following the pattern from machine-api-operator. Satisfies OpenShift 5.0 TLS.
Strict Obedience requirement for centralized TLS management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the operator’s metrics server with the cluster’s TLS security profile.
  - Added automatic detection of TLS configuration changes, enabling updated settings after restart.
  - Startup logs now report whether TLS enforcement is active.

- **Bug Fixes**
  - Improved handling and reporting of unsupported TLS cipher suites and cluster configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->