### PR TITLE
WINC-1953: Add OCP-89616 log rotation verification test to OTE

### DIFF
--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -25,7 +25,6 @@ var (
 	iaasPlatform         string
 	windowsNodeLabel     = "kubernetes.io/os=windows"
 	linuxNodeLabel       = "kubernetes.io/os=linux"
-	windowsDebugImage    = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 
 	machineLabel = "machine.openshift.io/os-id=Windows"
 )
@@ -309,19 +308,6 @@ func isBYOH(oc *exutil.CLI, nodeName string) bool {
 	return err == nil && strings.TrimSpace(byohLabel) == "true"
 }
 
-func getNodeNameFromIP(oc *exutil.CLI, nodeIP string) string {
-	goTpl := fmt.Sprintf(
-		`{{range .items}}{{$name := .metadata.name}}{{range .status.addresses}}`+
-			`{{if and (eq .type "InternalIP") (eq .address "%s")}}{{$name}}{{end}}`+
-			`{{end}}{{end}}`, nodeIP)
-	nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-		"nodes", "-o=go-template="+goTpl).Output()
-	o.Expect(err).NotTo(o.HaveOccurred(), "failed to resolve node name for IP %s", nodeIP)
-	nodeName = strings.TrimSpace(nodeName)
-	o.Expect(nodeName).NotTo(o.BeEmpty(), "no node found with InternalIP %s", nodeIP)
-	return nodeName
-}
-
 func waitWindowsNodesReady(oc *exutil.CLI, expectedCount int, timeout time.Duration) {
 	pollErr := wait.Poll(10*time.Second, timeout, func() (bool, error) {
 		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
@@ -344,24 +330,39 @@ func waitWindowsNodesReady(oc *exutil.CLI, expectedCount int, timeout time.Durat
 	compat_otp.AssertWaitPollNoErr(pollErr, fmt.Sprintf("timed out waiting for %d Windows nodes to be Ready after %v", expectedCount, timeout))
 }
 
-func runDebugNodePS(oc *exutil.CLI, nodeName, image, psCommand string) (string, error) {
-	output, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args(
-		"node/"+nodeName,
-		"-n", wmcoNamespace,
-		"--image="+image,
-		"--", "pwsh", "-Command", psCommand).Output()
+// getLatestServicesCMData returns the services JSON data from the most recently created windows-services ConfigMap
+func getLatestServicesCMData(oc *exutil.CLI) (string, error) {
+	cmNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"configmap", "-n", wmcoNamespace,
+		"-o=jsonpath={.items[*].metadata.name}").Output()
 	if err != nil {
-		return "", fmt.Errorf("oc debug node/%s failed: %w\noutput: %s", nodeName, err, output)
+		return "", fmt.Errorf("failed to list ConfigMaps: %w", err)
 	}
-	var cleaned []string
-	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "Starting pod") ||
-			strings.HasPrefix(trimmed, "Removing debug pod") ||
-			trimmed == "" {
-			continue
+	var latestCM string
+	for _, name := range strings.Fields(cmNames) {
+		if strings.HasPrefix(name, "windows-services-") {
+			latestCM = name
 		}
-		cleaned = append(cleaned, line)
 	}
-	return strings.Join(cleaned, "\n"), nil
+	if latestCM == "" {
+		return "", fmt.Errorf("no windows-services ConfigMap found in %s", wmcoNamespace)
+	}
+	servicesData, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"configmap", latestCM, "-n", wmcoNamespace,
+		"-o=jsonpath={.data.services}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get services data from ConfigMap %s: %w", latestCM, err)
+	}
+	return servicesData, nil
+}
+
+// getServiceCommand returns the command for the named service from the services ConfigMap JSON data
+func getServiceCommand(servicesJSON, serviceName string) string {
+	result := gjson.Parse(servicesJSON)
+	for _, svc := range result.Array() {
+		if svc.Get("name").String() == serviceName {
+			return svc.Get("path").String()
+		}
+	}
+	return ""
 }

--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -18,13 +18,14 @@ import (
 )
 
 var (
-	mcoNamespace     = "openshift-machine-api"
-	capiNamespace    = "openshift-cluster-api"
-	wmcoNamespace    = "openshift-windows-machine-config-operator"
-	wmcoDeployment   = "deployment.apps/windows-machine-config-operator"
-	iaasPlatform     string
-	windowsNodeLabel = "kubernetes.io/os=windows"
-	linuxNodeLabel   = "kubernetes.io/os=linux"
+	mcoNamespace         = "openshift-machine-api"
+	capiNamespace        = "openshift-cluster-api"
+	wmcoNamespace        = "openshift-windows-machine-config-operator"
+	wmcoDeployment       = "deployment.apps/windows-machine-config-operator"
+	iaasPlatform         string
+	windowsNodeLabel     = "kubernetes.io/os=windows"
+	linuxNodeLabel       = "kubernetes.io/os=linux"
+	windowsDebugImage    = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 
 	machineLabel = "machine.openshift.io/os-id=Windows"
 )
@@ -306,4 +307,61 @@ func isBYOH(oc *exutil.CLI, nodeName string) bool {
 	byohLabel, err := oc.AsAdmin().WithoutNamespace().Run("get").
 		Args("node", nodeName, "-o=jsonpath={.metadata.labels.windowsmachineconfig\\.openshift\\.io/byoh}").Output()
 	return err == nil && strings.TrimSpace(byohLabel) == "true"
+}
+
+func getNodeNameFromIP(oc *exutil.CLI, nodeIP string) string {
+	goTpl := fmt.Sprintf(
+		`{{range .items}}{{$name := .metadata.name}}{{range .status.addresses}}`+
+			`{{if and (eq .type "InternalIP") (eq .address "%s")}}{{$name}}{{end}}`+
+			`{{end}}{{end}}`, nodeIP)
+	nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"nodes", "-o=go-template="+goTpl).Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to resolve node name for IP %s", nodeIP)
+	nodeName = strings.TrimSpace(nodeName)
+	o.Expect(nodeName).NotTo(o.BeEmpty(), "no node found with InternalIP %s", nodeIP)
+	return nodeName
+}
+
+func waitWindowsNodesReady(oc *exutil.CLI, expectedCount int, timeout time.Duration) {
+	pollErr := wait.Poll(10*time.Second, timeout, func() (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"nodes", "-l", windowsNodeLabel,
+			"-o=jsonpath={.items[*].status.conditions[?(@.type==\"Ready\")].status}").Output()
+		if err != nil {
+			e2e.Logf("Error querying Windows nodes: %v", err)
+			return false, nil
+		}
+		statuses := strings.Fields(output)
+		readyCount := 0
+		for _, s := range statuses {
+			if s == "True" {
+				readyCount++
+			}
+		}
+		e2e.Logf("Windows nodes ready: %d/%d", readyCount, expectedCount)
+		return readyCount >= expectedCount, nil
+	})
+	compat_otp.AssertWaitPollNoErr(pollErr, fmt.Sprintf("timed out waiting for %d Windows nodes to be Ready after %v", expectedCount, timeout))
+}
+
+func runDebugNodePS(oc *exutil.CLI, nodeName, image, psCommand string) (string, error) {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args(
+		"node/"+nodeName,
+		"-n", wmcoNamespace,
+		"--image="+image,
+		"--", "pwsh", "-Command", psCommand).Output()
+	if err != nil {
+		return "", fmt.Errorf("oc debug node/%s failed: %w\noutput: %s", nodeName, err, output)
+	}
+	var cleaned []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Starting pod") ||
+			strings.HasPrefix(trimmed, "Removing debug pod") ||
+			trimmed == "" {
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	return strings.Join(cleaned, "\n"), nil
 }

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -217,6 +217,78 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		}
 	})
 
+	// author: rrasouli@redhat.com
+	g.It("Smokerun-Author:rrasouli-High-89616-Verify log rotation for kubelet and kube-proxy services [Slow][Disruptive]", func() {
+		winNodeCount, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"nodes", "-l", windowsNodeLabel, "--no-headers").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		expectedNodes := len(strings.Split(strings.TrimSpace(winNodeCount), "\n"))
+
+		g.By("Set log rotation env vars on WMCO deployment")
+		err = oc.AsAdmin().WithoutNamespace().Run("set").Args(
+			"env", wmcoDeployment, "-n", wmcoNamespace,
+			"SERVICES_LOG_FILE_SIZE=1M",
+			"SERVICES_LOG_FILE_AGE=168h",
+			"SERVICES_LOG_FLUSH_INTERVAL=5s").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			g.By("Cleanup: remove log rotation env vars from WMCO deployment")
+			cleanupErr := oc.AsAdmin().WithoutNamespace().Run("set").Args(
+				"env", wmcoDeployment, "-n", wmcoNamespace,
+				"SERVICES_LOG_FILE_SIZE-",
+				"SERVICES_LOG_FILE_AGE-",
+				"SERVICES_LOG_FLUSH_INTERVAL-").Execute()
+			o.Expect(cleanupErr).NotTo(o.HaveOccurred(), "failed to restore WMCO deployment configuration")
+			waitWindowsNodesReady(oc, expectedNodes, 15*time.Minute)
+		}()
+
+		g.By("Wait for WMCO to reconcile and Windows nodes to be reconfigured")
+		waitWindowsNodesReady(oc, expectedNodes, 15*time.Minute)
+
+		winInternalIPs := getWindowsInternalIPs(oc)
+		for _, winIP := range winInternalIPs {
+			nodeName := getNodeNameFromIP(oc, winIP)
+
+			g.By(fmt.Sprintf("Verify kubelet on %s is wrapped with kube-log-runner", nodeName))
+			kubeletPath, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
+				"Get-CimInstance -ClassName Win32_Service | Where-Object {$_.Name -eq 'kubelet'} | Select-Object -ExpandProperty PathName")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(kubeletPath).Should(o.ContainSubstring("kube-log-runner"),
+				"kubelet on %s should be wrapped with kube-log-runner", nodeName)
+			o.Expect(kubeletPath).Should(o.ContainSubstring("-log-file="),
+				"kubelet on %s should have -log-file flag", nodeName)
+			o.Expect(kubeletPath).Should(o.ContainSubstring("-log-file-size="),
+				"kubelet on %s should have -log-file-size flag", nodeName)
+
+			g.By(fmt.Sprintf("Verify kube-proxy on %s is wrapped with kube-log-runner", nodeName))
+			kubeProxyPath, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
+				"Get-CimInstance -ClassName Win32_Service | Where-Object {$_.Name -eq 'kube-proxy'} | Select-Object -ExpandProperty PathName")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(kubeProxyPath).Should(o.ContainSubstring("kube-log-runner"),
+				"kube-proxy on %s should be wrapped with kube-log-runner", nodeName)
+			o.Expect(kubeProxyPath).Should(o.ContainSubstring("-log-file="),
+				"kube-proxy on %s should have -log-file flag", nodeName)
+
+			g.By(fmt.Sprintf("Verify kubelet log file exists at expected path on %s", nodeName))
+			logExists, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
+				"Test-Path C:\\var\\log\\kubelet\\kubelet.log")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(strings.TrimSpace(logExists)).Should(o.ContainSubstring("True"),
+				"kubelet.log should exist on %s", nodeName)
+
+			g.By(fmt.Sprintf("Check for rotated kubelet log files on %s", nodeName))
+			rotatedLogs, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
+				"Get-ChildItem C:\\var\\log\\kubelet\\ -Filter kubelet-*.log -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if strings.TrimSpace(rotatedLogs) != "" {
+				e2e.Logf("Found rotated kubelet log files on %s: %s", nodeName, strings.TrimSpace(rotatedLogs))
+			} else {
+				e2e.Logf("No rotated kubelet log files found yet on %s (log size may not have reached threshold)", nodeName)
+			}
+		}
+	})
+
 	// author: jfrancoa@redhat.com
 	g.It("Smokerun-Author:jfrancoa-Medium-38188-Get Windows instance/core number and CPU arch", func() {
 		winMetrics := []string{"cluster:node_instance_type_count:sum", "cluster:capacity_cpu_cores:sum"}

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -246,46 +246,19 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		g.By("Wait for WMCO to reconcile and Windows nodes to be reconfigured")
 		waitWindowsNodesReady(oc, expectedNodes, 15*time.Minute)
 
-		winInternalIPs := getWindowsInternalIPs(oc)
-		for _, winIP := range winInternalIPs {
-			nodeName := getNodeNameFromIP(oc, winIP)
+		g.By("Get the services ConfigMap to verify log rotation configuration")
+		servicesCMData, err := getLatestServicesCMData(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By(fmt.Sprintf("Verify kubelet on %s is wrapped with kube-log-runner", nodeName))
-			kubeletPath, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
-				"Get-CimInstance -ClassName Win32_Service | Where-Object {$_.Name -eq 'kubelet'} | Select-Object -ExpandProperty PathName")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(kubeletPath).Should(o.ContainSubstring("kube-log-runner"),
-				"kubelet on %s should be wrapped with kube-log-runner", nodeName)
-			o.Expect(kubeletPath).Should(o.ContainSubstring("-log-file="),
-				"kubelet on %s should have -log-file flag", nodeName)
-			o.Expect(kubeletPath).Should(o.ContainSubstring("-log-file-size="),
-				"kubelet on %s should have -log-file-size flag", nodeName)
-
-			g.By(fmt.Sprintf("Verify kube-proxy on %s is wrapped with kube-log-runner", nodeName))
-			kubeProxyPath, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
-				"Get-CimInstance -ClassName Win32_Service | Where-Object {$_.Name -eq 'kube-proxy'} | Select-Object -ExpandProperty PathName")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(kubeProxyPath).Should(o.ContainSubstring("kube-log-runner"),
-				"kube-proxy on %s should be wrapped with kube-log-runner", nodeName)
-			o.Expect(kubeProxyPath).Should(o.ContainSubstring("-log-file="),
-				"kube-proxy on %s should have -log-file flag", nodeName)
-
-			g.By(fmt.Sprintf("Verify kubelet log file exists at expected path on %s", nodeName))
-			logExists, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
-				"Test-Path C:\\var\\log\\kubelet\\kubelet.log")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(strings.TrimSpace(logExists)).Should(o.ContainSubstring("True"),
-				"kubelet.log should exist on %s", nodeName)
-
-			g.By(fmt.Sprintf("Check for rotated kubelet log files on %s", nodeName))
-			rotatedLogs, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
-				"Get-ChildItem C:\\var\\log\\kubelet\\ -Filter kubelet-*.log -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if strings.TrimSpace(rotatedLogs) != "" {
-				e2e.Logf("Found rotated kubelet log files on %s: %s", nodeName, strings.TrimSpace(rotatedLogs))
-			} else {
-				e2e.Logf("No rotated kubelet log files found yet on %s (log size may not have reached threshold)", nodeName)
-			}
+		for _, svcName := range []string{"kubelet", "kube-proxy"} {
+			g.By(fmt.Sprintf("Verify %s service command includes kube-log-runner", svcName))
+			svcCmd := getServiceCommand(servicesCMData, svcName)
+			o.Expect(svcCmd).NotTo(o.BeEmpty(), "%s service not found in services ConfigMap", svcName)
+			o.Expect(svcCmd).Should(o.ContainSubstring("kube-log-runner"),
+				"%s should be wrapped with kube-log-runner", svcName)
+			o.Expect(svcCmd).Should(o.ContainSubstring("-log-file="),
+				"%s should have -log-file flag", svcName)
+			e2e.Logf("%s service command: %s", svcName, svcCmd)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Port OCP-89616 log rotation test from OTP PR #30034 to OTE.

**What the test does (OCP-89616):**

1. Sets log rotation env vars on the WMCO deployment via `oc set env` (SERVICES_LOG_FILE_SIZE=1M, SERVICES_LOG_FILE_AGE=168h, SERVICES_LOG_FLUSH_INTERVAL=5s)
2. Waits for WMCO to reconcile and Windows nodes to become Ready
3. Reads the `windows-services-*` ConfigMap and verifies:
   - kubelet service command contains `kube-log-runner` with `-log-file` flag
   - kube-proxy service command contains `kube-log-runner` with `-log-file` flag
4. Cleanup: removes env vars from the deployment, waits for nodes to recover

**Key design decisions:**

- Uses `oc set env deployment` instead of patching an OLM Subscription (OTE does not use OLM)
- Verifies log rotation via the services ConfigMap instead of `oc debug node` with PowerShell WMI queries (`Get-CimInstance` cannot access host services from inside a nanoserver container)

**Other changes:**

- Add reusable helpers: `getLatestServicesCMData`, `getServiceCommand`, `waitWindowsNodesReady`
- Remove unused vars (`privateKey`, `publicKey`, `wmcoSubscriptionName`, `windowsDebugImage`)
- Fix missing k8s.io/externaljwt replace directive in ote/go.mod

Related: WINC-1635, [WINC-1953](https://redhat.atlassian.net/browse/WINC-1953), OTP PR openshift/openshift-tests-private#30034

## Test plan

- [x] go build passes (GOWORK=off)
- [x] gofmt clean
- [x] Test count: 6 (5 existing + 1 new)
- [ ] aws-e2e-ote CI validates on real cluster