### PR TITLE
WINC-1969: Add OTE Batch 4 Smokerun Slow/Serial tests

### DIFF
--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -1,15 +1,21 @@
 package winc
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
+	"os/exec"
+	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
@@ -30,6 +36,7 @@ var (
 
 	machineLabel      = "machine.openshift.io/os-id=Windows"
 	windowsDebugImage = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
+	linuxDebugImage   = "registry.access.redhat.com/ubi9/ubi:latest"
 )
 
 // checkVersionAnnotationReady returns true if the WMCO version annotation is set on the node.
@@ -467,4 +474,395 @@ func createProject(oc *exutil.CLI, namespace string) {
 
 func deleteProject(oc *exutil.CLI, namespace string) {
 	oc.DeleteSpecifiedNamespaceAsAdmin(namespace)
+}
+
+func generateWindowsWebServerYAML(name, namespace, image string, replicas int, includeService bool, resourceLimits, runtimeClassName string) string {
+	var sb strings.Builder
+	if includeService {
+		sb.WriteString(fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: %s
+  labels:
+    app: %s
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: %s
+  type: LoadBalancer
+---
+`, name, name, name))
+	}
+	sb.WriteString(fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: %s
+  name: %s
+spec:
+  selector:
+    matchLabels:
+      app: %s
+  replicas: %d
+  template:
+    metadata:
+      labels:
+        app: %s
+      name: %s
+    spec:
+`, name, name, name, replicas, name, name))
+	if runtimeClassName != "" {
+		sb.WriteString(fmt.Sprintf("      runtimeClassName: %s\n", runtimeClassName))
+	}
+	sb.WriteString(`      tolerations:
+      - key: "os"
+        value: "Windows"
+        operator: Equal
+        effect: "NoSchedule"
+      - key: "os"
+        value: "windows"
+        operator: Equal
+        effect: "NoSchedule"
+      containers:
+      - name: windowswebserver
+        image: ` + image + `
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsNonRoot: false
+          windowsOptions:
+            runAsUserName: "ContainerAdministrator"
+`)
+	if resourceLimits != "" {
+		sb.WriteString(fmt.Sprintf(`        resources:
+          limits:
+            cpu: %s
+            memory: 1Gi
+          requests:
+            cpu: %s
+            memory: 512Mi
+`, resourceLimits, resourceLimits))
+	}
+	sb.WriteString(`        command:
+        - pwsh.exe
+        - -command
+        - $listener = New-Object System.Net.HttpListener; $listener.Prefixes.Add('http://*:80/'); $listener.Start();Write-Host('Listening at http://*:80/'); while ($listener.IsListening) { $context = $listener.GetContext(); $response = $context.Response; $content='<html><body><H1>Windows Container Web Server</H1></body></html>'; $buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; $response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };
+      nodeSelector:
+        kubernetes.io/os: windows
+`)
+	return sb.String()
+}
+
+func generateHPAYAML(name, namespace, deploymentName string, minReplicas, maxReplicas, stabilizationWindow int, metricName, averageValue string) string {
+	yaml := fmt.Sprintf(`apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: %s
+  minReplicas: %d
+  maxReplicas: %d
+  metrics:
+  - type: Resource
+    resource:
+      name: %s
+      target:
+        type: AverageValue
+        averageValue: %s
+`, name, namespace, deploymentName, minReplicas, maxReplicas, metricName, averageValue)
+	if stabilizationWindow > 0 {
+		yaml += fmt.Sprintf(`  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: %d
+`, stabilizationWindow)
+	}
+	return yaml
+}
+
+func generateRuntimeClassYAML(name, buildID string) string {
+	return fmt.Sprintf(`apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: %s
+handler: runhcs-wcow-process
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: windows
+    node.kubernetes.io/windows-build: "%s"
+  tolerations:
+  - key: os
+    value: Windows
+    effect: NoSchedule
+`, name, buildID)
+}
+
+func waitForDeploymentReady(oc *exutil.CLI, deploymentName, namespace string, timeout time.Duration) error {
+	var lastPodStatus string
+	imagePullBackOffCount := 0
+
+	err := wait.Poll(10*time.Second, timeout, func() (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", deploymentName,
+			"-n", namespace,
+			"-o", "jsonpath={.status.replicas},{.status.readyReplicas}").Output()
+		if err != nil {
+			return false, nil
+		}
+
+		parts := strings.Split(strings.TrimSpace(output), ",")
+		if len(parts) != 2 {
+			return false, nil
+		}
+
+		replicas, _ := strconv.Atoi(parts[0])
+		readyReplicas, _ := strconv.Atoi(parts[1])
+
+		if replicas > 0 && replicas == readyReplicas {
+			return true, nil
+		}
+
+		podStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods",
+			"-n", namespace,
+			"-l", "app="+deploymentName,
+			"-o", "jsonpath={.items[*].status.containerStatuses[*].state}").Output()
+
+		if err == nil && podStatus != "" {
+			lastPodStatus = podStatus
+
+			if strings.Contains(podStatus, "ImagePullBackOff") || strings.Contains(podStatus, "ErrImagePull") {
+				imagePullBackOffCount++
+				if imagePullBackOffCount >= 3 {
+					return false, fmt.Errorf("ImagePullBackOff detected - image cannot be pulled")
+				}
+			} else {
+				imagePullBackOffCount = 0
+			}
+
+			if strings.Contains(podStatus, "CrashLoopBackOff") {
+				return false, fmt.Errorf("CrashLoopBackOff detected - container crashing on start")
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		e2e.Logf("Deployment %s failed to become ready in namespace %s", deploymentName, namespace)
+		e2e.Logf("Last pod status: %s", lastPodStatus)
+
+		podList, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods",
+			"-n", namespace,
+			"-l", "app="+deploymentName,
+			"-o", "wide").Output()
+		e2e.Logf("Pod list:\n%s", podList)
+
+		events, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("events",
+			"-n", namespace,
+			"--field-selector", "involvedObject.kind=Pod",
+			"--sort-by", ".lastTimestamp").Output()
+		e2e.Logf("Pod events:\n%s", events)
+
+		deployStatus, _ := oc.AsAdmin().WithoutNamespace().Run("describe").Args("deployment", deploymentName,
+			"-n", namespace).Output()
+		e2e.Logf("Deployment status:\n%s", deployStatus)
+	}
+
+	if err != nil {
+		return fmt.Errorf("deployment %s in namespace %s did not become ready within %v: %w", deploymentName, namespace, timeout, err)
+	}
+	return nil
+}
+
+func checkWorkloadCreated(oc *exutil.CLI, name, namespace string, replicaCount int) bool {
+	readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"deployment", name, "-n", namespace, "-o=jsonpath={.status.readyReplicas}",
+	).Output()
+
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return replicaCount == 0
+		}
+		e2e.Logf("Failed to get deployment %s, retrying: %v", name, err)
+		return false
+	}
+
+	if readyReplicas == "" {
+		return replicaCount == 0
+	}
+
+	numberOfWorkloads, err := strconv.Atoi(readyReplicas)
+	if err != nil {
+		e2e.Logf("Could not parse readyReplicas count '%s' for deployment %s: %v", readyReplicas, name, err)
+		return false
+	}
+
+	return numberOfWorkloads == replicaCount
+}
+
+func scaleDeployment(oc *exutil.CLI, deploymentName string, replicas int, namespace string) error {
+	_, err := oc.AsAdmin().WithoutNamespace().Run("scale").
+		Args("--replicas="+strconv.Itoa(replicas), "deployment", deploymentName, "-n", namespace).Output()
+	if err != nil {
+		return fmt.Errorf("failed to scale deployment %s to %d replicas: %w", deploymentName, replicas, err)
+	}
+
+	pollErr := wait.Poll(20*time.Second, 30*time.Minute, func() (bool, error) {
+		return checkWorkloadCreated(oc, deploymentName, namespace, replicas), nil
+	})
+	if pollErr != nil {
+		return fmt.Errorf("deployment %s did not reach %d replicas within 30 minutes: %w", deploymentName, replicas, pollErr)
+	}
+
+	return nil
+}
+
+func getExternalIP(iaasPlatform string, oc *exutil.CLI, deploymentName string, namespace string) (string, error) {
+	var cmdArgs []string
+	if iaasPlatform == "azure" || iaasPlatform == "gcp" {
+		cmdArgs = []string{"get", "service", deploymentName, "-o=jsonpath={.status.loadBalancer.ingress[0].ip}", "-n", namespace}
+	} else {
+		cmdArgs = []string{"get", "service", deploymentName, "-o=jsonpath={.status.loadBalancer.ingress[0].hostname}", "-n", namespace}
+	}
+
+	lbTimeout := 5 * time.Minute
+	var extIP string
+	pollErr := wait.Poll(2*time.Second, lbTimeout, func() (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run(cmdArgs[0]).Args(cmdArgs[1:]...).Output()
+		if err != nil {
+			e2e.Logf("Error retrieving external IP, retrying: %v", err)
+			return false, nil
+		}
+		extIP = output
+		e2e.Logf("%v ExternalIP is %v", iaasPlatform, extIP)
+		if extIP == "" {
+			e2e.Logf("External IP is empty, trying next round")
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if pollErr != nil {
+		return "", fmt.Errorf("failed to get LoadBalancer IP after %v: %w", lbTimeout, pollErr)
+	}
+	return extIP, nil
+}
+
+func haveMetricsServer(oc *exutil.CLI) bool {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("apiservice", "v1beta1.metrics.k8s.io").Output()
+	return err == nil && strings.Contains(output, "True")
+}
+
+func getWindowsBuildID(oc *exutil.CLI, nodeID string) (string, error) {
+	build, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeID, "-o=jsonpath={.metadata.labels.node\\.kubernetes\\.io\\/windows-build}").Output()
+	return build, err
+}
+
+func checkConnectivity(ctx context.Context, IP string, delay int) error {
+	url := "http://" + net.JoinHostPort(IP, "80")
+	timeout := strconv.Itoa(delay)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		time.Sleep(time.Duration(delay) * time.Second)
+		curl := exec.CommandContext(ctx, "curl", "--connect-timeout", timeout, "-s", url)
+		out, err := curl.Output()
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("curl to %s failed: %v (output: %s)", url, err, string(out))
+		}
+		if !strings.Contains(string(out), "Windows Container Web Server") {
+			return fmt.Errorf("unexpected response from LB %s: %s", url, string(out))
+		}
+		e2e.Logf("Checked LB connectivity of %s", url)
+	}
+}
+
+func generateLinuxWebServerYAML(name, namespace, image string, replicas int) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: %s
+  name: %s
+spec:
+  selector:
+    matchLabels:
+      app: %s
+  replicas: %d
+  template:
+    metadata:
+      labels:
+        app: %s
+      name: %s
+    spec:
+      containers:
+      - name: linux-webserver
+        image: %s
+        ports:
+        - containerPort: 8080
+        command:
+        - /bin/bash
+        - -c
+        - |
+          cat > /tmp/index.html <<'HTMLEOF'
+          <html><body><H1>Linux Container Web Server</H1></body></html>
+          HTMLEOF
+          cd /tmp && /usr/libexec/platform-python -m http.server 8080
+      nodeSelector:
+        kubernetes.io/os: linux
+`, name, name, name, replicas, name, name, image)
+}
+
+func getWorkloadsNames(oc *exutil.CLI, deploymentName string, namespace string) ([]string, error) {
+	workloads, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "--selector", "app="+deploymentName, "--sort-by=.status.hostIP", "-o=jsonpath={.items[*].metadata.name}", "-n", namespace).Output()
+	if err != nil {
+		return nil, err
+	}
+	pods := strings.Fields(workloads)
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods found for deployment %s in namespace %s", deploymentName, namespace)
+	}
+	return pods, nil
+}
+
+func getWorkloadsIP(oc *exutil.CLI, deploymentName string, namespace string) ([]string, error) {
+	workloads, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "--selector", "app="+deploymentName, "--sort-by=.status.hostIP", "-o=jsonpath={.items[*].status.podIP}", "-n", namespace).Output()
+	if err != nil {
+		return nil, err
+	}
+	ips := strings.Fields(workloads)
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no pod IPs found for deployment %s in namespace %s", deploymentName, namespace)
+	}
+	return ips, nil
+}
+
+func buildInvokeWebRequestCommand(url string) string {
+	return fmt.Sprintf(
+		"$r = Invoke-WebRequest -Uri %s -UseBasicParsing -ErrorAction SilentlyContinue; "+
+			"if ($r.Content -is [byte[]]) { [System.Text.Encoding]::UTF8.GetString($r.Content) } else { $r.Content }",
+		url)
+}
+
+func runInBackground(ctx context.Context, cancel context.CancelFunc, check func(context.Context, string, int) error, val string, delay int) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer g.GinkgoRecover()
+		err := check(ctx, val, delay)
+		if err != nil {
+			cancel()
+			e2e.Logf("Error during invocation of %v(%v,%v): %v", runtime.FuncForPC(reflect.ValueOf(check).Pointer()).Name(), val, delay, err.Error())
+		}
+		errCh <- err
+	}()
+	return errCh
 }

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -1,6 +1,7 @@
 package winc
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -894,6 +895,312 @@ spec:
 		g.By("Verify Windows nodes remain Ready and functional")
 		waitWindowsNodesReady(oc, len(winInternalIPs), 5*time.Minute)
 		e2e.Logf("All Windows nodes are Ready and using certificates from controllerConfig")
+	})
+
+	g.It("Author:rrasouli-Smokerun-Medium-79100-Horizontal Pod Autoscaling with Windows containers", func() {
+		if !haveMetricsServer(oc) {
+			g.Skip("metrics-server is required for HPA testing")
+		}
+
+		namespace := "winc-79100"
+		deploymentName := "win-webserver"
+		defer deleteProject(oc, namespace)
+
+		g.By("Creating test namespace")
+		createProject(oc, namespace)
+
+		g.By("Creating Windows deployment")
+		manifest := generateWindowsWebServerYAML(deploymentName, namespace, windowsDebugImage, 1, false, "200m", "")
+		err := createResourceFromString(oc, namespace, manifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, deploymentName, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Creating memory-based HPA")
+		memoryManifest := generateHPAYAML("hpa-resource-metrics-memory", namespace, deploymentName, 1, 5, 20, "memory", "40Mi")
+		err = createResourceFromString(oc, namespace, memoryManifest)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create memory HPA")
+		defer func() {
+			if delErr := oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "hpa-resource-metrics-memory", "-n", namespace, "--ignore-not-found").Execute(); delErr != nil {
+				e2e.Logf("Warning: failed to cleanup memory HPA: %v", delErr)
+			}
+		}()
+
+		g.By("Verifying HPA scales up deployment")
+		err = wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			msg, _ := oc.AsAdmin().WithoutNamespace().Run("get").
+				Args("deployment", deploymentName, "-o=jsonpath={.status.readyReplicas}", "-n", namespace).Output()
+			numberOfWorkloads, _ := strconv.Atoi(msg)
+			return numberOfWorkloads > 1, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Deployment did not scale up")
+
+		g.By("Patching memory HPA to trigger scale down")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+			"hpa", "hpa-resource-metrics-memory",
+			"-n", namespace,
+			"--type=merge",
+			"--patch", `{"spec":{"metrics":[{"resource":{"target":{"type":"AverageValue","averageValue":"150Mi"},"name":"memory"},"type":"Resource"}]}}`,
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to patch memory HPA")
+
+		g.By("Removing memory HPA and scaling deployment back to 1")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "hpa-resource-metrics-memory", "-n", namespace, "--ignore-not-found").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to delete memory HPA")
+		err = scaleDeployment(oc, deploymentName, 1, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to scale deployment back to 1 after removing memory HPA")
+
+		g.By("Creating CPU-based HPA")
+		cpuManifest := generateHPAYAML("hpa-resource-metrics-cpu", namespace, deploymentName, 1, 5, 20, "cpu", "10m")
+		err = createResourceFromString(oc, namespace, cpuManifest)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create CPU HPA")
+		defer func() {
+			if delErr := oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "hpa-resource-metrics-cpu", "-n", namespace, "--ignore-not-found").Execute(); delErr != nil {
+				e2e.Logf("Warning: failed to cleanup CPU HPA: %v", delErr)
+			}
+		}()
+
+		g.By("Verifying HPA scales up deployment")
+		err = wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			msg, _ := oc.AsAdmin().WithoutNamespace().Run("get").
+				Args("deployment", deploymentName, "-o=jsonpath={.status.readyReplicas}", "-n", namespace).Output()
+			numberOfWorkloads, _ := strconv.Atoi(msg)
+			return numberOfWorkloads > 1, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Patching CPU HPA to trigger scale down")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+			"hpa", "hpa-resource-metrics-cpu",
+			"-n", namespace,
+			"--type=merge",
+			"--patch", `{"spec":{"metrics":[{"resource":{"target":{"type":"AverageValue","averageValue":"500m"},"name":"cpu"},"type":"Resource"}]}}`,
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Removing CPU HPA and scaling deployment back to 1")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "hpa-resource-metrics-cpu", "-n", namespace, "--ignore-not-found").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to delete CPU HPA")
+		err = scaleDeployment(oc, deploymentName, 1, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to scale deployment back to 1 after removing CPU HPA")
+	})
+
+	g.It("Author:rrasouli-Smokerun-Medium-87711-Windows workload with RuntimeClass [Serial]", func() {
+		namespace := "winc-87711"
+		deploymentName := "win-webserver"
+		defer deleteProject(oc, namespace)
+		createProject(oc, namespace)
+
+		g.By("Step 1: Get Windows node and its build version")
+		windowsNode, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("nodes", "-l", windowsNodeLabel, "-o=jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(windowsNode).NotTo(o.BeEmpty(), "At least one Windows node should exist")
+
+		buildID, err := getWindowsBuildID(oc, windowsNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Windows node %s has build ID: %s", windowsNode, buildID)
+
+		g.By("Step 2: Create RuntimeClass for Windows build")
+		runtimeClass := namespace + "-runtimeclass"
+		runtimeClassYaml := generateRuntimeClassYAML(runtimeClass, buildID)
+		err = createResourceFromString(oc, "", runtimeClassYaml)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Created RuntimeClass: %s for build ID: %s", runtimeClass, buildID)
+
+		defer func() {
+			_, err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("runtimeclass", runtimeClass).Output()
+			if err != nil {
+				e2e.Logf("Warning: Failed to delete RuntimeClass %s: %v", runtimeClass, err)
+			} else {
+				e2e.Logf("Deleted RuntimeClass: %s", runtimeClass)
+			}
+		}()
+
+		g.By("Step 3: Verify RuntimeClass was created successfully")
+		runtimeClassOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("runtimeclass", runtimeClass, "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(runtimeClassOutput).To(o.ContainSubstring("runhcs-wcow-process"), "RuntimeClass should have handler: runhcs-wcow-process")
+		o.Expect(runtimeClassOutput).To(o.ContainSubstring(buildID), "RuntimeClass should have build ID in nodeSelector")
+		e2e.Logf("RuntimeClass %s is properly configured with handler runhcs-wcow-process", runtimeClass)
+
+		g.By("Step 4: Create Windows deployment with RuntimeClass")
+		manifest := generateWindowsWebServerYAML(deploymentName, namespace, windowsDebugImage, 1, true, "", runtimeClass)
+		err = createResourceFromString(oc, namespace, manifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, deploymentName, namespace, 10*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 5: Verify pod spec contains correct RuntimeClass")
+		podName, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("pods", "-n", namespace, "-l=app="+deploymentName, "-o=jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podName).NotTo(o.BeEmpty(), "Pod should exist")
+
+		podRuntimeClass, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("pod", podName, "-n", namespace, "-o=jsonpath={.spec.runtimeClassName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podRuntimeClass).To(o.Equal(runtimeClass), "Pod should have runtimeClassName: %s", runtimeClass)
+		e2e.Logf("Pod %s has correct runtimeClassName: %s", podName, podRuntimeClass)
+
+		g.By("Step 6: Verify pod is scheduled on Windows node")
+		nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("pod", podName, "-n", namespace, "-o=jsonpath={.spec.nodeName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeName).NotTo(o.BeEmpty(), "Pod should be scheduled on a node")
+
+		nodeOS, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("node", nodeName, "-o=jsonpath={.metadata.labels.kubernetes\\.io/os}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeOS).To(o.Equal("windows"), "Pod should be scheduled on Windows node")
+		e2e.Logf("Pod is scheduled on Windows node: %s", nodeName)
+
+		g.By("Step 7: Validate workload functionality via HTTP")
+		if iaasPlatform != "vsphere" && iaasPlatform != "nutanix" && !isNone(oc) {
+			externalIP, err := getExternalIP(iaasPlatform, oc, deploymentName, namespace)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			url := "http://" + net.JoinHostPort(externalIP, "80")
+			var lastErr error
+			success := false
+			maxRetries := 20
+			retryInterval := 15 * time.Second
+
+			httpClient := &http.Client{Timeout: 15 * time.Second}
+			e2e.Logf("Testing HTTP connectivity to %s (max %d retries)", url, maxRetries)
+			for i := 0; i < maxRetries; i++ {
+				resp, err := httpClient.Get(url)
+				if err == nil && resp.StatusCode == 200 {
+					resp.Body.Close()
+					e2e.Logf("Windows workload with RuntimeClass is functional and accessible via HTTP")
+					success = true
+					break
+				}
+				if err != nil {
+					lastErr = err
+					e2e.Logf("Retry %d/%d: HTTP GET failed: %v", i+1, maxRetries, err)
+				} else {
+					lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+					resp.Body.Close()
+					e2e.Logf("Retry %d/%d: Got status %d, expected 200", i+1, maxRetries, resp.StatusCode)
+				}
+				if i < maxRetries-1 {
+					time.Sleep(retryInterval)
+				}
+			}
+			o.Expect(success).To(o.BeTrue(), "Should be able to connect to Windows web server after %d retries. Last error: %v", maxRetries, lastErr)
+		} else {
+			e2e.Logf("Skipping HTTP connectivity test on platform %s (LoadBalancer not supported)", iaasPlatform)
+		}
+
+		g.By("Step 8: Verify pod events show no RuntimeClass errors")
+		podEvents, err := oc.AsAdmin().WithoutNamespace().Run("get").
+			Args("events", "-n", namespace, "--field-selector", fmt.Sprintf("involvedObject.name=%s", podName), "-o=jsonpath={.items[*].message}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podEvents).NotTo(o.ContainSubstring("RuntimeClass not found"), "Pod events should not contain RuntimeClass not found errors")
+		o.Expect(podEvents).NotTo(o.ContainSubstring("forbidden RuntimeClass"), "Pod events should not contain forbidden RuntimeClass errors")
+		e2e.Logf("No RuntimeClass-related errors found in pod events")
+	})
+
+	g.It("Smokerun-Author:sgao-Critical-28632-Windows and Linux east west network during a long time", func() {
+		namespace := "winc-28632"
+		winDeployment := "win-webserver"
+		linuxDeployment := "linux-webserver"
+		defer deleteProject(oc, namespace)
+		createProject(oc, namespace)
+
+		g.By("Deploy Windows and Linux web servers")
+		winManifest := generateWindowsWebServerYAML(winDeployment, namespace, windowsDebugImage, 1, false, "", "")
+		err := createResourceFromString(oc, namespace, winManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		linuxManifest := generateLinuxWebServerYAML(linuxDeployment, namespace, linuxDebugImage, 1)
+		err = createResourceFromString(oc, namespace, linuxManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForDeploymentReady(oc, winDeployment, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, linuxDeployment, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Check communication: Windows pod <--> Linux pod")
+		winPodNames, err := getWorkloadsNames(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(winPodNames).NotTo(o.BeEmpty(), "Windows pod names should not be empty")
+		winPodIPs, err := getWorkloadsIP(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(winPodIPs).NotTo(o.BeEmpty(), "Windows pod IPs should not be empty")
+		linuxPodNames, err := getWorkloadsNames(oc, linuxDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(linuxPodNames).NotTo(o.BeEmpty(), "Linux pod names should not be empty")
+		linuxPodIPs, err := getWorkloadsIP(oc, linuxDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(linuxPodIPs).NotTo(o.BeEmpty(), "Linux pod IPs should not be empty")
+
+		g.By("Windows pod -> Linux pod")
+		psCmd := buildInvokeWebRequestCommand("http://" + net.JoinHostPort(linuxPodIPs[0], "8080"))
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", namespace, winPodNames[0], "--", "pwsh.exe", "-Command", psCmd).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Linux Container Web Server"), "Failed to access Linux web server from Windows pod")
+
+		g.By("Linux pod -> Windows pod")
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", namespace, linuxPodNames[0], "--", "curl", "-s", net.JoinHostPort(winPodIPs[0], "80")).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Windows Container Web Server"), "Failed to curl Windows web server from Linux pod")
+	})
+
+	g.It("Smokerun-Author:rrasouli-High-38186-[wmco] Windows LB service [Slow]", func() {
+		if iaasPlatform == "vsphere" || iaasPlatform == "nutanix" {
+			g.Skip(fmt.Sprintf("Platform %s does not support Load balancer, skipping", iaasPlatform))
+		}
+		if isNone(oc) {
+			g.Skip("Platform none does not support Load balancer, skipping")
+		}
+		namespace := "winc-38186"
+		deploymentName := "win-webserver"
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		defer deleteProject(oc, namespace)
+		createProject(oc, namespace)
+
+		g.By("Creating Windows web server deployment with LB service")
+		manifest := generateWindowsWebServerYAML(deploymentName, namespace, windowsDebugImage, 1, true, "", "")
+		err := createResourceFromString(oc, namespace, manifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, deploymentName, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		externalIP, err := getExternalIP(iaasPlatform, oc, deploymentName, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		lbURL := "http://" + net.JoinHostPort(externalIP, "80")
+		g.By("Waiting for LB endpoint to become reachable")
+		err = wait.Poll(10*time.Second, 3*time.Minute, func() (bool, error) {
+			curl := exec.CommandContext(ctx, "curl", "--connect-timeout", "5", "-s", lbURL)
+			out, curlErr := curl.Output()
+			if curlErr != nil {
+				e2e.Logf("LB not yet reachable: %v", curlErr)
+				return false, nil
+			}
+			if strings.Contains(string(out), "Windows Container Web Server") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "LB endpoint did not become reachable")
+
+		g.By("Test LB " + externalIP + " connectivity")
+		bgErr := runInBackground(ctx, cancel, checkConnectivity, externalIP, 5)
+
+		g.By("Scale to 6 Windows workloads across nodes")
+		err = scaleDeployment(oc, deploymentName, 6, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to scale deployment to 6 replicas")
+
+		cancel()
+		err = <-bgErr
+		o.Expect(err).NotTo(o.HaveOccurred(), "Connectivity check failed during scaling")
 	})
 
 })


### PR DESCRIPTION
## Summary

Migrate 4 Smokerun tests from OTP to OTE (Batch 4):

- OCP-79100  **Horizontal Pod Autoscaling with Windows containers (memory + CPU scale-up/down)**
- OCP-87711   **Windows workload with RuntimeClass [Serial] (runhcs-wcow-process handler, HTTP validation)**
- OCP-28632  **Windows and Linux east-west network (rewritten to self-provision workloads instead of Flexy)**
- OCP-38186   **Windows LB service during pod scaling [Slow] (background connectivity check during scale-up)**

Dropped from OTE migration:
- OCP-31276 (Configure CNI and internal networking check) --> covered by WMCO e2e testEastWestNetworking
- OCP-32273 (Configure kube proxy and external networking check) --> covered by WMCO e2e testNorthSouthNetworking

15 new helper functions added to utils.go for workload deployment, scaling, LB polling, HPA/RuntimeClass YAML generation, and connectivity testing. All tests use inline YAML instead of the OTP template system and windowsDebugImage instead of the winc-test-config ConfigMap.

Total OTE tests after this PR: 20

Depends on: #4439

Jira: https://issues.redhat.com/browse/WINC-1969