### PR TITLE
WINC-1970: Fix HostProcess for Windows service queries in OTE

### DIFF
--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -40,6 +41,7 @@ var (
 	linuxDebugImage   = "registry.access.redhat.com/ubi9/ubi:latest"
 )
 
+// Service represents a Windows service entry from the WICD windows-services ConfigMap.
 type Service struct {
 	Name         string   `json:"name"`
 	Path         string   `json:"path"`
@@ -187,6 +189,7 @@ func getContainerdVersion(oc *exutil.CLI, nodeIP string) string {
 	return "v" + parts[1]
 }
 
+// getValueFromText searches line-delimited text for a key and returns the value after the key.
 func getValueFromText(body []byte, searchVal string) string {
 	lines := strings.Split(string(body), "\n")
 	for _, field := range lines {
@@ -327,6 +330,7 @@ func isBYOH(oc *exutil.CLI, nodeName string) bool {
 	return err == nil && strings.TrimSpace(byohLabel) == "true"
 }
 
+// getNodeNameFromIP resolves a node's hostname from its InternalIP address using a Go template query.
 func getNodeNameFromIP(oc *exutil.CLI, nodeIP string) string {
 	goTpl := fmt.Sprintf(
 		`{{range .items}}{{$name := .metadata.name}}{{range .status.addresses}}`+
@@ -340,6 +344,7 @@ func getNodeNameFromIP(oc *exutil.CLI, nodeIP string) string {
 	return nodeName
 }
 
+// waitWindowsNodesReady polls until the expected number of Windows nodes report Ready status.
 func waitWindowsNodesReady(oc *exutil.CLI, expectedCount int, timeout time.Duration) {
 	pollErr := wait.Poll(10*time.Second, timeout, func() (bool, error) {
 		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
@@ -399,6 +404,7 @@ func getServiceCommand(servicesJSON, serviceName string) string {
 	return ""
 }
 
+// waitWindowsNodeReady polls until a specific Windows node reports Ready status.
 func waitWindowsNodeReady(oc *exutil.CLI, nodeName string, timeout time.Duration) {
 	pollErr := wait.Poll(10*time.Second, timeout, func() (bool, error) {
 		status, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
@@ -413,6 +419,10 @@ func waitWindowsNodeReady(oc *exutil.CLI, nodeName string, timeout time.Duration
 	compat_otp.AssertWaitPollNoErr(pollErr, fmt.Sprintf("timed out waiting for node %s to be Ready after %v", nodeName, timeout))
 }
 
+// runDebugNodePS runs a PowerShell command on a Windows node via oc debug node.
+// Suitable for host filesystem operations (e.g. Test-Path, Get-Content on C:\host\...) but
+// NOT for Windows service queries -- oc debug does not create a HostProcess container, so
+// Get-Service, sc.exe, etc. only see the container's SCM. Use runHostProcessPS for those.
 func runDebugNodePS(oc *exutil.CLI, nodeName, image, psCommand string) (string, error) {
 	output, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args(
 		"node/"+nodeName,
@@ -435,6 +445,137 @@ func runDebugNodePS(oc *exutil.CLI, nodeName, image, psCommand string) (string, 
 	return strings.Join(cleaned, "\n"), nil
 }
 
+// runHostProcessPS runs a PowerShell command on a Windows node using a HostProcess container.
+// Unlike runDebugNodePS, this creates an explicit HostProcess pod with hostProcess=true and
+// runAsUserName="NT AUTHORITY\SYSTEM", giving the process full access to the host's Service
+// Control Manager, processes, and registry. Required for Get-Service, sc.exe, Stop-Service,
+// Get-CimInstance, and any other command that needs to interact with host-level Windows
+// services or WMI. The pod is created via oc run with JSON overrides that set both pod-level
+// and container-level securityContext for HostProcess, polled until completion, and cleaned
+// up on exit. Pass waitForCompletion=false for fire-and-forget operations where the pod is
+// expected to self-destruct (e.g. stopping containerd).
+func runHostProcessPS(oc *exutil.CLI, nodeName, image, psCommand string, waitForCompletion ...bool) (string, error) {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random suffix: %w", err)
+	}
+	suffix := fmt.Sprintf("%x", b)
+	nodeSafe := strings.ReplaceAll(nodeName, ".", "-")
+	if len(nodeSafe) > 20 {
+		nodeSafe = nodeSafe[:20]
+	}
+	podName := fmt.Sprintf("hpc-%s-%s", nodeSafe, suffix)
+
+	hostProcess := true
+	runAsUser := "NT AUTHORITY\\SYSTEM"
+	winOpts := map[string]interface{}{
+		"hostProcess":   hostProcess,
+		"runAsUserName": runAsUser,
+	}
+	overrides := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"hostNetwork": true,
+			"os":          map[string]string{"name": "windows"},
+			"nodeSelector": map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			},
+			"tolerations": []map[string]string{
+				{"key": "os", "value": "Windows", "effect": "NoSchedule"},
+			},
+			"securityContext": map[string]interface{}{
+				"windowsOptions": winOpts,
+			},
+			"containers": []map[string]interface{}{
+				{
+					"name":    podName,
+					"image":   image,
+					"command": []string{"powershell.exe", "-Command", psCommand},
+					"securityContext": map[string]interface{}{
+						"windowsOptions": winOpts,
+					},
+				},
+			},
+		},
+	}
+	overridesJSON, err := json.Marshal(overrides)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal HostProcess pod overrides: %w", err)
+	}
+
+	e2e.Logf("[HostProcess] Creating pod %s on node %s", podName, nodeName)
+	e2e.Logf("[HostProcess] Command: %s", psCommand)
+	e2e.Logf("[HostProcess] Overrides: %s", string(overridesJSON))
+
+	createOutput, err := oc.AsAdmin().WithoutNamespace().Run("run").Args(
+		podName,
+		"-n", wmcoNamespace,
+		"--image="+image,
+		"--restart=Never",
+		"--override-type=merge",
+		"--overrides="+string(overridesJSON),
+	).Output()
+	if err != nil {
+		e2e.Logf("[HostProcess] Failed to create pod %s: %v, output: %s", podName, err, createOutput)
+		return "", fmt.Errorf("failed to create HostProcess pod on %s: %w", nodeName, err)
+	}
+	e2e.Logf("[HostProcess] Pod %s created successfully", podName)
+
+	cleanupPod := func() {
+		e2e.Logf("[HostProcess] Cleaning up pod %s", podName)
+		if delErr := oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+			"pod", podName, "-n", wmcoNamespace, "--ignore-not-found", "--wait=false").Execute(); delErr != nil {
+			e2e.Logf("[HostProcess] Warning: failed to delete pod %s: %v", podName, delErr)
+		}
+	}
+
+	if len(waitForCompletion) > 0 && !waitForCompletion[0] {
+		e2e.Logf("[HostProcess] Pod %s created, returning without waiting (fire-and-forget)", podName)
+		defer cleanupPod()
+		return "", nil
+	}
+
+	defer cleanupPod()
+
+	pollErr := wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+		phase, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"pod", podName, "-n", wmcoNamespace, "-o=jsonpath={.status.phase}").Output()
+		if err != nil {
+			e2e.Logf("[HostProcess] Poll: error getting phase for %s: %v", podName, err)
+			return false, nil
+		}
+		p := strings.TrimSpace(phase)
+		e2e.Logf("[HostProcess] Poll: pod %s phase=%s", podName, p)
+		return p == "Succeeded" || p == "Failed", nil
+	})
+	if pollErr != nil {
+		describeOutput, _ := oc.AsAdmin().WithoutNamespace().Run("describe").Args(
+			"pod", podName, "-n", wmcoNamespace).Output()
+		e2e.Logf("[HostProcess] Pod %s timed out. Describe:\n%s", podName, describeOutput)
+		return "", fmt.Errorf("HostProcess pod %s did not complete: %w", podName, pollErr)
+	}
+
+	phase, phaseErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"pod", podName, "-n", wmcoNamespace, "-o=jsonpath={.status.phase}").Output()
+	if phaseErr != nil {
+		return "", fmt.Errorf("failed to get HostProcess pod %s phase: %w", podName, phaseErr)
+	}
+	e2e.Logf("[HostProcess] Pod %s final phase: %s", podName, strings.TrimSpace(phase))
+
+	output, logErr := oc.AsAdmin().WithoutNamespace().Run("logs").Args(
+		podName, "-n", wmcoNamespace).Output()
+	if logErr != nil {
+		return "", fmt.Errorf("failed to get HostProcess pod logs: %w", logErr)
+	}
+	e2e.Logf("[HostProcess] Pod %s output: %s", podName, strings.TrimSpace(output))
+
+	if strings.TrimSpace(phase) == "Failed" {
+		return "", fmt.Errorf("HostProcess command failed on %s: %s", nodeName, output)
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// createResourceFromString writes a YAML manifest to a temp file and applies it via oc apply.
 func createResourceFromString(oc *exutil.CLI, namespace, manifest string) error {
 	tempFile, err := os.CreateTemp("", "manifest-*.yaml")
 	if err != nil {
@@ -461,6 +602,7 @@ func createResourceFromString(oc *exutil.CLI, namespace, manifest string) error 
 	return nil
 }
 
+// getRandomString returns a cryptographically random base64 string of the given length.
 func getRandomString(length int) string {
 	o.Expect(length).To(o.BeNumerically(">", 0), "getRandomString requires a positive length")
 	buff := make([]byte, length)
@@ -470,6 +612,7 @@ func getRandomString(length int) string {
 	return str[:length]
 }
 
+// createProject creates a namespace if it does not already exist and sets privileged SCC.
 func createProject(oc *exutil.CLI, namespace string) {
 	exists := oc.AsAdmin().WithoutNamespace().Run("get").Args("namespace", namespace).Execute()
 	if exists == nil {
@@ -481,10 +624,14 @@ func createProject(oc *exutil.CLI, namespace string) {
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
+// deleteProject deletes the given namespace.
 func deleteProject(oc *exutil.CLI, namespace string) {
 	oc.DeleteSpecifiedNamespaceAsAdmin(namespace)
 }
 
+// generateWindowsWebServerYAML returns a YAML manifest for a Windows web server Deployment
+// (and optionally a LoadBalancer Service). Used to deploy Windows workloads for connectivity
+// and scaling tests.
 func generateWindowsWebServerYAML(name, namespace, image string, replicas int, includeService bool, resourceLimits, runtimeClassName string) string {
 	var sb strings.Builder
 	if includeService {
@@ -563,6 +710,7 @@ spec:
 	return sb.String()
 }
 
+// generateHPAYAML returns a YAML manifest for a HorizontalPodAutoscaler targeting a Deployment.
 func generateHPAYAML(name, namespace, deploymentName string, minReplicas, maxReplicas, stabilizationWindow int, metricName, averageValue string) string {
 	yaml := fmt.Sprintf(`apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -593,6 +741,7 @@ spec:
 	return yaml
 }
 
+// generateRuntimeClassYAML returns a YAML manifest for a Windows RuntimeClass with node selector and tolerations.
 func generateRuntimeClassYAML(name, buildID string) string {
 	return fmt.Sprintf(`apiVersion: node.k8s.io/v1
 kind: RuntimeClass
@@ -610,6 +759,8 @@ scheduling:
 `, name, buildID)
 }
 
+// waitForDeploymentReady polls until all replicas of a Deployment are ready, or returns an error
+// on timeout, ImagePullBackOff, or CrashLoopBackOff. Logs diagnostic info on failure.
 func waitForDeploymentReady(oc *exutil.CLI, deploymentName, namespace string, timeout time.Duration) error {
 	var lastPodStatus string
 	imagePullBackOffCount := 0
@@ -686,6 +837,7 @@ func waitForDeploymentReady(oc *exutil.CLI, deploymentName, namespace string, ti
 	return nil
 }
 
+// checkWorkloadCreated returns true if the Deployment has exactly the expected number of ready replicas.
 func checkWorkloadCreated(oc *exutil.CLI, name, namespace string, replicaCount int) bool {
 	readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 		"deployment", name, "-n", namespace, "-o=jsonpath={.status.readyReplicas}",
@@ -712,6 +864,8 @@ func checkWorkloadCreated(oc *exutil.CLI, name, namespace string, replicaCount i
 	return numberOfWorkloads == replicaCount
 }
 
+// scaleDeployment scales a Deployment to the given replica count and waits until the desired
+// number of ready replicas is reached (up to 30 minutes).
 func scaleDeployment(oc *exutil.CLI, deploymentName string, replicas int, namespace string) error {
 	_, err := oc.AsAdmin().WithoutNamespace().Run("scale").
 		Args("--replicas="+strconv.Itoa(replicas), "deployment", deploymentName, "-n", namespace).Output()
@@ -729,6 +883,7 @@ func scaleDeployment(oc *exutil.CLI, deploymentName string, replicas int, namesp
 	return nil
 }
 
+// getExternalIP polls for the LoadBalancer external IP (or hostname on AWS) assigned to a Service.
 func getExternalIP(iaasPlatform string, oc *exutil.CLI, deploymentName string, namespace string) (string, error) {
 	var cmdArgs []string
 	if iaasPlatform == "azure" || iaasPlatform == "gcp" {
@@ -760,16 +915,20 @@ func getExternalIP(iaasPlatform string, oc *exutil.CLI, deploymentName string, n
 	return extIP, nil
 }
 
+// haveMetricsServer returns true if the metrics API service (v1beta1.metrics.k8s.io) is available.
 func haveMetricsServer(oc *exutil.CLI) bool {
 	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("apiservice", "v1beta1.metrics.k8s.io").Output()
 	return err == nil && strings.Contains(output, "True")
 }
 
+// getWindowsBuildID returns the Windows build number label from a node (e.g. "10.0.20348").
 func getWindowsBuildID(oc *exutil.CLI, nodeID string) (string, error) {
 	build, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeID, "-o=jsonpath={.metadata.labels.node\\.kubernetes\\.io\\/windows-build}").Output()
 	return build, err
 }
 
+// checkConnectivity repeatedly curls the given IP on port 80 and verifies the Windows web server
+// response. Runs until the context is cancelled. Used with runInBackground for load-testing.
 func checkConnectivity(ctx context.Context, IP string, delay int) error {
 	url := "http://" + net.JoinHostPort(IP, "80")
 	timeout := strconv.Itoa(delay)
@@ -795,6 +954,7 @@ func checkConnectivity(ctx context.Context, IP string, delay int) error {
 	}
 }
 
+// generateLinuxWebServerYAML returns a YAML manifest for a Linux web server Deployment using python http.server.
 func generateLinuxWebServerYAML(name, namespace, image string, replicas int) string {
 	return fmt.Sprintf(`apiVersion: apps/v1
 kind: Deployment
@@ -831,6 +991,7 @@ spec:
 `, name, name, name, replicas, name, name, image)
 }
 
+// getWorkloadsNames returns the pod names for all pods belonging to the given Deployment, sorted by host IP.
 func getWorkloadsNames(oc *exutil.CLI, deploymentName string, namespace string) ([]string, error) {
 	workloads, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "--selector", "app="+deploymentName, "--sort-by=.status.hostIP", "-o=jsonpath={.items[*].metadata.name}", "-n", namespace).Output()
 	if err != nil {
@@ -843,6 +1004,7 @@ func getWorkloadsNames(oc *exutil.CLI, deploymentName string, namespace string) 
 	return pods, nil
 }
 
+// getWorkloadsIP returns the pod IPs for all pods belonging to the given Deployment, sorted by host IP.
 func getWorkloadsIP(oc *exutil.CLI, deploymentName string, namespace string) ([]string, error) {
 	workloads, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "--selector", "app="+deploymentName, "--sort-by=.status.hostIP", "-o=jsonpath={.items[*].status.podIP}", "-n", namespace).Output()
 	if err != nil {
@@ -855,6 +1017,7 @@ func getWorkloadsIP(oc *exutil.CLI, deploymentName string, namespace string) ([]
 	return ips, nil
 }
 
+// buildInvokeWebRequestCommand returns a PowerShell command that fetches a URL and decodes the response as UTF-8.
 func buildInvokeWebRequestCommand(url string) string {
 	return fmt.Sprintf(
 		"$r = Invoke-WebRequest -Uri %s -UseBasicParsing -ErrorAction SilentlyContinue; "+
@@ -862,6 +1025,8 @@ func buildInvokeWebRequestCommand(url string) string {
 		url)
 }
 
+// runInBackground launches a check function (e.g. checkConnectivity) in a goroutine and returns
+// a channel that receives the error when the function exits. Cancels the context on error.
 func runInBackground(ctx context.Context, cancel context.CancelFunc, check func(context.Context, string, int) error, val string, delay int) <-chan error {
 	errCh := make(chan error, 1)
 	go func() {
@@ -876,6 +1041,8 @@ func runInBackground(ctx context.Context, cancel context.CancelFunc, check func(
 	return errCh
 }
 
+// getLatestServicesCMName returns the name of the last windows-services-* ConfigMap found in the
+// WMCO namespace. The iteration order matches OTP's popItemFromList (last match wins).
 func getLatestServicesCMName(oc *exutil.CLI) (string, error) {
 	cmNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 		"configmap", "-n", wmcoNamespace,
@@ -895,6 +1062,8 @@ func getLatestServicesCMName(oc *exutil.CLI) (string, error) {
 	return latestCM, nil
 }
 
+// waitForServicesCM polls until getLatestServicesCMName returns the expected ConfigMap name.
+// Used after deleting/recreating CMs to verify WMCO reconciles the correct version.
 func waitForServicesCM(oc *exutil.CLI, expectedCMName string, timeout time.Duration) {
 	pollErr := wait.Poll(10*time.Second, timeout, func() (bool, error) {
 		cmName, err := getLatestServicesCMName(oc)
@@ -910,6 +1079,8 @@ func waitForServicesCM(oc *exutil.CLI, expectedCMName string, timeout time.Durat
 	compat_otp.AssertWaitPollNoErr(pollErr, fmt.Sprintf("Expected windows-services ConfigMap %s not found after %v", expectedCMName, timeout))
 }
 
+// generateWICDConfigMapYAML returns a YAML manifest for a WICD windows-services ConfigMap.
+// Ported from OTP generators.go GenerateWICDConfigMap.
 func generateWICDConfigMapYAML(name, servicesJSON string) string {
 	return fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap
@@ -921,27 +1092,33 @@ data:
 `, name, servicesJSON)
 }
 
+// checkWindowsServiceRunning returns true if the named Windows service is in Running state on the
+// given node. Uses a HostProcess pod to query the host's Service Control Manager.
 func checkWindowsServiceRunning(oc *exutil.CLI, nodeName, image, serviceName string) (bool, error) {
 	cmd := fmt.Sprintf("Get-Service '%s' | Select-Object -ExpandProperty Status", serviceName)
-	output, err := runDebugNodePS(oc, nodeName, image, cmd)
+	output, err := runHostProcessPS(oc, nodeName, image, cmd)
 	if err != nil {
 		return false, err
 	}
 	return strings.TrimSpace(output) == "Running", nil
 }
 
+// getServiceBinPath returns the PathName (binary path) of a Windows service via WMI CIM query.
+// Uses a HostProcess pod to access the host's Service Control Manager.
 func getServiceBinPath(oc *exutil.CLI, nodeName, image, serviceName string) (string, error) {
 	cmd := fmt.Sprintf("Get-CimInstance -ClassName Win32_Service | Where-Object { $_.Name -eq '%s' } | Select-Object -ExpandProperty PathName", serviceName)
-	output, err := runDebugNodePS(oc, nodeName, image, cmd)
+	output, err := runHostProcessPS(oc, nodeName, image, cmd)
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(output), nil
 }
 
+// setServiceBinPath modifies the binary path of a Windows service using sc.exe config.
+// Uses a HostProcess pod to access the host's Service Control Manager.
 func setServiceBinPath(oc *exutil.CLI, nodeName, image, serviceName, binPath string) error {
 	cmd := fmt.Sprintf(`sc.exe config %s binPath= "%s"`, serviceName, binPath)
-	output, err := runDebugNodePS(oc, nodeName, image, cmd)
+	output, err := runHostProcessPS(oc, nodeName, image, cmd)
 	if err != nil {
 		return fmt.Errorf("sc.exe config failed: %w (output: %s)", err, output)
 	}
@@ -949,13 +1126,4 @@ func setServiceBinPath(oc *exutil.CLI, nodeName, image, serviceName, binPath str
 		return fmt.Errorf("sc.exe config did not report SUCCESS: %s", output)
 	}
 	return nil
-}
-
-func stopWindowsService(oc *exutil.CLI, nodeName, image, serviceName string) (string, error) {
-	cmd := fmt.Sprintf("Stop-Service '%s' -Force -ErrorAction SilentlyContinue; (Get-Service '%s').Status", serviceName, serviceName)
-	output, err := runDebugNodePS(oc, nodeName, image, cmd)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(output), nil
 }

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -249,7 +249,16 @@ var _ = g.Describe("[OTP][sig-windows] Windows_Containers", func() {
 		}()
 
 		g.By("Wait for WMCO to reconcile and Windows nodes to be reconfigured")
+		err = waitForDeploymentReady(oc, wmcoDeploymentName, wmcoNamespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "WMCO deployment did not become ready after env var update")
 		waitWindowsNodesReady(oc, expectedNodes, 15*time.Minute)
+
+		g.By("Wait for services ConfigMap to be updated with log rotation configuration")
+		err = wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+			_, pollErr := getLatestServicesCMData(oc)
+			return pollErr == nil, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "services ConfigMap was not updated after setting log rotation env vars")
 
 		g.By("Get the services ConfigMap to verify log rotation configuration")
 		servicesCMData, err := getLatestServicesCMData(oc)
@@ -933,7 +942,7 @@ spec:
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to scale deployment back to 1 after removing memory HPA")
 
 		g.By("Creating CPU-based HPA")
-		cpuManifest := generateHPAYAML("hpa-resource-metrics-cpu", namespace, deploymentName, 1, 5, 20, "cpu", "10m")
+		cpuManifest := generateHPAYAML("hpa-resource-metrics-cpu", namespace, deploymentName, 1, 5, 20, "cpu", "1m")
 		err = createResourceFromString(oc, namespace, cpuManifest)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create CPU HPA")
 		defer func() {
@@ -1325,7 +1334,7 @@ spec:
 	})
 
 	// author: rrasouli@redhat.com
-	g.It("Author:rrasouli-Smokerun-Medium-76765-WICD-Remove-Services [Disruptive]", func() {
+	g.It("Author:rrasouli-Longduration-Smokerun-Medium-76765-WICD-Remove-Services [Slow][Disruptive]", func() {
 		wmcoLogVersion, err := getWMCOVersionFromLogs(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -1466,47 +1475,94 @@ spec:
 		retryInterval := 30 * time.Second
 		defer waitWindowsNodesReady(oc, len(winHostNames), 15*time.Minute)
 
+		// Stop-Service -Force handles the dependency chain that sc.exe stop
+		// cannot (error 1051). Kubelet and containerd are stopped together in
+		// a single HostProcess pod at the end: kubelet must still be running
+		// to schedule the pod, and stopping containerd is self-destructive
+		// (kills the pod's own runtime), so the pod will report as failed.
 		for _, nodeName := range winHostNames {
 			e2e.Logf("Stopping services on Windows host: %s", nodeName)
+
 			for _, serviceName := range removedServices {
+				if serviceName == "kubelet" || serviceName == "containerd" {
+					continue
+				}
 				var lastErr error
+				lastStatus := ""
 				for i := 0; i < maxRetries; i++ {
 					e2e.Logf("Attempt %d to stop service %s on %s", i+1, serviceName, nodeName)
-					status, err := stopWindowsService(oc, nodeName, windowsDebugImage, serviceName)
+					cmd := fmt.Sprintf(
+						"Stop-Service '%s' -Force -ErrorAction SilentlyContinue; "+
+							"(Get-Service '%s').Status",
+						serviceName, serviceName)
+					status, err := runHostProcessPS(oc, nodeName, windowsDebugImage, cmd)
 					if err != nil {
 						e2e.Logf("Error stopping service %s on %s: %v", serviceName, nodeName, err)
 						lastErr = err
+						if i < maxRetries-1 {
+							time.Sleep(retryInterval)
+						}
 						continue
 					}
 					lastErr = nil
+					status = strings.TrimSpace(status)
+					lastStatus = status
 					e2e.Logf("Service %s status on %s: %s", serviceName, nodeName, status)
 					if status != "Running" {
 						break
 					}
-					e2e.Logf("Service %s is still running on %s, retrying in %v...", serviceName, nodeName, retryInterval)
+					e2e.Logf("Service %s still running on %s, retrying in %v...",
+						serviceName, nodeName, retryInterval)
 					time.Sleep(retryInterval)
 				}
 				o.Expect(lastErr).NotTo(o.HaveOccurred(),
 					"Failed to stop service %s on host %s after retries", serviceName, nodeName)
+				o.Expect(lastStatus).NotTo(o.Equal("Running"),
+					"Service %s is still Running on host %s after %d stop attempts", serviceName, nodeName, maxRetries)
+			}
+
+			e2e.Logf("Stopping kubelet and containerd on %s (fire-and-forget)", nodeName)
+			cmd := "Stop-Service 'kubelet' -Force -ErrorAction SilentlyContinue; " +
+				"Stop-Service 'containerd' -Force -ErrorAction SilentlyContinue"
+			_, err = runHostProcessPS(oc, nodeName, windowsDebugImage, cmd, false)
+			o.Expect(err).NotTo(o.HaveOccurred(),
+				"Failed to launch kubelet/containerd stop on %s", nodeName)
+		}
+
+		g.By("Step 12: Wait for nodes to recover and verify critical services")
+		waitWindowsNodesReady(oc, len(winHostNames), 15*time.Minute)
+		for _, nodeName := range winHostNames {
+			for _, svcName := range []string{"kubelet", "containerd"} {
+				ok, err := checkWindowsServiceRunning(oc, nodeName, windowsDebugImage, svcName)
+				o.Expect(err).NotTo(o.HaveOccurred(),
+					"Failed to check %s on %s", svcName, nodeName)
+				o.Expect(ok).To(o.BeTrue(),
+					"Service %s should be running on %s after node recovery", svcName, nodeName)
 			}
 		}
 
-		g.By("Step 12: Verify no unexpected services are running")
+		g.By("Step 13: Verify no unexpected services are running")
 		unexpectedServices := []string{"unwanted-service-1", "unwanted-service-2"}
 		for _, nodeName := range winHostNames {
 			for _, service := range unexpectedServices {
 				checkCmd := fmt.Sprintf("Get-Service '%s' -ErrorAction SilentlyContinue", service)
-				output, err := runDebugNodePS(oc, nodeName, windowsDebugImage, checkCmd)
-				if err != nil || strings.Contains(output, "Cannot find") {
+				output, err := runHostProcessPS(oc, nodeName, windowsDebugImage, checkCmd)
+				if err != nil {
+					e2e.Logf("Error checking service %s on %s: %v", service, nodeName, err)
+					continue
+				}
+				if strings.TrimSpace(output) == "" || strings.Contains(output, "Cannot find") {
 					continue
 				}
 				statusCmd := fmt.Sprintf("Get-Service '%s' | Select-Object -ExpandProperty Status", service)
-				statusOutput, err := runDebugNodePS(oc, nodeName, windowsDebugImage, statusCmd)
-				if err == nil {
-					status := strings.TrimSpace(statusOutput)
-					if status != "" && status != "Stopped" {
-						e2e.Failf("Service %s is still running on host %s", service, nodeName)
-					}
+				statusOutput, err := runHostProcessPS(oc, nodeName, windowsDebugImage, statusCmd)
+				if err != nil {
+					e2e.Logf("Error checking status for %s on %s: %v", service, nodeName, err)
+					continue
+				}
+				status := strings.TrimSpace(statusOutput)
+				if status != "" && status != "Stopped" {
+					e2e.Failf("Service %s is still running on host %s", service, nodeName)
 				}
 			}
 			e2e.Logf("Finished checking for unexpected services on %s", nodeName)
@@ -1605,7 +1661,7 @@ spec:
 
 		g.By("Ensure Windows workers were not restarted after CA rotation")
 		for _, nodeName := range winHostNames {
-			uptimeOutput, err := runDebugNodePS(oc, nodeName, windowsDebugImage,
+			uptimeOutput, err := runHostProcessPS(oc, nodeName, windowsDebugImage,
 				`(Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")`)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get uptime from %s", nodeName)
 


### PR DESCRIPTION
## Summary

PR #4444 (Batch 5) introduced OTE tests that use runDebugNodePS (via oc debug node) for Windows service queries. CI showed OCP-76765 failing because oc debug node on Windows creates a regular container, not a HostProcess container. The container has its own isolated Service Control Manager, so Get-Service, sc.exe, and Stop-Service all return empty results.

This PR fixes both the service query mechanism and the service stop logic:

1. Adds runHostProcessPS() which creates an explicit HostProcess pod with hostProcess=true and runAsUserName="NT AUTHORITY\SYSTEM", giving full access to host services. Supports a fire-and-forget mode (waitForCompletion=false) for self-destructive operations like stopping containerd.

2. Replaces sc.exe stop with Stop-Service -Force for stopping services. sc.exe stop fails with error 1051 when a service has running dependents (e.g. hybrid-overlay-node). Stop-Service -Force handles the dependency chain automatically.

3. Handles the self-destructive containerd/kubelet stop: stopping containerd via HostProcess kills the pod's own runtime. The fix stops all other services first, then stops kubelet and containerd together in a single fire-and-forget HostProcess pod.

4. Adds a recovery verification step: after stopping all services, waits for nodes to become Ready (WICD restarts services), then verifies kubelet and containerd are running before checking for unexpected services.

5. Marks OCP-76765 as Longduration/Slow. CI run showed the test completing all 13 steps in ~15 minutes but getting interrupted during post-test cleanup (scaleDeployment defer). Adding Longduration and [Slow] tags signals the CI to allocate sufficient time.

6. Fixes fire-and-forget race condition: the original fire-and-forget polled for the pod to reach Running phase, but stopping kubelet kills the status reporter before it can update the pod phase. The fix returns immediately after pod creation -- the pod is accepted and scheduled, and Step 12 verifies the effect (node recovery + services running).

7. Fixes HPA test flakiness (OCP-79100): CPU HPA threshold was 10m but idle Windows containers use near-zero CPU. Changed to 1m which triggers on any running Windows process (metrics-server minimum granularity).

8. Fixes log rotation test flakiness (OCP-89616): after setting WMCO env vars, added waitForDeploymentReady to block until WMCO rollout completes before checking the services ConfigMap.

## Changes

- Add runHostProcessPS() to utils.go -- creates HostProcess pods for service queries, with variadic waitForCompletion parameter for fire-and-forget mode
- Extract cleanupPod helper that logs deletion errors instead of silently ignoring them
- Add lastStatus tracking to service stop retry loop and assert final status is not "Running" after retries
- Add sleep(retryInterval) on error path for consistent retry spacing
- Fix fire-and-forget mode to return immediately after pod creation instead of polling pod phase (avoids race with kubelet stopping before it can report Running)
- Update checkWindowsServiceRunning, getServiceBinPath, setServiceBinPath to use runHostProcessPS instead of runDebugNodePS
- Rewrite OCP-76765 Step 11 to use Stop-Service -Force via HostProcess with two-phase stop (non-runtime services first, then kubelet+containerd fire-and-forget)
- Add Step 12: wait for node recovery, verify kubelet/containerd running
- Renumber old Step 12 to Step 13
- Remove unused SSH job infrastructure (runPowerShellSSHJob, getSSHToolsImage, getSSHUsername, getNodeInternalIP, stopWindowsService)
- OCP-79100: Change CPU HPA threshold from 10m to 1m to trigger on any running Windows process
- OCP-89616: Add waitForDeploymentReady(wmcoDeploymentName) after oc set env to wait for WMCO rollout before checking services ConfigMap
- Add Go doc comments to all functions in utils.go
- Mark OCP-76765 as Longduration-Smokerun with [Slow][Disruptive] tags

## Root Cause

Three separate issues in the original code:

1. oc debug node on Windows mounts the host filesystem at C:\host\ but does NOT create a HostProcess container. File operations work via the mounted volume, but service operations query the container's own SCM, not the host's.

2. sc.exe stop cannot stop services that have running dependents (error 1051). Stop-Service -Force handles the dependency chain. Additionally, stopping containerd from inside a HostProcess container is self-destructive since containerd is the pod's own runtime.

3. Fire-and-forget mode polled for pod Running phase, but Stop-Service 'kubelet' kills kubelet before it can report the pod status back to the API server. The pod stays Pending forever from the API's perspective, causing a timeout.

4. HPA CPU threshold was too high (10m) for idle Windows containers which use near-zero CPU.

5. Log rotation test checked ConfigMap before WMCO deployment had finished restarting after env var update.

## Test plan

- [x] OCP-76765 (WICD-Remove-Services): Passed -- all 13 steps completed in ~18.6 minutes on live AWS cluster with 2 Windows nodes
- [x] OCP-76765 CI run 1: All 13 steps completed on us-east-2 cluster, interrupted during post-test cleanup (Longduration tag added)
- [x] OCP-76765 CI run 2: Failed at Step 11 fire-and-forget -- pod never reached Running because kubelet died first (fire-and-forget race fix applied)
- [x] OCP-76765 CI run 3: All 13 steps passed with CodeRabbit fixes (cleanupPod, lastStatus assertion, retry sleep)
- [x] OCP-56354 (Service binPath reconciliation): Uses getServiceBinPath/setServiceBinPath -- also uses HostProcess fix
- [x] OCP-79100 (HPA): Fixed CPU threshold flakiness by changing from 10m to 1m
- [x] OCP-89616 (Log rotation): Fixed flakiness by waiting for WMCO deployment rollout before checking ConfigMap
- OCP-50403 and OCP-33783: Unaffected (only check ConfigMaps and files, not services)

## Polarion alignment

Updated OCP-76765 Polarion test case to 13 steps matching OTE implementation (was 11 steps with duplicates and incorrect ordering).