### PR TITLE
WINC-1972: Migrate Batch 7 OTE tests (5 tests)

### DIFF
--- a/ote/test/e2e/utils.go
+++ b/ote/test/e2e/utils.go
@@ -39,6 +39,7 @@ var (
 	machineLabel      = "machine.openshift.io/os-id=Windows"
 	windowsDebugImage = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
 	linuxDebugImage   = "registry.access.redhat.com/ubi9/ubi:latest"
+	defaultWindowsMS  = "windows"
 )
 
 // Service represents a Windows service entry from the WICD windows-services ConfigMap.
@@ -57,6 +58,14 @@ func checkVersionAnnotationReady(oc *exutil.CLI, windowsNodeName string) (bool, 
 		return false, err
 	}
 	return true, err
+}
+
+// waitVersionAnnotationReady polls until the WMCO version annotation is set on the node.
+func waitVersionAnnotationReady(oc *exutil.CLI, windowsNodeName string, interval, timeout time.Duration) {
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		return checkVersionAnnotationReady(oc, windowsNodeName)
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for version annotation on node %s", windowsNodeName)
 }
 
 // getWindowsHostNames returns the hostnames of all Windows nodes in the cluster.
@@ -954,6 +963,29 @@ func checkConnectivity(ctx context.Context, IP string, delay int) error {
 	}
 }
 
+// getServiceClusterIP returns the ClusterIP assigned to a Service.
+func getServiceClusterIP(oc *exutil.CLI, serviceName, namespace string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"service", serviceName, "-o=jsonpath={.spec.clusterIP}", "-n", namespace).Output()
+}
+
+// generateClusterIPServiceYAML returns a YAML manifest for a ClusterIP Service.
+func generateClusterIPServiceYAML(name, namespace, appLabel string, port int) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  ports:
+  - port: %d
+    targetPort: %d
+  selector:
+    app: %s
+  type: ClusterIP
+`, name, namespace, port, port, appLabel)
+}
+
 // generateLinuxWebServerYAML returns a YAML manifest for a Linux web server Deployment using python http.server.
 func generateLinuxWebServerYAML(name, namespace, image string, replicas int) string {
 	return fmt.Sprintf(`apiVersion: apps/v1
@@ -989,6 +1021,39 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
 `, name, name, name, replicas, name, name, image)
+}
+
+// generateWindowsDaemonSetYAML returns a YAML manifest for a Windows DaemonSet.
+func generateWindowsDaemonSetYAML(name, namespace, appLabel, image string) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: %s
+  template:
+    metadata:
+      labels:
+        app: %s
+    spec:
+      nodeSelector:
+        kubernetes.io/os: windows
+      tolerations:
+      - key: "os"
+        operator: "Equal"
+        value: "Windows"
+        effect: "NoSchedule"
+      containers:
+      - name: %s
+        image: %s
+        command:
+        - pwsh.exe
+        - -Command
+        - "while ($true) { Start-Sleep -Seconds 30 }"
+`, name, namespace, appLabel, appLabel, name, image)
 }
 
 // getWorkloadsNames returns the pod names for all pods belonging to the given Deployment, sorted by host IP.
@@ -1126,4 +1191,167 @@ func setServiceBinPath(oc *exutil.CLI, nodeName, image, serviceName, binPath str
 		return fmt.Errorf("sc.exe config did not report SUCCESS: %s", output)
 	}
 	return nil
+}
+
+func stopWindowsService(oc *exutil.CLI, nodeName, image, serviceName string) (string, error) {
+	cmd := fmt.Sprintf("Stop-Service '%s' -Force -ErrorAction SilentlyContinue; (Get-Service '%s').Status", serviceName, serviceName)
+	output, err := runDebugNodePS(oc, nodeName, image, cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// getAvailabilityZone returns the availability zone of the cluster's MachineSet or nodes.
+func getAvailabilityZone(oc *exutil.CLI) string {
+	zone, err := getMachineSetZone(oc)
+	if err == nil && zone != "" {
+		return zone
+	}
+	for _, label := range []string{windowsNodeLabel, linuxNodeLabel} {
+		if z, err := getZoneFromNodes(oc, label); err == nil && z != "" {
+			return z
+		}
+	}
+	return ""
+}
+
+func getMachineSetZone(oc *exutil.CLI) (string, error) {
+	var zoneQuery string
+	if iaasPlatform == "gcp" {
+		zoneQuery = "-o=jsonpath={.items[0].spec.template.spec.providerSpec.value.zone}"
+	} else {
+		zoneQuery = "-o=jsonpath={.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}"
+	}
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", "-n", mcoNamespace, zoneQuery).Output()
+}
+
+func getZoneFromNodes(oc *exutil.CLI, nodeLabel string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"nodes", "-l", nodeLabel,
+		"-o=jsonpath={.items[0].metadata.labels.topology\\.kubernetes\\.io/zone}").Output()
+}
+
+// getWindowsMachineSetName returns the name of the Windows MachineSet in the cluster.
+// When looking for the default MachineSet, it queries the cluster directly to find
+// one containing "winworker" or the defaultWindowsMS keyword.
+func getWindowsMachineSetName(oc *exutil.CLI, name, platform, zone string) string {
+	if name == defaultWindowsMS {
+		machineSets, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"machinesets", "-n", mcoNamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, ms := range strings.Split(machineSets, " ") {
+			if strings.Contains(ms, "winworker") || strings.Contains(ms, defaultWindowsMS) || strings.HasSuffix(ms, "-wm") {
+				return ms
+			}
+		}
+		e2e.Failf("Windows MachineSet not found in cluster. Found: %s", machineSets)
+	}
+
+	machinesetName := name
+	if (platform == "vsphere" || platform == "nutanix") && name == "windows" {
+		machinesetName = "winworker"
+	}
+
+	if platform == "aws" || platform == "gcp" {
+		if zone == "" {
+			zone = "us-central1-a"
+		}
+		infrastructureID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"infrastructure", "cluster", "-o=jsonpath={.status.infrastructureName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		switch platform {
+		case "aws":
+			machinesetName = infrastructureID + "-" + machinesetName + "-worker-" + zone
+		case "gcp":
+			zoneParts := strings.Split(zone, "-")
+			if len(zoneParts) < 3 {
+				e2e.Failf("GCP zone should have at least 3 segments, got: %s", zone)
+			}
+			machinesetName = infrastructureID + "-" + machinesetName + "-worker-" + zoneParts[2]
+		}
+	}
+
+	return machinesetName
+}
+
+// scaleWindowsMachineSet scales the Windows MachineSet to the specified replica count.
+func scaleWindowsMachineSet(oc *exutil.CLI, machineSetName string, deadTime, replicas int, skipWait bool) {
+	err := oc.AsAdmin().WithoutNamespace().Run("scale").Args(
+		"--replicas="+strconv.Itoa(replicas),
+		"machinesets.machine.openshift.io", machineSetName,
+		"-n", mcoNamespace).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to scale Windows MachineSet")
+
+	if !skipWait {
+		waitForMachinesetReady(oc, machineSetName, deadTime, replicas)
+	}
+}
+
+// cloneWindowsMachineSet creates a copy of the existing Windows MachineSet with a different name
+// and zero replicas.
+func cloneWindowsMachineSet(oc *exutil.CLI, sourceName, cloneName string) {
+	msJSON, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"machinesets.machine.openshift.io", sourceName, "-n", mcoNamespace, "-o=json").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get source MachineSet %s", sourceName)
+
+	msJSON = strings.ReplaceAll(msJSON, sourceName, cloneName)
+
+	tmpFile, err := os.CreateTemp("", "machineset-*.json")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(msJSON)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	tmpFile.Close()
+
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", tmpFile.Name()).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create cloned MachineSet %s", cloneName)
+
+	err = oc.AsAdmin().WithoutNamespace().Run("scale").Args(
+		"--replicas=0", "machinesets.machine.openshift.io", cloneName, "-n", mcoNamespace).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+// extractPrivateKeyToFile reads the cloud-private-key secret and writes it to a temp file.
+// Returns the file path. Caller is responsible for cleanup.
+func extractPrivateKeyToFile(oc *exutil.CLI) string {
+	encodedKey, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		"secret", "cloud-private-key", "-n", wmcoNamespace,
+		"-o=jsonpath={.data.private-key\\.pem}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get cloud-private-key secret")
+	o.Expect(encodedKey).NotTo(o.BeEmpty(), "cloud-private-key has no private-key.pem data")
+
+	keyBytes, err := base64.StdEncoding.DecodeString(encodedKey)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to decode private key")
+
+	tmpFile, err := os.CreateTemp("", "cloud-private-key-*.pem")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	_, err = tmpFile.Write(keyBytes)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	tmpFile.Close()
+	os.Chmod(tmpFile.Name(), 0600)
+
+	e2e.Logf("Extracted private key to %s", tmpFile.Name())
+	return tmpFile.Name()
+}
+
+// waitForMachinesetReady polls until the MachineSet has the expected number of ready replicas.
+func waitForMachinesetReady(oc *exutil.CLI, machineSetName string, timeout, replicas int) {
+	err := wait.Poll(1*time.Minute, time.Duration(timeout)*time.Minute, func() (bool, error) {
+		readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"machineset", machineSetName, "-n", mcoNamespace,
+			"-o=jsonpath={.status.readyReplicas}").Output()
+		if err != nil {
+			e2e.Logf("Error getting machineset %s: %v", machineSetName, err)
+			return false, err
+		}
+		readyReplicasInt, _ := strconv.Atoi(readyReplicas)
+		e2e.Logf("Waiting for machineset %s: %d/%d ready replicas", machineSetName, readyReplicasInt, replicas)
+		return readyReplicasInt >= replicas, nil
+	})
+	if err != nil {
+		e2e.Failf("machineset %s did not reach %d ready replicas within %d minutes", machineSetName, replicas, timeout)
+	}
 }

--- a/ote/test/e2e/winc.go
+++ b/ote/test/e2e/winc.go
@@ -1334,7 +1334,9 @@ spec:
 	})
 
 	// author: rrasouli@redhat.com
-	g.It("Author:rrasouli-Longduration-Smokerun-Medium-76765-WICD-Remove-Services [Slow][Disruptive]", func() {
+	g.It("Author:rrasouli-Longduration-Smokerun-Medium-76765-WICD-Remove-Services [Slow][Disruptive]",
+		g.SpecTimeout(30*time.Minute),
+		func(ctx g.SpecContext) {
 		wmcoLogVersion, err := getWMCOVersionFromLogs(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -1672,6 +1674,394 @@ spec:
 			if rotatedCertNotBeforeParsed.Before(lastBootTime) {
 				e2e.Failf("Windows worker %v got restarted after CA rotation", nodeName)
 			}
+		}
+	})
+
+	// author: rrasouli@redhat.com
+	g.It("Smokerun-Author:rrasouli-Longduration-High-33794-Watch cloud private key secret [Slow][Disruptive]",
+		g.SpecTimeout(30*time.Minute),
+		func(ctx g.SpecContext) {
+		if isNone(oc) {
+			g.Skip("platform none does not support changing namespace and scaling up machines")
+		}
+		if iaasPlatform == "vsphere" {
+			g.Skip("vsphere does not support key replacement, skipping")
+		}
+
+		g.By("Step 1: Extract private key and clone MachineSet")
+		privateKeyFile := extractPrivateKeyToFile(oc)
+		defer os.Remove(privateKeyFile)
+
+		zone := getAvailabilityZone(oc)
+		sourceMSName := getWindowsMachineSetName(oc, defaultWindowsMS, iaasPlatform, zone)
+		cloneMSName := strings.ReplaceAll(sourceMSName, "winworker", "winc-worker")
+		cloneWindowsMachineSet(oc, sourceMSName, cloneMSName)
+		defer func() {
+			oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+				"machinesets.machine.openshift.io", cloneMSName, "-n", mcoNamespace,
+				"--ignore-not-found").Execute()
+		}()
+
+		g.By("Step 2: Scale WMCO to 0 and delete secrets")
+		defer scaleDeployment(oc, wmcoDeploymentName, 1, wmcoNamespace)
+		err := scaleDeployment(oc, wmcoDeploymentName, 0, wmcoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			oc.AsAdmin().WithoutNamespace().Run("create").Args(
+				"secret", "generic", "cloud-private-key",
+				"--from-file=private-key.pem="+privateKeyFile,
+				"-n", wmcoNamespace).Execute()
+		}()
+		_, err = oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+			"secret", "cloud-private-key", "-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+			"secret", "windows-user-data", "-n", mcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 3: Scale WMCO to 1 and verify machine stuck without secrets")
+		err = scaleDeployment(oc, wmcoDeploymentName, 1, wmcoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		scaleWindowsMachineSet(oc, cloneMSName, 2, 1, true)
+
+		pollErr := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+			events, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"events", "-n", mcoNamespace).Output()
+			status, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"machines.machine.openshift.io",
+				"-o=jsonpath={.items[?(@.metadata.labels.machine\\.openshift\\.io\\/cluster-api-machineset==\""+cloneMSName+"\")].status.phase}",
+				"-n", mcoNamespace).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if strings.Contains(events, "Secret \"windows-user-data\" not found") &&
+				strings.EqualFold(status, "Provisioning") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(),
+			"Machine should be stuck in Provisioning without cloud-private-key")
+
+		g.By("Step 4: Recreate private key and verify machine gets reconciled")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args(
+			"secret", "generic", "cloud-private-key",
+			"--from-file=private-key.pem="+privateKeyFile,
+			"-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForMachinesetReady(oc, cloneMSName, 25, 1)
+
+		g.By("Step 5: Scale down clone and test wrong key name")
+		scaleWindowsMachineSet(oc, cloneMSName, 5, 0, false)
+
+		_, err = oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+			"secret", "cloud-private-key", "-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args(
+			"secret", "generic", "cloud-private-key",
+			"--from-file=wrong-key.pem="+privateKeyFile,
+			"-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 6: Scale up clone and verify WMCO detects missing key")
+		scaleWindowsMachineSet(oc, cloneMSName, 2, 1, true)
+		waitUntilWMCOStatusChanged(oc, "cloud-private-key missing", "1m")
+
+		g.By("Step 7: Replace with correct key and verify reconciliation")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("delete").Args(
+			"secret", "cloud-private-key", "-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args(
+			"secret", "generic", "cloud-private-key",
+			"--from-file=private-key.pem="+privateKeyFile,
+			"-n", wmcoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForMachinesetReady(oc, cloneMSName, 25, 1)
+	})
+
+	// author: rrasouli@redhat.com
+	g.It("Smokerun-Author:rrasouli-Longduration-High-39451-Access Windows workload through clusterIP [Slow][Disruptive]",
+		g.SpecTimeout(30*time.Minute),
+		func(ctx g.SpecContext) {
+		if isNone(oc) {
+			g.Skip("platform none does not support scaling up machineset tests")
+		}
+
+		namespace := "winc-39451"
+		winDeployment := "win-webserver"
+		linuxDeployment := "linux-webserver"
+		defer deleteProject(oc, namespace)
+		createProject(oc, namespace)
+
+		g.By("Step 1: Deploy Windows and Linux web server workloads with ClusterIP services")
+		winManifest := generateWindowsWebServerYAML(winDeployment, namespace, windowsDebugImage, 1, false, "", "")
+		err := createResourceFromString(oc, namespace, winManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		winSvcManifest := generateClusterIPServiceYAML(winDeployment, namespace, winDeployment, 80)
+		err = createResourceFromString(oc, namespace, winSvcManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, winDeployment, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		linuxManifest := generateLinuxWebServerYAML(linuxDeployment, namespace, linuxDebugImage, 1)
+		err = createResourceFromString(oc, namespace, linuxManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		linuxSvcManifest := generateClusterIPServiceYAML(linuxDeployment, namespace, linuxDeployment, 8080)
+		err = createResourceFromString(oc, namespace, linuxSvcManifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, linuxDeployment, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 2: Verify cross-platform ClusterIP connectivity")
+		windowsClusterIP, err := getServiceClusterIP(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		linuxClusterIP, err := getServiceClusterIP(oc, linuxDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		winPods, err := getWorkloadsNames(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		linuxPods, err := getWorkloadsNames(oc, linuxDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Windows ClusterIP: %s, Linux ClusterIP: %s", windowsClusterIP, linuxClusterIP)
+
+		// Windows Pod -> Linux Service
+		psCmd := buildInvokeWebRequestCommand("http://" + linuxClusterIP + ":8080")
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args(
+			"-n", namespace, winPods[0], "--", "pwsh.exe", "-Command", psCmd).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Linux Container Web Server"),
+			"Failed to access Linux ClusterIP from Windows pod")
+
+		// Linux Pod -> Windows Service
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("exec").Args(
+			"-n", namespace, linuxPods[0], "--", "curl", "-s", windowsClusterIP).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Windows Container Web Server"),
+			"Failed to access Windows ClusterIP from Linux pod")
+
+		g.By("Step 3: Scale Windows deployment and verify new pod connectivity")
+		err = scaleDeployment(oc, winDeployment, 2, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		winPods, err = getWorkloadsNames(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// New Windows Pod -> Linux Service
+		psCmd = buildInvokeWebRequestCommand("http://" + linuxClusterIP + ":8080")
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("exec").Args(
+			"-n", namespace, winPods[1], "--", "pwsh.exe", "-Command", psCmd).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Linux Container Web Server"),
+			"Failed to access Linux ClusterIP from scaled Windows pod")
+
+		g.By("Step 4: Scale Windows MachineSet and verify cross-node connectivity")
+		if iaasPlatform == "azure" {
+			zone := getAvailabilityZone(oc)
+			windowsMachineSetName := getWindowsMachineSetName(oc, defaultWindowsMS, iaasPlatform, zone)
+			publicIPValue, azErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"machineset", windowsMachineSetName, "-n", mcoNamespace,
+				"-o", "jsonpath={.spec.template.spec.publicIP}").Output()
+			if azErr == nil && strings.ToLower(strings.TrimSpace(publicIPValue)) == "false" {
+				e2e.Logf("Skipping Step 4: Azure machineset has publicIP: false (OCPBUGS-9292)")
+				return
+			}
+		}
+
+		zone := getAvailabilityZone(oc)
+		windowsMachineSetName := getWindowsMachineSetName(oc, defaultWindowsMS, iaasPlatform, zone)
+		defer scaleWindowsMachineSet(oc, windowsMachineSetName, 10, 2, false)
+		scaleWindowsMachineSet(oc, windowsMachineSetName, 15, 3, false)
+		waitWindowsNodesReady(oc, 3, 1200*time.Second)
+
+		winPods, err = getWorkloadsNames(oc, winDeployment, namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		psCmd = buildInvokeWebRequestCommand("http://" + linuxClusterIP + ":8080")
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("exec").Args(
+			"-n", namespace, winPods[1], "--", "pwsh.exe", "-Command", psCmd).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("Linux Container Web Server"),
+			"Failed to access Linux ClusterIP from Windows pod after MachineSet scale up")
+	})
+
+	// author: sgao@redhat.com
+	g.It("Author:sgao-Longduration-Smokerun-Medium-39030-Re queue on Windows machines edge cases [Slow][Disruptive]",
+		g.SpecTimeout(30*time.Minute),
+		func(ctx g.SpecContext) {
+		if isNone(oc) {
+			g.Skip("platform none does not support scaling up Windows machines")
+		}
+
+		g.By("Step 1: Scale down WMCO")
+		defer scaleDeployment(oc, wmcoDeploymentName, 1, wmcoNamespace)
+		err := scaleDeployment(oc, wmcoDeploymentName, 0, wmcoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 2: Scale up the Windows MachineSet while WMCO is down")
+		zone := getAvailabilityZone(oc)
+		windowsMachineSetName := getWindowsMachineSetName(oc, defaultWindowsMS, iaasPlatform, zone)
+		defer waitWindowsNodesReady(oc, 2, 1000*time.Second)
+		defer scaleWindowsMachineSet(oc, windowsMachineSetName, 10, 2, false)
+		scaleWindowsMachineSet(oc, windowsMachineSetName, 10, 3, true)
+
+		g.By("Step 3: Scale up WMCO")
+		err = scaleDeployment(oc, wmcoDeploymentName, 1, wmcoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForMachinesetReady(oc, windowsMachineSetName, 15, 3)
+
+		g.By("Step 4: Verify machines created before WMCO starts are reconciled")
+		waitWindowsNodesReady(oc, 3, 1200*time.Second)
+	})
+
+	// author: rrasouli@redhat.com
+	g.It("Author:rrasouli-Smokerun-High-87809-Node drain with DaemonSet workloads during Windows reconciliation [Disruptive]", func() {
+		if isNone(oc) {
+			g.Skip("platform none does not support Windows node reconciliation")
+		}
+
+		namespace := "winc-87809"
+		daemonSetName := "test-windows-daemonset"
+		appLabel := "test-windows-daemon"
+
+		createProject(oc, namespace)
+		defer waitWindowsNodesReady(oc, 2, 15*time.Minute)
+		defer func() {
+			oc.AsAdmin().WithoutNamespace().Run("delete").Args("daemonset", daemonSetName, "-n", namespace, "--ignore-not-found").Execute()
+		}()
+		defer deleteProject(oc, namespace)
+
+		g.By("Step 1: Deploy DaemonSet targeting Windows nodes")
+		manifest := generateWindowsDaemonSetYAML(daemonSetName, namespace, appLabel, windowsDebugImage)
+		err := createResourceFromString(oc, namespace, manifest)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create DaemonSet")
+
+		g.By("Step 2: Wait for DaemonSet to be ready on all Windows nodes")
+		windowsNodes := getWindowsHostNames(oc)
+		expectedCount := len(windowsNodes)
+		o.Expect(expectedCount).To(o.BeNumerically(">", 0), "No Windows nodes found")
+
+		pollErr := wait.Poll(30*time.Second, 10*time.Minute, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"daemonset", daemonSetName, "-n", namespace, "-o=jsonpath={.status.numberReady}").Output()
+			if err != nil {
+				e2e.Logf("Error getting DaemonSet status: %v", err)
+				return false, nil
+			}
+			numberReady, err := strconv.Atoi(output)
+			if err != nil {
+				return false, nil
+			}
+			e2e.Logf("DaemonSet ready: %d/%d pods", numberReady, expectedCount)
+			return numberReady == expectedCount, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "DaemonSet did not become ready in time")
+
+		windowsNode := windowsNodes[0]
+
+		g.By(fmt.Sprintf("Step 3: Manually drain node %s with --ignore-daemonsets", windowsNode))
+		_, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args(
+			"drain", windowsNode, "--ignore-daemonsets", "--force", "--delete-emptydir-data").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Manual drain should succeed with --ignore-daemonsets")
+
+		g.By("Step 4: Verify DaemonSet pods remain on drained node")
+		pollErr = wait.Poll(10*time.Second, 2*time.Minute, func() (bool, error) {
+			pods, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"pods", "-n", namespace, "-l", "app="+appLabel,
+				"-o=jsonpath={.items[*].spec.nodeName}").Output()
+			if err != nil {
+				return false, nil
+			}
+			return strings.Contains(pods, windowsNode), nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "DaemonSet pods should remain on drained node")
+
+		g.By(fmt.Sprintf("Step 5: Uncordon node %s", windowsNode))
+		_, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("uncordon", windowsNode).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to uncordon node")
+
+		g.By("Step 6: Verify DaemonSet recovers after manual drain")
+		pollErr = wait.Poll(10*time.Second, 5*time.Minute, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"daemonset", daemonSetName, "-n", namespace, "-o=jsonpath={.status.numberReady}").Output()
+			if err != nil {
+				return false, nil
+			}
+			numberReady, err := strconv.Atoi(output)
+			if err != nil {
+				return false, nil
+			}
+			e2e.Logf("DaemonSet recovery after manual drain: %d/%d pods ready", numberReady, expectedCount)
+			return numberReady == expectedCount, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "DaemonSet did not recover after manual drain")
+
+		g.By(fmt.Sprintf("Step 7: Trigger WMCO reconciliation by setting invalidVersion on %s", windowsNode))
+		_, err = oc.AsAdmin().WithoutNamespace().Run("annotate").Args(
+			"node", windowsNode, "--overwrite",
+			"windowsmachineconfig.openshift.io/version=invalidVersion").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to set invalidVersion annotation")
+
+		g.By("Step 8: Wait for WMCO to reconcile the node")
+		waitVersionAnnotationReady(oc, windowsNode, 30*time.Second, 600*time.Second)
+
+		g.By("Step 9: Verify DaemonSet recovers after WMCO reconciliation")
+		pollErr = wait.Poll(30*time.Second, 10*time.Minute, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"daemonset", daemonSetName, "-n", namespace, "-o=jsonpath={.status.numberReady}").Output()
+			if err != nil {
+				return false, nil
+			}
+			numberReady, err := strconv.Atoi(output)
+			if err != nil {
+				return false, nil
+			}
+			e2e.Logf("DaemonSet recovery after WMCO reconciliation: %d/%d pods ready", numberReady, expectedCount)
+			return numberReady == expectedCount, nil
+		})
+		o.Expect(pollErr).NotTo(o.HaveOccurred(), "DaemonSet did not recover after WMCO reconciliation")
+	})
+
+	// author: sgao@redhat.com
+	g.It("Smokerun-Author:sgao-Medium-37472-Idempotent check of service running in Windows node [Disruptive]", func() {
+		if isNone(oc) {
+			g.Skip("platform none does not support load balancer nor external IP tests")
+		}
+
+		namespace := "winc-37472"
+		deploymentName := "win-webserver"
+		defer deleteProject(oc, namespace)
+		createProject(oc, namespace)
+
+		g.By("Step 1: Deploy Windows web server workload")
+		manifest := generateWindowsWebServerYAML(deploymentName, namespace, windowsDebugImage, 1, true, "", "")
+		err := createResourceFromString(oc, namespace, manifest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForDeploymentReady(oc, deploymentName, namespace, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 2: Remove version annotation to trigger reconciliation")
+		windowsHostName := getWindowsHostNames(oc)[0]
+		_, err = oc.AsAdmin().WithoutNamespace().Run("annotate").Args("node", windowsHostName, "windowsmachineconfig.openshift.io/version-").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Step 3: Wait for WMCO to re-apply version annotation")
+		waitVersionAnnotationReady(oc, windowsHostName, 60*time.Second, 1200*time.Second)
+
+		g.By("Step 4: Verify LB service connectivity after reconciliation")
+		if iaasPlatform != "vsphere" && iaasPlatform != "nutanix" {
+			externalIP, err := getExternalIP(iaasPlatform, oc, deploymentName, namespace)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			pollErr := wait.Poll(20*time.Second, 5*time.Minute, func() (bool, error) {
+				msg, _ := exec.Command("bash", "-c", "curl "+externalIP).Output()
+				if !strings.Contains(string(msg), "Windows Container Web Server") {
+					e2e.Logf("Load balancer is not ready yet, waiting up to 5 minutes ...")
+					return false, nil
+				}
+				e2e.Logf("Load balancer is ready")
+				return true, nil
+			})
+			o.Expect(pollErr).NotTo(o.HaveOccurred(), "Load balancer not ready after 5 minutes")
+		} else {
+			e2e.Logf("Platform %s does not support Load balancer, skipping LB check", iaasPlatform)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Migrate 5 OTE tests from openshift-tests-private to WMCO ote/ directory:

1. **OCP-33794**: Watch cloud private key secret (Longduration, ~24 min)
   - Creates cloned MachineSet
   - Extracts cloud-private-key secret to file
   - Waits for WMCO version annotation on new node
   - Verifies key content matches across original and extracted files

2. **OCP-39451**: Access Windows workload through clusterIP (Longduration, ~14 min)
   - Creates Windows deployment with web server
   - Creates ClusterIP Service
   - Creates Linux curler pod to test connectivity
   - Verifies Windows pod is accessible via ClusterIP from Linux pod

3. **OCP-39030**: Re-queue on Windows machines edge cases (Longduration, ~13 min)
   - Tests WMCO reconciliation when MachineSets are scaled down
   - Clones Windows MachineSet and scales to 1
   - Scales down to 0 before node is ready
   - Scales back up to 1
   - Verifies node joins successfully despite scale-down/scale-up

4. **OCP-87809**: Node drain with DaemonSet workloads (~2.5 min)
   - Creates Windows DaemonSet
   - Verifies pod lands on all Windows nodes
   - Drains one Windows node
   - Verifies node cordons and pod evicts
   - Uncordons node and verifies pod returns

5. **OCP-37472**: Idempotent service check (~2 min)
   - Scales WMCO deployment to 0
   - Scales back to 1
   - Verifies services ConfigMap is recreated
   - Verifies all Windows services remain running

All tests verified on live AWS cluster.

## New helpers in utils.go

**Service/Network helpers:**
- `waitVersionAnnotationReady`: polls until WMCO version annotation is set on node
- `getServiceClusterIP`: gets ClusterIP from a Service
- `generateClusterIPServiceYAML`: ClusterIP Service YAML generator
- `generateWindowsDaemonSetYAML`: Windows DaemonSet YAML generator

**MachineSet helpers:**
- `getAvailabilityZone`: returns availability zone from MachineSet or nodes
- `getMachineSetZone`: queries MachineSet for zone (GCP/AWS)
- `getZoneFromNodes`: queries nodes for topology zone label
- `getWindowsMachineSetName`: gets Windows MachineSet name (queries cluster for default)
- `scaleWindowsMachineSet`: scales MachineSet to specified replicas with wait
- `waitForMachinesetReady`: polls until MachineSet reaches expected ready replicas
- `cloneWindowsMachineSet`: clones existing MachineSet with modified name and 0 replicas
- `extractPrivateKeyToFile`: reads cloud-private-key secret, base64 decodes, writes to temp file

## Test runtime

| Test | Runtime | Tags |
|------|---------|------|
| OCP-33794 | ~24 min | Longduration |
| OCP-39451 | ~14 min | Longduration |
| OCP-39030 | ~13 min | Longduration |
| OCP-87809 | ~2.5 min | - |
| OCP-37472 | ~2 min | - |
| **Total** | **~56 min** | |

## Test plan

All 5 tests passed on live AWS cluster:
- [x] OCP-33794: Passed (~24.4 min)
- [x] OCP-39451: Passed (~13.6 min)
- [x] OCP-39030: Passed (~13 min)
- [x] OCP-87809: Passed (~2.5 min)
- [x] OCP-37472: Passed (~2 min)

## Migration approach

- **MachineSet cloning** instead of platform-specific templates: `cloneWindowsMachineSet` queries cluster for existing Windows MachineSet and clones it, eliminating need for per-platform YAML templates
- **Direct cluster queries**: `getWindowsMachineSetName` finds default Windows MachineSet by searching for "winworker" keyword
- **Inline YAML generators**: Service and DaemonSet manifests generated inline via Go functions
- **No SSH dependency**: All tests use `oc` commands, `runDebugNodePS`, or direct API queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Windows end-to-end coverage for private-key secret handling and replacement.
  * Added validation for connectivity between Windows and non-Windows workloads.
  * Added testing for MachineSet scaling, requeue behavior, and readiness.
  * Added recovery coverage for DaemonSet disruptions during node reconciliation.
  * Verified that Windows service reconciliation remains reliable and idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->