### PR TITLE
Update LABEL release in Containerfile and restores createdAt placeholder in hack/pre-release.sh

### DIFF
--- a/hack/pre-release.sh
+++ b/hack/pre-release.sh
@@ -129,7 +129,7 @@ update_WMCO_version() {
   
   echo "Updating Containerfile and Containerfile.bundle to $updated_version"
   sed -i "s/LABEL version=\"v$version\"/LABEL version=\"v$updated_version\"/g" Containerfile Containerfile.bundle
-  sed -i "s/LABEL release=\"$version\"/LABEL release=\"$updated_version\"/g" Containerfile.bundle    
+  sed -i "s/LABEL release=\"v$version\"/LABEL release=\"v$updated_version\"/g" Containerfile Containerfile.bundle
 }
 
 # This function updates the OCP version in all relevant files 

--- a/hack/pre-release.sh
+++ b/hack/pre-release.sh
@@ -230,6 +230,7 @@ github_update() {
   # remove make bundle artifacts
   sed -i 's/REPLACE_IMAGE:latest/REPLACE_IMAGE/' bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
   sed -i "s/operator-sdk-v1.14.0+git/operator-sdk-$OPERATOR_SDK_VERSION+git/" bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+  sed -i 's/createdAt: ".*"/createdAt: REPLACE_DATE/' bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
 
   commit_message="[$base_branch] Update version to $updated_version
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release metadata updates across container build files.
  - Ensured generated bundle manifests use a consistent creation date during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->