### PR TITLE
WINC-2046: Adds log file to windows-exporter

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -32,9 +32,13 @@ const (
 // will be enabled for services that support it.
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoint string, vxlanPort string,
 	platform config.PlatformType, debug bool) (*servicescm.Data, error) {
+	windowsExporterLogLevel := "info"
+	if debug {
+		windowsExporterLogLevel = "debug"
+	}
 	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
-		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
-		windows.WindowsExporterPath, windows.TLSConfPath)
+		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s --log.level %s --log.file %s",
+		windows.WindowsExporterPath, windows.TLSConfPath, windowsExporterLogLevel, windows.WindowsExporterLogPath)
 	kubeletConfiguration, err := getKubeletServiceConfiguration(kubeletArgsFromIgnition, debug, platform)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine kubelet service configuration spec: %w", err)

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -45,6 +45,57 @@ func TestGetHostnameCmd(t *testing.T) {
 	}
 }
 
+func TestWindowsExporterConfiguration(t *testing.T) {
+	tests := []struct {
+		name                string
+		debug               bool
+		expectedCmdContains []string
+	}{
+		{
+			name:  "Default logging",
+			debug: false,
+			expectedCmdContains: []string{
+				windows.WindowsExporterPath,
+				"--web.config.file " + windows.TLSConfPath,
+				"--log.level info",
+				"--log.file " + windows.WindowsExporterLogPath,
+			},
+		},
+		{
+			name:  "Debug logging enabled",
+			debug: true,
+			expectedCmdContains: []string{
+				windows.WindowsExporterPath,
+				"--web.config.file " + windows.TLSConfPath,
+				"--log.level debug",
+				"--log.file " + windows.WindowsExporterLogPath,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := GenerateManifest(nil, "https://api-server.endpoint.local:6443", "",
+				config.AWSPlatformType, test.debug)
+			require.NoError(t, err, "error generating services manifest")
+
+			var command string
+			for _, service := range data.Services {
+				if service.Name == windows.WindowsExporterServiceName {
+					command = service.Command
+					break
+				}
+			}
+			require.NotEmpty(t, command, "windows_exporter service not found in generated manifest")
+
+			for _, expectedStr := range test.expectedCmdContains {
+				assert.Contains(t, command, expectedStr,
+					"Command should contain: %s\nActual command: %s", expectedStr, command)
+			}
+		})
+	}
+}
+
 func TestHybridOverlayConfiguration(t *testing.T) {
 	tests := []struct {
 		name                   string

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -81,6 +81,10 @@ const (
 	wicdPath = K8sDir + "\\windows-instance-config-daemon.exe"
 	// WindowsExporterPath is the location of the windows_exporter.exe
 	WindowsExporterPath = K8sDir + "\\windows_exporter.exe"
+	// windowsExporterLogDir is the remote windows_exporter log directory
+	windowsExporterLogDir = logDir + "\\windows_exporter"
+	// WindowsExporterLogPath is the location of the windows_exporter log file
+	WindowsExporterLogPath = windowsExporterLogDir + "\\windows_exporter.log"
 	// NetworkConfScriptPath is the location of the network configuration script
 	NetworkConfScriptPath = remoteDir + "\\network-conf.ps1"
 	// AzureCloudNodeManagerPath is the location of the azure-cloud-node-manager.exe
@@ -188,6 +192,7 @@ var (
 		HybridOverlayLogDir,
 		ContainerdDir,
 		containerdLogDir,
+		windowsExporterLogDir,
 		ContainerdConfigDir,
 		podManifestDirectory,
 		K8sDir,

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -27,6 +27,8 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
 		"csi-proxy/csi-proxy.log",
+	}
+	optionalLogs := []string{
 		"windows_exporter/windows_exporter.log",
 	}
 	nodeArtifacts := filepath.Join(tc.artifactDir, "nodes")
@@ -54,6 +56,9 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 				})
 				assert.NoError(t, err)
 			})
+		}
+		for _, file := range optionalLogs {
+			_ = retrieveLog(node.GetName(), file, nodeDir)
 		}
 	}
 }

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -27,6 +27,7 @@ func (tc *testContext) testNodeLogs(t *testing.T) {
 		"containerd/containerd.log",
 		"wicd/windows-instance-config-daemon.exe.INFO",
 		"csi-proxy/csi-proxy.log",
+		"windows_exporter/windows_exporter.log",
 	}
 	nodeArtifacts := filepath.Join(tc.artifactDir, "nodes")
 	for _, node := range gc.allNodes() {


### PR DESCRIPTION
This allows windows-exporter to use a log file, and use the globally configurable log files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows exporter services now support configurable logging levels, using detailed debug logging when debug mode is enabled and standard informational logging otherwise.
  * Exporter logs are written to a dedicated log file for easier troubleshooting and monitoring.

* **Bug Fixes**
  * Windows exporter logs are now included in required system log collection, improving diagnostic coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->