### PR TITLE
WINC-2037: Pin image to digest in Containerfile and Containerfile.bundle and track  digests via Renovate 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26@sha256:c1488dc4364e229cb6963b4e0b088e3e93ef377bf92463d68b7b7e2ab1166f8f as build
 
 LABEL stage=build
 

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as image-replacer
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26@sha256:c1488dc4364e229cb6963b4e0b088e3e93ef377bf92463d68b7b7e2ab1166f8f as image-replacer
 COPY bundle/manifests /manifests
 RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:bdad703adb1b026afb53abb2fbdaa943f6a441a34be4074a0e47d90806e1d201|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 RUN sed -i "s|REPLACE_DATE|$(date "+%Y-%m-%dT%H:%M:%SZ")|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -106,7 +106,19 @@
   "dockerfile": {
     "enabled": true,
     "additionalBranchPrefix": "{{baseBranch}}/",
-    "branchPrefix": "konflux/mintmaker/"
+    "branchPrefix": "konflux/mintmaker/",
+    "packageRules": [
+      {
+        "matchFileNames": [
+          "Containerfile",
+          "Containerfile.bundle"
+        ],
+        "pinDigests": true,
+        "matchUpdateTypes": [
+          "digest"
+        ]
+      }
+    ]
   },
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build processes now use fixed, verified base image versions for greater consistency.
  * Automated maintenance is configured to monitor and update pinned image references when appropriate.
  * No changes were made to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->