### PR TITLE
bump go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/windows-machine-config-operator
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go language version to 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->