### PR TITLE
[nodeconfig] Remove CniStateDir from delete test assertion

### DIFF
--- a/test/e2e/delete_test.go
+++ b/test/e2e/delete_test.go
@@ -128,10 +128,7 @@ func (tc *testContext) getProxyCABundle() (string, error) {
 func (tc *testContext) checkDirsDoNotExist(address string) (bool, error) {
 	command := ""
 
-	dirs := make([]string, 0, len(windows.RequiredDirectories)+1)
-	dirs = append(dirs, windows.RequiredDirectories...)
-	dirs = append(dirs, windows.CniStateDir)
-	for _, dir := range dirs {
+	for _, dir := range windows.RequiredDirectories {
 		command += fmt.Sprintf("if ((Test-Path %s) -eq $true) { Write-Output %s exists}", dir, dir)
 	}
 	command += "exit 0"


### PR DESCRIPTION
The CniStateDir (C:\var\lib\cni) removal in removeDirectories() is best-effort and swallows errors, matching the same pattern used for K8sDir. The checkDirsDoNotExist test was incorrectly asserting that CniStateDir is removed, causing vsphere-proxy-e2e-operator failures on BYOH nodes where the removal may not always succeed.

Remove CniStateDir from checkDirsDoNotExist so the test matches the production contract. Only RequiredDirectories are asserted.

This PR commit updates the actual  https://github.com/openshift/windows-machine-config-operator/pull/4278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end deletion checks to validate only the required directories, improving test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->