### PR TITLE
WINC-2015: [hack] Run creation tests in setup-only mode

### DIFF
--- a/hack/run-ci-e2e-test.sh
+++ b/hack/run-ci-e2e-test.sh
@@ -138,11 +138,6 @@ fi
 
 echo "Testing against Windows Server $WIN_VER"
 
-if [[ "$TEST" == "setup-only" ]]; then
-  echo "Setup complete. Skipping e2e tests (-t setup-only)."
-  exit 0
-fi
-
 # MIRROR_REGISTRY_HOST holds the container mirror registry URL, its value will be set in CI
 MIRROR_REGISTRY_HOST=${MIRROR_REGISTRY_HOST:-}
 
@@ -163,6 +158,11 @@ if [[ "$TEST" != "upgrade-setup" && "$TEST" != "upgrade-test" ]]; then
   # Get logs for the creation tests
   printf "\n####### WMCO logs for creation tests #######\n" >> "$ARTIFACT_DIR"/wmco.log
   get_WMCO_logs
+fi
+
+if [[ "$TEST" == "setup-only" ]]; then
+  echo "Setup complete with Windows nodes provisioned. Skipping remaining e2e tests (-t setup-only)."
+  exit 0
 fi
 
 if [[ "$TEST" = "basic" ]]; then


### PR DESCRIPTION
## Summary

The setup-only mode in hack/run-ci-e2e-test.sh exits before running any e2e tests, including the creation tests that provision the cloud-private-key secret and Windows MachineSets. This causes the aws-e2e-ote CI job to run OTE extension tests on a cluster with zero Windows nodes, failing all 5 tests that require them.

This moves the setup-only exit to after the creation tests so that:
- WMCO is installed (existing behavior)
- TestWMCO/create runs: creates cloud-private-key secret, applies MachineSet, waits for Windows nodes
- Exit before basic, upgrade, and deletion tests (still skipped)

The subsequent OTE test step finds Ready Windows nodes on the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test flow to verify Windows node provisioning before selectively skipping remaining tests.
  * Updated test status messaging to more clearly indicate when provisioning has completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->