### PR TITLE
[WINC-1979] Implement log rotation for windows-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,11 @@ The log rotation functionality is disabled by default, causing log files to grow
 Managed Windows services with log rotation capabilities:
 - kubelet
 - kube-proxy
+- windows_exporter
 
 Not yet supported:
 - containerd
 - csi-proxy
-- windows_exporter
 - hybrid-overlay-node
 - azure-cloud-node-manager
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -32,9 +32,15 @@ const (
 // will be enabled for services that support it.
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoint string, vxlanPort string,
 	platform config.PlatformType, debug bool) (*servicescm.Data, error) {
-	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
-		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
-		windows.WindowsExporterPath, windows.TLSConfPath)
+	windowsExporterLogLevel := "info"
+	if debug {
+		windowsExporterLogLevel = "debug"
+	}
+	windowsExporterServiceCommand := logconfig.GetKubeLogRunnerCmd(windows.KubeLogRunnerPath,
+		windows.WindowsExporterPath, windows.WindowsExporterLogPath)
+	windowsExporterServiceCommand = fmt.Sprintf("%s --collectors.enabled "+
+		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s --log.level %s --log.file stdout",
+		windowsExporterServiceCommand, windows.TLSConfPath, windowsExporterLogLevel)
 	kubeletConfiguration, err := getKubeletServiceConfiguration(kubeletArgsFromIgnition, debug, platform)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine kubelet service configuration spec: %w", err)

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
@@ -41,6 +42,79 @@ func TestGetHostnameCmd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := getHostnameCmd(test.platformType)
 			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestWindowsExporterConfiguration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		debug                  bool
+		expectedCmdContains    []string
+		expectedCmdNotContains []string
+	}{
+		{
+			name:  "default log level with kube-log-runner wrapping",
+			debug: false,
+			expectedCmdContains: []string{
+				windows.KubeLogRunnerPath,
+				"-log-file=" + windows.WindowsExporterLogPath,
+				windows.WindowsExporterPath,
+				"--collectors.enabled",
+				"--web.config.file " + windows.TLSConfPath,
+				"--log.level info",
+				"--log.file stdout",
+			},
+			expectedCmdNotContains: []string{
+				"--log.level debug",
+			},
+		},
+		{
+			name:  "debug log level with kube-log-runner wrapping",
+			debug: true,
+			expectedCmdContains: []string{
+				windows.KubeLogRunnerPath,
+				"-log-file=" + windows.WindowsExporterLogPath,
+				windows.WindowsExporterPath,
+				"--collectors.enabled",
+				"--web.config.file " + windows.TLSConfPath,
+				"--log.level debug",
+				"--log.file stdout",
+			},
+			expectedCmdNotContains: []string{
+				"--log.level info",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := GenerateManifest(map[string]string{}, "https://api:6443", "", "", test.debug)
+			require.NoError(t, err)
+
+			var windowsExporterSvc *servicescm.Service
+			for i := range result.Services {
+				if result.Services[i].Name == windows.WindowsExporterServiceName {
+					windowsExporterSvc = &result.Services[i]
+					break
+				}
+			}
+			require.NotNil(t, windowsExporterSvc, "windows_exporter service not found in manifest")
+
+			assert.Equal(t, uint(2), windowsExporterSvc.Priority)
+			assert.False(t, windowsExporterSvc.Bootstrap)
+			assert.Nil(t, windowsExporterSvc.Dependencies)
+			assert.Nil(t, windowsExporterSvc.NodeVariablesInCommand)
+			assert.Nil(t, windowsExporterSvc.PowershellPreScripts)
+
+			for _, expected := range test.expectedCmdContains {
+				assert.Contains(t, windowsExporterSvc.Command, expected,
+					"Command should contain: %s\nActual command: %s", expected, windowsExporterSvc.Command)
+			}
+			for _, unexpected := range test.expectedCmdNotContains {
+				assert.NotContains(t, windowsExporterSvc.Command, unexpected,
+					"Command should not contain: %s\nActual command: %s", unexpected, windowsExporterSvc.Command)
+			}
 		})
 	}
 }

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -81,6 +81,10 @@ const (
 	wicdPath = K8sDir + "\\windows-instance-config-daemon.exe"
 	// WindowsExporterPath is the location of the windows_exporter.exe
 	WindowsExporterPath = K8sDir + "\\windows_exporter.exe"
+	// windowsExporterLogDir is the remote windows_exporter log directory
+	windowsExporterLogDir = logDir + "\\windows_exporter"
+	// WindowsExporterLogPath is the location of the windows_exporter log file
+	WindowsExporterLogPath = windowsExporterLogDir + "\\windows_exporter.log"
 	// NetworkConfScriptPath is the location of the network configuration script
 	NetworkConfScriptPath = remoteDir + "\\network-conf.ps1"
 	// AzureCloudNodeManagerPath is the location of the azure-cloud-node-manager.exe
@@ -188,6 +192,7 @@ var (
 		HybridOverlayLogDir,
 		ContainerdDir,
 		containerdLogDir,
+		windowsExporterLogDir,
 		ContainerdConfigDir,
 		podManifestDirectory,
 		K8sDir,


### PR DESCRIPTION
Adds log rotation for windows-exporter 

This allows windows-exporter logs to be managed by kube-log-runner, and rotated automatically. 