### PR TITLE
WINC-2047: [ote] Set test lifecycle to blocking

### DIFF
--- a/ote/cmd/wmco-tests-ext/main.go
+++ b/ote/cmd/wmco-tests-ext/main.go
@@ -73,7 +73,7 @@ func main() {
 		if match := re.FindStringSubmatch(spec.Name); match != nil {
 			spec.Include(et.PlatformEquals(match[1]))
 		}
-		spec.Lifecycle = et.LifecycleInforming
+		spec.Lifecycle = et.LifecycleBlocking
 	})
 
 	ext.AddSpecs(componentSpecs)


### PR DESCRIPTION
## Summary

All OTE tests had their lifecycle hardcoded to `LifecycleInforming` in `ote/cmd/wmco-tests-ext/main.go`. The openshift-tests framework treats informing tests as non-blocking, so the `aws-e2e-ote` Prow job reported "all tests passed" even when individual tests failed. PRs were merged based on this false signal.

This changes the lifecycle to `LifecycleBlocking` so that test failures properly fail the CI job.

## Changes

- `ote/cmd/wmco-tests-ext/main.go`: `LifecycleInforming` -> `LifecycleBlocking`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Component test specifications now block lifecycle progression when they fail, rather than reporting failures as informational only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->