### PR TITLE
docs: update PTR record in BYOH pre-requisites

### DIFF
--- a/docs/byoh-instance-pre-requisites.md
+++ b/docs/byoh-instance-pre-requisites.md
@@ -10,7 +10,9 @@ The following pre-requisites must be fulfilled in order to add a Windows BYOH no
   * Contain only lowercase alphanumeric characters or '-'.
   * Start with an alphanumeric character.
   * End with an alphanumeric character.
-* A PTR record must exist corresponding to the instance address which resolves to the instance hostname for successful reverse DNS lookups.
+* Configure PTR record according the `windows-instances` key address type:
+  * When the `windows-instances` ConfigMap key is an IP address, a PTR record must exist corresponding to that address, resolving to the instance hostname. This allows WMCO to validate CSR node names via reverse DNS lookup. 
+  * When the ConfigMap key is a DNS name (e.g., a headless Service FQDN like `win-byoh-0.headless.default.svc.cluster.local`), no PTR record is required. WMCO validates the node name by matching it directly against the DNS name.
 * Containerd should not be installed. If it is installed already, it is recommended to uninstall as WMCO installs and manages containerd.
 * If the instance uses a static IP, and the instance is *not* running Windows Server 2022, deviceless NICs must be disabled
   * This can be done by running the following in PowerShell:


### PR DESCRIPTION
This pull request updates the BYOH (Bring Your Own Host) Windows instance prerequisites documentation to clarify the requirements for PTR records based on whether the `windows-instances` ConfigMap key is an IP address or a DNS name. This helps users correctly configure reverse DNS lookups and node validation for WMCO (Windows Machine Config Operator).

Documentation improvements:

* Clarified that when the `windows-instances` ConfigMap key is an IP address, a PTR record must exist for that address, resolving to the instance hostname, to allow WMCO to validate CSR node names via reverse DNS lookup.
* Specified that when the ConfigMap key is a DNS name (such as a headless Service FQDN), no PTR record is required, as WMCO will validate the node name by matching it directly against the DNS name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified reverse-DNS prerequisites for Windows instances.
  * IP address entries now require a PTR record for node-name validation.
  * DNS-name entries are validated directly and do not require PTR records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->