### PR TITLE
WINC-2043:  Restore create verb for CSRs

### DIFF
--- a/bundle/manifests/prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -14,7 +14,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "discovery.k8s.io"
+  - discovery.k8s.io
   resources:
   - endpointslices
   verbs:

--- a/bundle/manifests/system-wicd-nodes_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/system-wicd-nodes_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -14,7 +14,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -106,6 +106,7 @@ rules:
   resources:
   - certificatesigningrequests
   verbs:
+  - create
   - get
   - list
   - watch

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -67,6 +67,9 @@ import (
 //+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;create;delete
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterrolebindings,verbs=get;create;delete
+// create on CSRs is never called directly here, however it is required so the RBAC
+// escalation check permits granting that same permission to WICD's ClusterRole in EnsureWICDRBAC
+//+kubebuilder:rbac:groups="certificates.k8s.io",resources=certificatesigningrequests,verbs=create
 //+kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures,verbs=get;list;watch
 
 const (


### PR DESCRIPTION
The create permission on certificatesigningrequests was added by hand to config/rbac/role.yaml and the bundle CSV without a matching kubebuilder marker. A later `make manifests` regeneration silently dropped it from role.yaml, since nothing in Go source backed it.

Without this permission, the operator's own ServiceAccount lacks a verb it must hold in order to grant that same permission to WICD's ClusterRole in EnsureWICDRBAC, causing Kubernetes' RBAC escalation check to reject the ClusterRoleBinding and the operator to fail to start.

This PR adds a +kubebuilder:rbac marker for create on CSRs next to the existing WICD RBAC markers in configmap_controller.go, then regenerate config/rbac/role.yaml via `make bundle`.


Context:
- https://github.com/openshift/windows-machine-config-operator/pull/3133 initial proposal missing the +kubebuilder:rbac marker for create in configmap_controller.go
- https://github.com/openshift/windows-machine-config-operator/pull/3480 droped the manual edit 
- https://github.com/openshift/windows-machine-config-operator/pull/4389 seeing the issues in bundle