### PR TITLE
[tekton] Skip pipeline for ote/ directory changes

### DIFF
--- a/.tekton/windows-machine-config-operator-release-5-0-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-5-0-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "master"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
+      && !files.all.all(x, x.matches('^ote/|^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-5-0

--- a/.tekton/windows-machine-config-operator-release-5-0-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-5-0-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "master"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
+      && !files.all.all(x, x.matches('^ote/|^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: windows-machine-config-operator-release-5-0


### PR DESCRIPTION
Adds ote/ to the Pipelines as Code on-cel-expression skip list so pull requests changing only files under that directory do not trigger the release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline triggers to ignore changes limited to the `ote/` directory.
  * Pull requests and pushes affecting only this directory will no longer start unnecessary pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->