### PR TITLE
WINC-1971: Register proxy test suite in OTE

### DIFF
--- a/ote/cmd/wmco-tests-ext/main.go
+++ b/ote/cmd/wmco-tests-ext/main.go
@@ -116,6 +116,11 @@ func registerSuites(ext *e.Extension) {
 			Qualifiers: []string{`name.contains("[Disruptive]")`},
 		},
 		{
+			Name:       "windows-machine-config-operator/proxy",
+			Parents:    []string{"openshift/disruptive"},
+			Qualifiers: []string{`name.contains("[node-proxy]")`},
+		},
+		{
 			Name:       "windows-machine-config-operator/non-disruptive",
 			Qualifiers: []string{`!name.contains("[Disruptive]")`},
 		},


### PR DESCRIPTION
## Summary

Register `windows-machine-config-operator/proxy` test suite in OTE without adding tests yet.

## Why

Unblocks openshift/release#83352 which references this suite but fails because it doesn't exist in master yet.

## How it works

1. **Now (this PR):** Suite registered, matches 0 tests ✅
2. **After this merges:** openshift/release#83352 passes (runs 0 tests) ✅  
3. **After #4459 merges:** Suite auto-populates with 6 proxy tests ✅

## Changes

- Added `windows-machine-config-operator/proxy` suite to `ote/cmd/wmco-tests-ext/main.go`
- Qualifier: `name.contains("[node-proxy]")`
- Parent: `openshift/disruptive`

## Testing

Suite exists and runs (0 tests currently):
```bash
openshift-tests run windows-machine-config-operator/proxy
# Returns successfully with no tests matched
```

## Related

- Unblocks: openshift/release#83352
- Tests will populate from: #4459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a dedicated disruptive test suite for Windows machine proxy functionality.
  - The suite runs tests labeled for node proxy behavior, improving coverage of proxy-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->