### PR TITLE
OCPBUGS-111093: reconcile proxy vars from cluster proxy

### DIFF
--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -348,6 +348,14 @@ spec:
           - watch
         - apiGroups:
           - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
           - operator.openshift.io
           resources:
           - networks

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -286,7 +286,11 @@ func main() {
 		setupLog.Error(err, "error removing invalid annotations from Linux nodes")
 	}
 
-	proxyEnabled := cluster.IsProxyEnabled()
+	proxyEnabled, err := cluster.IsProxyEnabled(ctx, mgr.GetAPIReader())
+	if err != nil {
+		setupLog.Error(err, "unable to determine proxy state")
+		os.Exit(1)
+	}
 	configMapReconciler, err := controllers.NewConfigMapReconciler(ctx, mgr, clusterConfig, watchNamespace, proxyEnabled)
 	if err != nil {
 		setupLog.Error(err, "unable to create ConfigMap reconciler")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -190,6 +190,14 @@ rules:
   - watch
 - apiGroups:
   - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
   - operator.openshift.io
   resources:
   - networks

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -71,6 +71,7 @@ import (
 // escalation check permits granting that same permission to WICD's ClusterRole in EnsureWICDRBAC
 //+kubebuilder:rbac:groups="certificates.k8s.io",resources=certificatesigningrequests,verbs=create
 //+kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures,verbs=get;list;watch
+//+kubebuilder:rbac:groups="config.openshift.io",resources=proxies,verbs=get;list;watch
 
 const (
 	// BYOHLabel is a label that should be applied to all Windows nodes not associated with a Machine.
@@ -537,7 +538,28 @@ func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(windowsNodeVersionChangePredicate())).
 		Watches(&mcfgv1.MachineConfig{}, handler.EnqueueRequestsFromMapFunc(r.mapToServicesConfigMap),
 			builder.WithPredicates(machineConfigCreatedPredicate())).
+		Watches(&oconfig.Proxy{}, handler.EnqueueRequestsFromMapFunc(r.mapToServicesConfigMap),
+			builder.WithPredicates(proxyChangedPredicate())).
 		Complete(r)
+}
+
+// proxyChangedPredicate triggers a reconcile on create or update of the cluster Proxy object, so that the
+// windows-services ConfigMap is regenerated with the current cluster-wide proxy variables.
+func proxyChangedPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == "cluster"
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == "cluster"
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+	}
 }
 
 func machineConfigCreatedPredicate() predicate.Funcs {
@@ -737,7 +759,11 @@ func generateServicesManifest(ctx context.Context, client client.Client, port st
 	if err != nil {
 		return nil, fmt.Errorf("Error getting kubelet args from ignition: %w", err)
 	}
-	svcData, err := services.GenerateManifest(argsFromIgnition, apiServerEndpoint, port, platform,
+	proxyVars, err := cluster.GetProxyVars(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get proxy vars: %w", err)
+	}
+	svcData, err := services.GenerateManifest(argsFromIgnition, apiServerEndpoint, port, platform, proxyVars,
 		ctrl.Log.V(1).Enabled())
 	if err != nil {
 		return nil, fmt.Errorf("error generating expected Windows service state: %w", err)

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/mod/semver"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
@@ -33,12 +33,25 @@ const (
 	ClusterAPINamespace = "openshift-cluster-api"
 )
 
-var (
-	// WatchedEnvironmentVars is a list of the WMCO watched environment variables
-	WatchedEnvironmentVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
-	// clusterWideProxyVars is a map of the global egress proxy variables and values from WMCO's environment
-	clusterWideProxyVars map[string]string
-)
+// proxyEnvVars is the single source of truth for the cluster-wide egress proxy environment variables WMCO watches.
+// Each entry binds the variable name to the field of the cluster Proxy status that supplies its value.
+var proxyEnvVars = []struct {
+	name  string
+	value func(oconfig.ProxyStatus) string
+}{
+	{"HTTP_PROXY", func(s oconfig.ProxyStatus) string { return s.HTTPProxy }},
+	{"HTTPS_PROXY", func(s oconfig.ProxyStatus) string { return s.HTTPSProxy }},
+	{"NO_PROXY", func(s oconfig.ProxyStatus) string { return s.NoProxy }},
+}
+
+// WatchedEnvironmentVars returns the names of the WMCO watched environment variables.
+func WatchedEnvironmentVars() []string {
+	names := make([]string, len(proxyEnvVars))
+	for i, v := range proxyEnvVars {
+		names[i] = v.name
+	}
+	return names
+}
 
 // Network interface contains methods to interact with cluster network objects
 type Network interface {
@@ -357,24 +370,26 @@ func GetDNS(subnet string) (string, error) {
 }
 
 // IsProxyEnabled returns whether a global egress proxy is active in the cluster
-func IsProxyEnabled() bool {
-	return len(GetProxyVars()) > 0
+func IsProxyEnabled(ctx context.Context, reader client.Reader) (bool, error) {
+	proxyVars, err := GetProxyVars(ctx, reader)
+	if err != nil {
+		return false, err
+	}
+	return len(proxyVars) > 0, nil
 }
 
-// GetProxyVars returns a map of the proxy variables and values from the WMCO container's environment. The presence of
-// any implies a proxy is enabled, as OLM would have injected them into the operator spec. Returns an empty map otherwise.
-func GetProxyVars() map[string]string {
-	if clusterWideProxyVars != nil {
-		return clusterWideProxyVars
+// GetProxyVars returns a map of the cluster-wide egress proxy variables and values, read from the cluster Proxy
+// object's status. Only non-empty values are included; an empty map means no proxy is active.
+func GetProxyVars(ctx context.Context, reader client.Reader) (map[string]string, error) {
+	proxy := &oconfig.Proxy{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: "cluster"}, proxy); err != nil {
+		return nil, fmt.Errorf("unable to get cluster proxy: %w", err)
 	}
-	// if clusterWideProxyVars is not already cached, initialize it. We never expect these values to change during
-	// runtime as OLM restarts the operator when the global cluster proxy config changes
-	clusterWideProxyVars = make(map[string]string, len(WatchedEnvironmentVars))
-	for _, envVar := range WatchedEnvironmentVars {
-		value, found := os.LookupEnv(envVar)
-		if found {
-			clusterWideProxyVars[envVar] = value
+	proxyVars := make(map[string]string)
+	for _, v := range proxyEnvVars {
+		if value := v.value(proxy.Status); value != "" {
+			proxyVars[v.name] = value
 		}
 	}
-	return clusterWideProxyVars
+	return proxyVars, nil
 }

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -645,7 +645,11 @@ func (nc *NodeConfig) SyncTrustedCABundle(ctx context.Context) error {
 	for _, bundle := range cc.Spec.ImageRegistryBundleData {
 		caBundle += appendToCABundle(bundle)
 	}
-	if cluster.IsProxyEnabled() {
+	proxyEnabled, err := cluster.IsProxyEnabled(ctx, nc.client)
+	if err != nil {
+		return fmt.Errorf("unable to determine proxy state: %w", err)
+	}
+	if proxyEnabled {
 		proxyCA := &core.ConfigMap{}
 		if err := nc.client.Get(ctx, types.NamespacedName{Namespace: nc.wmcoNamespace,
 			Name: certificates.ProxyCertsConfigMap}, proxyCA); err != nil {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -31,7 +31,7 @@ const (
 // GenerateManifest returns the expected state of the Windows service configmap. If debug is true, debug logging
 // will be enabled for services that support it.
 func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoint string, vxlanPort string,
-	platform config.PlatformType, debug bool) (*servicescm.Data, error) {
+	platform config.PlatformType, proxyVars map[string]string, debug bool) (*servicescm.Data, error) {
 	windowsExporterServiceCommand := fmt.Sprintf("%s --collectors.enabled "+
 		"cpu,logical_disk,net,os,service,system,container,memory,cpu_info --web.config.file %s",
 		windows.WindowsExporterPath, windows.TLSConfPath)
@@ -59,11 +59,7 @@ func GenerateManifest(kubeletArgsFromIgnition map[string]string, apiServerEndpoi
 	}
 	// TODO: All payload filenames and checksums must be added here https://issues.redhat.com/browse/WINC-847
 	files := &[]servicescm.FileInfo{}
-	var watchedEnvVars []string
-	for _, envVar := range cluster.WatchedEnvironmentVars {
-		watchedEnvVars = append(watchedEnvVars, envVar)
-	}
-	return servicescm.NewData(services, files, cluster.GetProxyVars(), watchedEnvVars)
+	return servicescm.NewData(services, files, proxyVars, cluster.WatchedEnvironmentVars())
 }
 
 // containerdConfiguration returns the service specification for the Windows containerd service

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/windows-machine-config-operator/pkg/metadata"
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
+	"github.com/openshift/windows-machine-config-operator/pkg/servicescm"
 	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 )
 
@@ -355,34 +356,190 @@ func (tc *testContext) testEnvVars(t *testing.T) {
 			}
 		})
 	}
+
+	// The windows-services ConfigMap must reflect the cluster-wide proxy state (OCPBUGS-111093). Only non-empty
+	// values are expected, as empty proxy fields are not written to the ConfigMap.
+	t.Run("services ConfigMap", func(t *testing.T) {
+		expectedCMEnvVars := expectedProxyVars(clusterProxy.Status.HTTPProxy, clusterProxy.Status.HTTPSProxy,
+			clusterProxy.Status.NoProxy)
+		require.NoError(t, tc.waitForConfigMapProxyVars(expectedCMEnvVars),
+			"windows-services ConfigMap proxy vars do not match cluster proxy status")
+	})
 }
 
-// testEnvVarRemoval tests that on each node the system-level and the process-level environment variables
-// are unset when the cluster-wide proxy is disabled by patching the proxy variables in the cluster proxy object.
+// testEnvVarRemoval removes the cluster-wide proxy fields one at a time and, after each removal, verifies that
+// the windows-services ConfigMap and the nodes reflect only the remaining proxy variables. This guards against
+// OCPBUGS-111093, where removing a single proxy field (e.g. httpsProxy) left the corresponding variable behind
+// in the ConfigMap.
 func (tc *testContext) testEnvVarRemoval(t *testing.T) {
-	var patches []*patch.JSONPatch
-	patches = append(patches, patch.NewJSONPatch("remove", "/spec/httpProxy", nil),
-		patch.NewJSONPatch("remove", "/spec/httpsProxy", nil),
-		patch.NewJSONPatch("remove", "/spec/noProxy", nil))
-	patchData, err := json.Marshal(patches)
-	require.NoErrorf(t, err, "%v", patches)
-	_, err = tc.client.Config.ConfigV1().Proxies().Patch(
-		context.TODO(),
-		"cluster",
-		types.JSONPatchType,
-		patchData,
-		meta.PatchOptions{},
-	)
-	patchString := string(patchData)
-	require.NoErrorf(t, err, "unable to patch %s", patchString)
-	require.NoError(t, tc.waitForAllNodesToReboot())
-	for _, node := range gc.allNodes() {
-		addr, err := controllers.GetAddress(node.Status.Addresses)
-		require.NoError(t, err, "unable to get node address")
-		envVarsRemoved, err := tc.checkEnvVarsRemoved(addr)
-		require.NoError(t, err, "error determining if ENV vars are removed")
-		assert.True(t, envVarsRemoved, "ENV vars not removed")
+	stages := []struct {
+		name  string
+		field string
+	}{
+		{name: "NO_PROXY", field: "/spec/noProxy"},
+		{name: "HTTPS_PROXY", field: "/spec/httpsProxy"},
+		{name: "HTTP_PROXY", field: "/spec/httpProxy"},
 	}
+	for _, stage := range stages {
+		t.Run(stage.name, func(t *testing.T) {
+			// Capture the current Proxy status so we can detect when the cluster network operator has
+			// processed the upcoming removal; the status is updated asynchronously from the spec patch.
+			prePatchProxy, err := tc.client.Config.ConfigV1().Proxies().Get(context.TODO(), "cluster",
+				meta.GetOptions{})
+			require.NoError(t, err, "unable to get cluster proxy")
+
+			// Remove a single proxy field from the cluster Proxy spec
+			patches := []*patch.JSONPatch{patch.NewJSONPatch("remove", stage.field, nil)}
+			patchData, err := json.Marshal(patches)
+			require.NoErrorf(t, err, "%v", patches)
+			_, err = tc.client.Config.ConfigV1().Proxies().Patch(context.TODO(), "cluster", types.JSONPatchType,
+				patchData, meta.PatchOptions{})
+			require.NoErrorf(t, err, "unable to patch %s", string(patchData))
+
+			// Wait for the Proxy status to reflect the removal before deriving expectations, otherwise we
+			// may compute expected variables from stale status. Convergence is any change from the pre-patch
+			// status; note status.noProxy retains operator-generated entries while a proxy is still active,
+			// so it does not necessarily become empty when spec.noProxy is removed.
+			var expectedEnvVars map[string]string
+			err = wait.PollUntilContextTimeout(context.TODO(), retry.Interval, retry.ResourceChangeTimeout, true,
+				func(context.Context) (bool, error) {
+					clusterProxy, err := tc.client.Config.ConfigV1().Proxies().Get(context.TODO(), "cluster",
+						meta.GetOptions{})
+					if err != nil {
+						return false, nil
+					}
+					if reflect.DeepEqual(clusterProxy.Status, prePatchProxy.Status) {
+						return false, nil
+					}
+					expectedEnvVars = expectedProxyVars(clusterProxy.Status.HTTPProxy,
+						clusterProxy.Status.HTTPSProxy, clusterProxy.Status.NoProxy)
+					return true, nil
+				})
+			require.NoErrorf(t, err, "cluster proxy status did not converge after removing %s", stage.name)
+
+			// Primary assertion: the ConfigMap must drop the removed key while keeping the rest (OCPBUGS-111093)
+			require.NoError(t, tc.waitForConfigMapProxyVars(expectedEnvVars),
+				"windows-services ConfigMap proxy vars not updated after removing %s", stage.name)
+
+			// The env var change triggers a node reboot; wait for it before checking node-level state
+			require.NoError(t, tc.waitForAllNodesToReboot())
+			for _, node := range gc.allNodes() {
+				addr, err := controllers.GetAddress(node.Status.Addresses)
+				require.NoError(t, err, "unable to get node address")
+				require.NoErrorf(t, tc.checkNodeProxyVars(addr, expectedEnvVars),
+					"node %s proxy vars do not match expected state after removing %s", node.GetName(), stage.name)
+			}
+		})
+	}
+}
+
+// expectedProxyVars builds the set of proxy environment variables that should appear in the windows-services
+// ConfigMap given the cluster Proxy status values. Only non-empty values are included, mirroring the operator's
+// cluster.GetProxyVars behavior.
+func expectedProxyVars(httpProxy, httpsProxy, noProxy string) map[string]string {
+	expected := map[string]string{}
+	if httpProxy != "" {
+		expected["HTTP_PROXY"] = httpProxy
+	}
+	if httpsProxy != "" {
+		expected["HTTPS_PROXY"] = httpsProxy
+	}
+	if noProxy != "" {
+		expected["NO_PROXY"] = noProxy
+	}
+	return expected
+}
+
+// getCurrentServicesConfigMapName returns the name of the windows-services ConfigMap for the running WMCO version
+func (tc *testContext) getCurrentServicesConfigMapName() (string, error) {
+	operatorVersion, err := getWMCOVersion()
+	if err != nil {
+		return "", err
+	}
+	return servicescm.NamePrefix + operatorVersion, nil
+}
+
+// getProxyEnvVarsFromConfigMap returns the proxy environment variables stored in the current windows-services
+// ConfigMap. Returns an empty map when no proxy variables are set.
+func (tc *testContext) getProxyEnvVarsFromConfigMap() (map[string]string, error) {
+	cmName, err := tc.getCurrentServicesConfigMapName()
+	if err != nil {
+		return nil, err
+	}
+	cm, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(context.TODO(), cmName, meta.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting ConfigMap %s: %w", cmName, err)
+	}
+	cmData, err := servicescm.Parse(cm.Data)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse ConfigMap %s data: %w", cmName, err)
+	}
+	return cmData.EnvironmentVars, nil
+}
+
+// waitForConfigMapProxyVars waits until the windows-services ConfigMap's proxy environment variables match the
+// expected map. Nil and empty maps are treated as equal, since the field is omitted when no proxy is set. This
+// absorbs the delay between patching the Proxy spec, the status settling, and WMCO regenerating the ConfigMap.
+func (tc *testContext) waitForConfigMapProxyVars(expected map[string]string) error {
+	var lastSeen map[string]string
+	var lastErr error
+	err := wait.PollUntilContextTimeout(context.TODO(), retry.Interval, retry.ResourceChangeTimeout, true,
+		func(context.Context) (bool, error) {
+			actual, err := tc.getProxyEnvVarsFromConfigMap()
+			if err != nil {
+				lastErr = err
+				return false, nil
+			}
+			lastSeen = actual
+			if len(actual) == 0 && len(expected) == 0 {
+				return true, nil
+			}
+			return reflect.DeepEqual(actual, expected), nil
+		})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for ConfigMap proxy vars to equal %v (last seen %v, last error %v): %w",
+			expected, lastSeen, lastErr, err)
+	}
+	return nil
+}
+
+// checkNodeProxyVars verifies that the system-level and service-level proxy environment variables on the instance
+// at the given address match the expected set: variables present in the set must have the expected value, and
+// variables absent from the set must not be set on the instance.
+func (tc *testContext) checkNodeProxyVars(address string, expected map[string]string) error {
+	watchedEnvVars := []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+	for _, proxyVar := range watchedEnvVars {
+		expectedVal, shouldExist := expected[proxyVar]
+
+		systemEnvVars, err := tc.getSystemEnvVar(address, proxyVar)
+		if err != nil {
+			return fmt.Errorf("error retrieving system level ENV var %s: %w", proxyVar, err)
+		}
+		actualVal, exists := systemEnvVars[proxyVar]
+		if shouldExist && (!exists || actualVal != expectedVal) {
+			return fmt.Errorf("system ENV var %s = %q, expected %q", proxyVar, actualVal, expectedVal)
+		}
+		if !shouldExist && exists {
+			return fmt.Errorf("system ENV var %s should be removed but is set to %q", proxyVar, actualVal)
+		}
+
+		for _, svcName := range windows.RequiredServices {
+			svcEnvVars, err := tc.getProxyEnvVarsFromService(address, svcName,
+				fmt.Sprintf("%s-%s", svcName, "staged"))
+			if err != nil {
+				return fmt.Errorf("error retrieving service %s ENV vars: %w", svcName, err)
+			}
+			svcVal, svcExists := svcEnvVars[proxyVar]
+			if shouldExist && (!svcExists || svcVal != expectedVal) {
+				return fmt.Errorf("service %s ENV var %s = %q, expected %q", svcName, proxyVar, svcVal, expectedVal)
+			}
+			if !shouldExist && svcExists {
+				return fmt.Errorf("service %s ENV var %s should be removed but is set to %q", svcName, proxyVar,
+					svcVal)
+			}
+		}
+	}
+	return nil
 }
 
 // testTrustedCAConfigMap tests multiple aspects of expected functionality for the trusted-ca ConfigMap


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy settings are now detected from the cluster’s OpenShift configuration.
  * Windows service configuration updates automatically when proxy settings change.
  * Proxy variables are applied consistently to system and required services.
  * Proxy certificate handling is enabled only when proxying is active.

* **Bug Fixes**
  * Startup now stops with a clear error if proxy status cannot be determined.
  * Proxy configuration updates and removals are reflected more reliably after reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->