### PR TITLE
[release-4.18] OCPBUGS-88352: [pkg] Add TOFU host key validation

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -72,7 +72,7 @@ func (r *instanceReconciler) ensureInstanceIsUpToDate(instanceInfo *instance.Inf
 		return nil
 	}
 
-	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+	nc, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 		instanceInfo, r.signer, labelsToApply, annotationsToApply, r.platform)
 	if err != nil {
 		return fmt.Errorf("failed to create new nodeconfig: %w", err)
@@ -127,7 +127,7 @@ func (r *instanceReconciler) updateKubeletCA(node core.Node, contents []byte) er
 	if err != nil {
 		return fmt.Errorf("error creating instance for node %s: %w", node.Name, err)
 	}
-	nodeConfig, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR,
+	nodeConfig, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR,
 		r.watchNamespace, winInstance, r.signer, nil, nil, r.platform)
 	if err != nil {
 		return fmt.Errorf("error creating nodeConfig for instance %s: %w", winInstance.Address, err)
@@ -158,7 +158,7 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 		return fmt.Errorf("unable to create instance object from node: %w", err)
 	}
 
-	nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+	nc, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 		instance, r.signer, nil, nil, r.platform)
 	if err != nil {
 		return fmt.Errorf("failed to create new nodeconfig: %w", err)
@@ -167,6 +167,14 @@ func (r *instanceReconciler) deconfigureInstance(node *core.Node) error {
 	if err = nc.Deconfigure(); err != nil {
 		return err
 	}
+
+	// Remove stored SSH host key to prevent stale keys blocking IP reuse (best-effort)
+	// Only done during permanent removal, not during upgrade/reconfiguration
+	if err := nc.Windows.RemoveHostKey(context.TODO()); err != nil {
+		r.log.Error(err, "failed to remove SSH host key, IP reuse may be affected",
+			"node", instance.Node.GetName())
+	}
+
 	if err = r.client.Delete(context.TODO(), instance.Node); err != nil {
 		return fmt.Errorf("error deleting node %s: %w", instance.Node.GetName(), err)
 	}

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -104,7 +104,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+		nc, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 			instanceInfo, signer, nil, nil, r.platform)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)

--- a/controllers/registry_controller.go
+++ b/controllers/registry_controller.go
@@ -99,7 +99,7 @@ func (r *registryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to create instance object from node: %w", err)
 		}
-		nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+		nc, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 			winInstance, r.signer, nil, nil, r.platform)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to create new nodeconfig: %w", err)

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -242,7 +242,7 @@ func (r *SecretReconciler) reconcileTLSSecret(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("unable to create instance object from node: %w", err)
 		}
-		nc, err := nodeconfig.NewNodeConfig(r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
+		nc, err := nodeconfig.NewNodeConfig(ctx, r.client, r.k8sclientset, r.clusterServiceCIDR, r.watchNamespace,
 			winInstance, r.signer, nil, nil, r.platform)
 		if err != nil {
 			return fmt.Errorf("failed to create new nodeconfig: %w", err)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -146,6 +146,56 @@ Alternatively, any service event logs can be viewed using SSH with the following
   packet_trace.sh -i $SSH_KEY stop $WIN_NODE_NAME
   ```
 
+## SSH host key validation
+
+WMCO uses Trust On First Use (TOFU) pinning to validate SSH host keys and prevent man-in-the-middle attacks. Host keys are automatically managed and stored in the cluster.
+
+### Storage locations
+- **Node annotation** (preferred): Keys are stored as `windowsmachineconfig.openshift.io/ssh-host-key` annotation on the Node object after the node joins the cluster
+- **ConfigMap** (fallback): For BYOH instances before the Node exists, keys are temporarily stored in the `windows-ssh-host-keys` ConfigMap by instance address (IP or hostname)
+
+### Inspecting stored host keys
+
+To view the host key for a specific node:
+```shell script
+oc get node <node-name> -o jsonpath='{.metadata.annotations.windowsmachineconfig\.openshift\.io/ssh-host-key}'
+```
+
+To view all host keys in the ConfigMap (BYOH pre-Node bootstrap):
+```shell script
+oc get configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator -o yaml
+```
+
+### Troubleshooting SSH connection failures
+
+If SSH connections fail with "host key mismatch" errors:
+
+1. **Check if a stale key exists**: 
+   ```shell script
+   # For nodes that exist:
+   oc get node <node-name> -o jsonpath='{.metadata.annotations}'
+   
+   # For BYOH instances before Node creation:
+   oc get configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator -o yaml
+   ```
+
+2. **Remove stale keys** (only if you're certain the instance has been recreated or the IP reused):
+   ```shell script
+   # Remove from Node annotation (if Node exists):
+   oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-
+   oc annotate node <node-name> windowsmachineconfig.openshift.io/ssh-host-key-type-
+   ```
+
+   To remove from ConfigMap (BYOH instances):
+   ```shell script
+   # Edit the ConfigMap and manually delete the entry under .data for the instance address
+   oc edit configmap windows-ssh-host-keys -n openshift-windows-machine-config-operator
+   ```
+
+3. **WMCO will re-establish trust** on the next connection attempt using TOFU
+
+**Note**: The `windows-ssh-host-keys` ConfigMap is automatically created and managed by WMCO. Do not delete or modify it unless troubleshooting a specific issue. It is labeled with `app.kubernetes.io/managed-by: windows-machine-config-operator` for identification.
+
 ## External troubleshooting references
 * [Containers on Windows troubleshooting](https://docs.microsoft.com/en-us/virtualization/windowscontainers/troubleshooting)
 * [Troubleshoot host and container image mismatches](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/update-containers#troubleshoot-host-and-container-image-mismatches)

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -210,8 +210,7 @@ func (a *Approver) validateWithHostName(nodeName string, windowsInstances []*ins
 	if err != nil {
 		return false, fmt.Errorf("unable to create signer from private key secret: %w", err)
 	}
-	// check if the node name matches any of the instances host names
-	hasEntry, err := matchesHostname(nodeName, windowsInstances, instanceSigner)
+	hasEntry, err := matchesHostname(ctx, a.client, nodeName, windowsInstances, instanceSigner)
 	if err != nil {
 		return false, fmt.Errorf("unable to map node name to the host names of Windows instances: %w", err)
 	}
@@ -295,10 +294,10 @@ func hasUsages(csr *certificates.CertificateSigningRequest, usages []certificate
 
 // matchesHostname returns true if given node name matches with host name of any of the instances present
 // in the given instance list
-func matchesHostname(nodeName string, windowsInstances []*instance.Info,
+func matchesHostname(ctx context.Context, c client.Client, nodeName string, windowsInstances []*instance.Info,
 	instanceSigner ssh.Signer) (bool, error) {
 	for _, instanceInfo := range windowsInstances {
-		hostName, err := findHostName(instanceInfo, instanceSigner)
+		hostName, err := findHostName(ctx, c, instanceInfo, instanceSigner)
 		if err != nil {
 			return false, fmt.Errorf("unable to find host name for instance with address %s: %w",
 				instanceInfo.Address, err)
@@ -312,9 +311,8 @@ func matchesHostname(nodeName string, windowsInstances []*instance.Info,
 }
 
 // findHostName returns the actual host name of the instance by running the 'hostname' command
-func findHostName(instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
-	// We don't need to pass most args here as we just need to be able to run commands on the instance.
-	win, err := windows.New("", instanceInfo, instanceSigner, nil)
+func findHostName(ctx context.Context, c client.Client, instanceInfo *instance.Info, instanceSigner ssh.Signer) (string, error) {
+	win, err := windows.NewWithClient(ctx, c, "", instanceInfo, instanceSigner, nil, "")
 	if err != nil {
 		return "", fmt.Errorf("error instantiating Windows instance: %w", err)
 	}

--- a/pkg/nodeconfig/nodeconfig.go
+++ b/pkg/nodeconfig/nodeconfig.go
@@ -3,6 +3,7 @@ package nodeconfig
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -117,7 +118,7 @@ func (ow OutWriter) Write(p []byte) (n int, err error) {
 
 // NewNodeConfig creates a new instance of nodeConfig to be used by the caller.
 // hostName having a value will result in the VM's hostname being changed to the given value.
-func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServiceCIDR, wmcoNamespace string,
+func NewNodeConfig(ctx context.Context, c client.Client, clientset *kubernetes.Clientset, clusterServiceCIDR, wmcoNamespace string,
 	instanceInfo *instance.Info, signer ssh.Signer, additionalLabels,
 	additionalAnnotations map[string]string, platformType configv1.PlatformType) (*nodeConfig, error) {
 
@@ -132,7 +133,8 @@ func NewNodeConfig(c client.Client, clientset *kubernetes.Clientset, clusterServ
 	}
 
 	log := ctrl.Log.WithName(fmt.Sprintf("nc %s", instanceInfo.Address))
-	win, err := windows.New(clusterDNS, instanceInfo, signer, &platformType)
+	// Use NewWithClient to enable SSH host key validation
+	win, err := windows.NewWithClient(ctx, c, clusterDNS, instanceInfo, signer, &platformType, wmcoNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("error instantiating Windows instance from VM: %w", err)
 	}
@@ -197,10 +199,26 @@ func (nc *nodeConfig) Configure() error {
 		for key, value := range nc.additionalAnnotations {
 			annotationsToApply[key] = value
 		}
+
+		// Migrate SSH host key from ConfigMap to Node annotation if not present
+		// This handles Machine API/BYOH where initial SSH happened before Node existed
+		migratedAddr, err := nc.addSSHHostKeyAnnotation(context.TODO(), annotationsToApply)
+		if err != nil {
+			return fmt.Errorf("failed to prepare SSH host key annotation: %w", err)
+		}
+
 		if err := metadata.ApplyLabelsAndAnnotations(context.TODO(), nc.client, *nc.node, nc.additionalLabels,
 			annotationsToApply); err != nil {
 			return fmt.Errorf("error updating public key hash and additional annotations on node %s: %w",
 				nc.node.GetName(), err)
+		}
+
+		// Cleanup ConfigMap entry after successful migration to Node annotation
+		if migratedAddr != "" {
+			validator := windows.NewHostKeyValidator(nc.client, nc.wmcoNamespace, nc.node.Name, migratedAddr)
+			if err := validator.RemoveHostKey(context.TODO()); err != nil {
+				nc.log.Error(err, "failed to cleanup ConfigMap entry after migration", "address", migratedAddr)
+			}
 		}
 
 		if err := nc.Windows.ConfigureWICD(nc.wmcoNamespace, wicdKC); err != nil {
@@ -562,7 +580,7 @@ func (nc *nodeConfig) Deconfigure() error {
 	if err := nc.cleanupWithWICD(); err != nil {
 		return err
 	}
-	if err := nc.Windows.RemoveFilesAndNetworks(); err != nil {
+	if err := nc.Windows.RemoveFilesAndNetworks(ctx); err != nil {
 		return fmt.Errorf("error deconfiguring instance: %w", err)
 	}
 
@@ -789,6 +807,39 @@ func CreatePubKeyHashAnnotation(key ssh.PublicKey) string {
 // existing CA bundle string
 func appendToCABundle(bundle mcfg.ImageRegistryBundle) string {
 	return fmt.Sprintf("# %s\n%s\n\n", strings.ReplaceAll(bundle.File, "..", ":"), bundle.Data)
+}
+
+// addSSHHostKeyAnnotation reads SSH host key from ConfigMap and adds to annotations map
+// Returns the address if a key was migrated (for cleanup after successful apply)
+func (nc *NodeConfig) addSSHHostKeyAnnotation(ctx context.Context, annotations map[string]string) (string, error) {
+	if _, exists := nc.node.Annotations[windows.SSHHostKeyAnnotation]; exists {
+		return "", nil
+	}
+
+	addr := nc.Windows.GetAddress()
+	if addr == "" {
+		return "", fmt.Errorf("unable to get node address")
+	}
+
+	validator := windows.NewHostKeyValidator(nc.client, nc.wmcoNamespace, nc.node.Name, addr)
+	store := validator.GetStore()
+	if store == nil {
+		return "", nil
+	}
+
+	key, err := store.GetHostKey(ctx, addr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read host key from ConfigMap: %w", err)
+	}
+	if key == nil {
+		return "", nil
+	}
+
+	annotations[windows.SSHHostKeyAnnotation] = base64.StdEncoding.EncodeToString(key.Marshal())
+	annotations[windows.SSHHostKeyTypeAnnotation] = key.Type()
+
+	nc.log.V(1).Info("migrating SSH host key from ConfigMap to Node annotation", "address", addr)
+	return addr, nil
 }
 
 // validWICDServiceAccountTokenSecret returns true if the given secret provides a token for the WICD SA

--- a/pkg/windows/connectivity.go
+++ b/pkg/windows/connectivity.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/retry"
 )
@@ -35,7 +37,7 @@ func newAuthErr(err error) *AuthErr {
 
 type connectivity interface {
 	// init initialises the connectivity medium
-	init() error
+	init(context.Context) error
 	// run executes the given command on the remote system
 	run(cmd string) (string, error)
 	// createSFTPClient initializes an SFTP client from the existing SSH client. Caller should close the connection.
@@ -44,6 +46,10 @@ type connectivity interface {
 	transfer(*sftp.Client, io.Reader, string, string) error
 	// transferFiles transfers the given files to a given remote directory
 	transferFiles(*sftp.Client, map[string][]byte, string) error
+	// close closes all network connections
+	close() error
+	// removeHostKey removes the stored SSH host key
+	removeHostKey(context.Context) error
 }
 
 // sshConnectivity encapsulates the information needed to connect to the Windows VM over ssh
@@ -56,27 +62,45 @@ type sshConnectivity struct {
 	signer ssh.Signer
 	// sshClient is the client used to access the Windows VM via ssh
 	sshClient *ssh.Client
-	log       logr.Logger
+	// hostKeyValidator validates SSH host keys using TOFU pinning
+	hostKeyValidator *HostKeyValidator
+	log              logr.Logger
 }
 
-// newSshConnectivity returns an instance of sshConnectivity
-func newSshConnectivity(username, ipAddress string, signer ssh.Signer, logger logr.Logger) (connectivity, error) {
-	c := &sshConnectivity{
-		username:  username,
-		ipAddress: ipAddress,
-		signer:    signer,
-		log:       logger,
+// newSshConnectivity returns an instance of sshConnectivity with host key validation
+func newSshConnectivity(ctx context.Context, c client.Client, nodeName, username, ipAddress string, signer ssh.Signer, namespace string, logger logr.Logger) (connectivity, error) {
+	conn := &sshConnectivity{
+		username:         username,
+		ipAddress:        ipAddress,
+		signer:           signer,
+		hostKeyValidator: NewHostKeyValidator(c, namespace, nodeName, ipAddress),
+		log:              logger,
 	}
-	if err := c.init(); err != nil {
+	if err := conn.init(ctx); err != nil {
 		return nil, fmt.Errorf("error instantiating SSH client: %w", err)
 	}
-	return c, nil
+	return conn, nil
 }
 
 // init initialises the key based SSH client
-func (c *sshConnectivity) init() error {
-	if c.username == "" || c.ipAddress == "" || c.signer == nil {
-		return fmt.Errorf("incomplete sshConnectivity information: %v", c)
+func (c *sshConnectivity) init(ctx context.Context) error {
+	var missingFields []string
+	if c.username == "" {
+		missingFields = append(missingFields, "username")
+	}
+	if c.ipAddress == "" {
+		missingFields = append(missingFields, "ipAddress")
+	}
+	if c.signer == nil {
+		missingFields = append(missingFields, "signer")
+	}
+	if len(missingFields) > 0 {
+		return fmt.Errorf("incomplete sshConnectivity: missing %v", missingFields)
+	}
+
+	hostKeyCallback, err := c.hostKeyValidator.GetHostKeyCallback(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get host key callback: %w", err)
 	}
 
 	config := &ssh.ClientConfig{
@@ -84,9 +108,8 @@ func (c *sshConnectivity) init() error {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(c.signer),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 	}
-	var err error
 	var sshClient *ssh.Client
 	// Retry if we are unable to create a client as the VM could still be executing the steps in its user data
 	err = wait.PollImmediate(time.Minute, retry.Timeout, func() (bool, error) {
@@ -105,6 +128,14 @@ func (c *sshConnectivity) init() error {
 		return fmt.Errorf("unable to connect to Windows VM %s: %w", c.ipAddress, err)
 	}
 	c.sshClient = sshClient
+
+	if err := c.hostKeyValidator.PersistSeenKey(ctx); err != nil {
+		if closeErr := c.sshClient.Close(); closeErr != nil {
+			return fmt.Errorf("failed to persist SSH host key: %w (SSH close error: %v)", err, closeErr)
+		}
+		return fmt.Errorf("failed to persist SSH host key: %w", err)
+	}
+
 	return nil
 }
 
@@ -188,4 +219,20 @@ func (c *sshConnectivity) transferFiles(sftpClient *sftp.Client, files map[strin
 		}
 	}
 	return nil
+}
+
+func (c *sshConnectivity) close() error {
+	err := c.sshClient.Close()
+	// If the error is due to the underlying connection being already closed, don't return an error
+	if errors.Is(err, syscall.EINVAL) || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+func (c *sshConnectivity) removeHostKey(ctx context.Context) error {
+	if c.hostKeyValidator == nil {
+		return nil
+	}
+	return c.hostKeyValidator.RemoveHostKey(ctx)
 }

--- a/pkg/windows/hostkey.go
+++ b/pkg/windows/hostkey.go
@@ -1,0 +1,386 @@
+package windows
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/ssh"
+	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/windows-machine-config-operator/pkg/retry"
+)
+
+const (
+	// SSHHostKeyAnnotation stores the trusted SSH host public key for the Windows instance
+	SSHHostKeyAnnotation = "windowsmachineconfig.openshift.io/ssh-host-key"
+	// SSHHostKeyTypeAnnotation stores the SSH host key algorithm type (e.g., ssh-rsa, ssh-ed25519)
+	SSHHostKeyTypeAnnotation = "windowsmachineconfig.openshift.io/ssh-host-key-type"
+	// SSHHostKeysConfigMap stores host keys by address before Node exists
+	SSHHostKeysConfigMap = "windows-ssh-host-keys"
+)
+
+// hostKeyStore persists SSH host keys in cluster storage
+type hostKeyStore interface {
+	GetHostKey(ctx context.Context, address string) (ssh.PublicKey, error)
+	StoreHostKey(ctx context.Context, address string, key ssh.PublicKey) error
+}
+
+// nodeAnnotationHostKeyStore stores host keys in Node annotations or ConfigMap
+type nodeAnnotationHostKeyStore struct {
+	namespace string
+	client    client.Client
+	nodeName  string
+	address   string
+	log       logr.Logger
+}
+
+// HostKeyValidator validates SSH host keys using TOFU (Trust On First Use) pinning
+type HostKeyValidator struct {
+	store   hostKeyStore
+	seenKey ssh.PublicKey
+}
+
+// NewHostKeyValidator creates a new HostKeyValidator
+func NewHostKeyValidator(c client.Client, namespace, nodeName, address string) *HostKeyValidator {
+	var store hostKeyStore
+	// Only create store if namespace is available (required for ConfigMap operations and cleanup)
+	if c != nil && namespace != "" && (nodeName != "" || address != "") {
+		log := ctrl.Log.WithName("hostkey")
+		if nodeName != "" {
+			log = log.WithValues("node", nodeName)
+		}
+		if address != "" {
+			log = log.WithValues("address", address)
+		}
+		store = &nodeAnnotationHostKeyStore{
+			client:    c,
+			nodeName:  nodeName,
+			address:   address,
+			namespace: namespace,
+			log:       log,
+		}
+	}
+	return &HostKeyValidator{
+		store: store,
+	}
+}
+
+// GetHostKeyCallback returns an ssh.HostKeyCallback that implements TOFU host key pinning
+func (v *HostKeyValidator) GetHostKeyCallback(ctx context.Context) (ssh.HostKeyCallback, error) {
+	if v.seenKey != nil {
+		return v.validateCallback(base64.StdEncoding.EncodeToString(v.seenKey.Marshal()))
+	}
+
+	if v.store == nil {
+		return v.tofuCallback(), nil
+	}
+
+	storedKey, err := v.store.GetHostKey(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stored host key: %w", err)
+	}
+	if storedKey == nil {
+		return v.tofuCallback(), nil
+	}
+
+	return v.validateCallback(base64.StdEncoding.EncodeToString(storedKey.Marshal()))
+}
+
+// tofuCallback returns a callback that trusts the first key seen
+func (v *HostKeyValidator) tofuCallback() ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if v.seenKey == nil {
+			v.seenKey = key
+			return nil
+		}
+		if !bytes.Equal(v.seenKey.Marshal(), key.Marshal()) {
+			return fmt.Errorf("host key changed during connection attempts")
+		}
+		return nil
+	}
+}
+
+// PersistSeenKey persists the in-memory seenKey to cluster storage after successful SSH connection
+func (v *HostKeyValidator) PersistSeenKey(ctx context.Context) error {
+	if v.seenKey == nil || v.store == nil {
+		return nil
+	}
+	return v.store.StoreHostKey(ctx, "", v.seenKey)
+}
+
+// GetStore returns the underlying hostKeyStore for direct access
+func (v *HostKeyValidator) GetStore() hostKeyStore {
+	return v.store
+}
+
+// RemoveHostKey removes the stored host key to prevent stale keys blocking IP reuse
+func (v *HostKeyValidator) RemoveHostKey(ctx context.Context) error {
+	if v.store == nil {
+		return nil
+	}
+	store, ok := v.store.(*nodeAnnotationHostKeyStore)
+	if !ok {
+		return nil
+	}
+	if store.address == "" {
+		return nil
+	}
+	return store.cleanupConfigMapEntry(ctx, store.address)
+}
+
+// validateCallback returns a callback that validates against the stored key
+func (v *HostKeyValidator) validateCallback(storedKeyB64 string) (ssh.HostKeyCallback, error) {
+	storedKeyBytes, err := base64.StdEncoding.DecodeString(storedKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid stored host key format: %w", err)
+	}
+
+	storedKey, err := ssh.ParsePublicKey(storedKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse stored host key: %w", err)
+	}
+
+	return ssh.FixedHostKey(storedKey), nil
+}
+
+// GetHostKey retrieves the stored host key from Node annotation or ConfigMap
+func (s *nodeAnnotationHostKeyStore) GetHostKey(ctx context.Context, address string) (ssh.PublicKey, error) {
+	if s.nodeName != "" {
+		key, err := s.getKeyFromNode(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if key != nil {
+			return key, nil
+		}
+	}
+
+	lookupAddress := address
+	if lookupAddress == "" {
+		lookupAddress = s.address
+	}
+	if lookupAddress != "" {
+		return s.getKeyFromConfigMap(ctx, lookupAddress)
+	}
+
+	return nil, nil
+}
+
+// getKeyFromNode retrieves the SSH host key from the Node annotation
+func (s *nodeAnnotationHostKeyStore) getKeyFromNode(ctx context.Context) (ssh.PublicKey, error) {
+	node := &core.Node{}
+	err := s.client.Get(ctx, types.NamespacedName{Name: s.nodeName}, node)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %s: %w", s.nodeName, err)
+	}
+
+	storedKeyB64, hasKey := node.GetAnnotations()[SSHHostKeyAnnotation]
+	if !hasKey {
+		return nil, nil
+	}
+
+	storedKeyBytes, err := base64.StdEncoding.DecodeString(storedKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid stored host key format: %w", err)
+	}
+
+	return ssh.ParsePublicKey(storedKeyBytes)
+}
+
+// getKeyFromConfigMap retrieves the SSH host key from the ConfigMap by address
+// Returns nil if namespace is not set (graceful degradation to session-only TOFU)
+func (s *nodeAnnotationHostKeyStore) getKeyFromConfigMap(ctx context.Context, address string) (ssh.PublicKey, error) {
+	if s.namespace == "" {
+		return nil, nil
+	}
+
+	cm := &core.ConfigMap{}
+	err := s.client.Get(ctx, types.NamespacedName{Namespace: s.namespace, Name: SSHHostKeysConfigMap}, cm)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap: %w", err)
+	}
+
+	storedKeyB64, exists := cm.Data[address]
+	if !exists {
+		return nil, nil
+	}
+
+	storedKeyBytes, err := base64.StdEncoding.DecodeString(storedKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid stored host key format in ConfigMap: %w", err)
+	}
+
+	return ssh.ParsePublicKey(storedKeyBytes)
+}
+
+// StoreHostKey stores the SSH host key in Node annotation or ConfigMap
+func (s *nodeAnnotationHostKeyStore) StoreHostKey(ctx context.Context, address string, key ssh.PublicKey) error {
+	if s.nodeName != "" {
+		err := s.storeKeyToNode(ctx, key)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+			// Node not found, fall through to ConfigMap storage
+		} else {
+			// Successfully stored to Node annotation, cleanup ConfigMap
+			cleanupAddress := address
+			if cleanupAddress == "" {
+				cleanupAddress = s.address
+			}
+			if cleanupAddress != "" {
+				if err := s.cleanupConfigMapEntry(ctx, cleanupAddress); err != nil {
+					s.log.Error(err, "failed to cleanup ConfigMap entry, key remains but will not be used", "address", cleanupAddress)
+				}
+			}
+			return nil
+		}
+	}
+
+	storeAddress := address
+	if storeAddress == "" {
+		storeAddress = s.address
+	}
+	if storeAddress == "" {
+		return fmt.Errorf("cannot store host key: no node name or address available")
+	}
+
+	return s.storeKeyToConfigMap(ctx, storeAddress, key)
+}
+
+// storeKeyToNode stores the SSH host key as a Node annotation with retry on conflicts
+func (s *nodeAnnotationHostKeyStore) storeKeyToNode(ctx context.Context, key ssh.PublicKey) error {
+	keyB64 := base64.StdEncoding.EncodeToString(key.Marshal())
+
+	err := wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
+		node := &core.Node{}
+		if err := s.client.Get(ctx, types.NamespacedName{Name: s.nodeName}, node); err != nil {
+			return false, err
+		}
+
+		if node.Annotations == nil {
+			node.Annotations = make(map[string]string)
+		}
+
+		node.Annotations[SSHHostKeyAnnotation] = keyB64
+		node.Annotations[SSHHostKeyTypeAnnotation] = key.Type()
+
+		if err := s.client.Update(ctx, node); err != nil {
+			if apierrors.IsConflict(err) {
+				// Retry on conflict
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to store host key annotation: %w", err)
+	}
+
+	return nil
+}
+
+// storeKeyToConfigMap stores the SSH host key in the ConfigMap by address using JSON Patch
+// Creates the ConfigMap if it doesn't exist
+func (s *nodeAnnotationHostKeyStore) storeKeyToConfigMap(ctx context.Context, address string, key ssh.PublicKey) error {
+	if s.namespace == "" {
+		return fmt.Errorf("namespace not set, cannot store host key")
+	}
+
+	keyB64 := base64.StdEncoding.EncodeToString(key.Marshal())
+	cm := &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      SSHHostKeysConfigMap,
+			Namespace: s.namespace,
+		},
+	}
+
+	patchData := fmt.Sprintf(`{"data":{"%s":"%s"}}`, address, keyB64)
+	err := s.client.Patch(ctx, cm, client.RawPatch(types.StrategicMergePatchType, []byte(patchData)))
+	if err == nil {
+		return nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		cm = &core.ConfigMap{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      SSHHostKeysConfigMap,
+				Namespace: s.namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "windows-machine-config-operator",
+				},
+			},
+			Data: map[string]string{address: keyB64},
+		}
+		if err := s.client.Create(ctx, cm); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create ConfigMap: %w", err)
+			}
+			// ConfigMap was created concurrently, retry patch
+			patchErr := s.client.Patch(ctx, cm, client.RawPatch(types.StrategicMergePatchType, []byte(patchData)))
+			if patchErr != nil {
+				return fmt.Errorf("failed to patch ConfigMap after concurrent creation: %w", patchErr)
+			}
+		}
+		return nil
+	}
+
+	return fmt.Errorf("failed to patch ConfigMap: %w", err)
+}
+
+// cleanupConfigMapEntry removes the ConfigMap entry for the given address with retry on conflicts
+func (s *nodeAnnotationHostKeyStore) cleanupConfigMapEntry(ctx context.Context, address string) error {
+	if s.namespace == "" {
+		return nil
+	}
+
+	err := wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
+		cm := &core.ConfigMap{}
+		if err := s.client.Get(ctx, types.NamespacedName{Namespace: s.namespace, Name: SSHHostKeysConfigMap}, cm); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("failed to get ConfigMap for cleanup: %w", err)
+		}
+
+		if _, exists := cm.Data[address]; !exists {
+			return true, nil
+		}
+
+		delete(cm.Data, address)
+		if err := s.client.Update(ctx, cm); err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to update ConfigMap for cleanup: %w", err)
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to cleanup ConfigMap entry: %w", err)
+	}
+
+	s.log.V(1).Info("cleaned up ConfigMap entry", "address", address)
+	return nil
+}

--- a/pkg/windows/hostkey_test.go
+++ b/pkg/windows/hostkey_test.go
@@ -1,0 +1,157 @@
+package windows
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// generateTestHostKey generates a test RSA host key
+func generateTestHostKey(t *testing.T) ssh.PublicKey {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "failed to generate RSA key")
+
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err, "failed to create SSH public key")
+
+	return publicKey
+}
+
+func TestHostKeyValidator_TOFU(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, core.AddToScheme(scheme))
+
+	node := &core.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	ctx := context.Background()
+
+	validator := NewHostKeyValidator(fakeClient, "openshift-windows-machine-config-operator", "test-node", "")
+
+	callback, err := validator.GetHostKeyCallback(ctx)
+	require.NoError(t, err, "failed to get TOFU callback")
+
+	hostKey := generateTestHostKey(t)
+
+	err = callback("test-host", &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 22}, hostKey)
+	require.NoError(t, err, "TOFU callback should accept first key")
+
+	err = validator.PersistSeenKey(ctx)
+	require.NoError(t, err, "failed to persist seen key")
+
+	var updatedNode core.Node
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: "test-node"}, &updatedNode)
+	require.NoError(t, err, "failed to get updated node")
+
+	storedKey, exists := updatedNode.Annotations[SSHHostKeyAnnotation]
+	require.True(t, exists, "host key annotation should be stored")
+
+	storedKeyBytes, err := base64.StdEncoding.DecodeString(storedKey)
+	require.NoError(t, err, "failed to decode stored key")
+
+	parsedStoredKey, err := ssh.ParsePublicKey(storedKeyBytes)
+	require.NoError(t, err, "failed to parse stored key")
+
+	assert.Equal(t, hostKey.Marshal(), parsedStoredKey.Marshal(), "stored key should match original")
+	assert.Equal(t, hostKey.Type(), updatedNode.Annotations[SSHHostKeyTypeAnnotation], "key type should match")
+}
+
+func TestHostKeyValidator_ValidateStoredKey(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, core.AddToScheme(scheme))
+
+	hostKey := generateTestHostKey(t)
+	keyBytes := hostKey.Marshal()
+	keyB64 := base64.StdEncoding.EncodeToString(keyBytes)
+
+	node := &core.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "test-node",
+			Annotations: map[string]string{
+				SSHHostKeyAnnotation:     keyB64,
+				SSHHostKeyTypeAnnotation: hostKey.Type(),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	ctx := context.Background()
+
+	validator := NewHostKeyValidator(fakeClient, "openshift-windows-machine-config-operator", "test-node", "")
+
+	callback, err := validator.GetHostKeyCallback(ctx)
+	require.NoError(t, err, "failed to get validation callback")
+
+	err = callback("test-host", &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 22}, hostKey)
+	assert.NoError(t, err, "validation should succeed with correct key")
+
+	wrongKey := generateTestHostKey(t)
+	err = callback("test-host", &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 22}, wrongKey)
+	assert.Error(t, err, "validation should fail with wrong key")
+}
+
+func TestHostKeyValidator_ConfigMapFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, core.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	ctx := context.Background()
+
+	validator := NewHostKeyValidator(fakeClient, "openshift-windows-machine-config-operator", "", "10.1.42.1")
+
+	callback, err := validator.GetHostKeyCallback(ctx)
+	require.NoError(t, err, "failed to get TOFU callback")
+
+	hostKey := generateTestHostKey(t)
+
+	err = callback("test-host", &net.TCPAddr{IP: net.ParseIP("10.1.42.1"), Port: 22}, hostKey)
+	require.NoError(t, err, "TOFU callback should accept first key")
+
+	err = validator.PersistSeenKey(ctx)
+	require.NoError(t, err, "failed to persist seen key")
+
+	cm := &core.ConfigMap{}
+	err = fakeClient.Get(ctx, client.ObjectKey{
+		Namespace: "openshift-windows-machine-config-operator",
+		Name:      SSHHostKeysConfigMap,
+	}, cm)
+	require.NoError(t, err, "ConfigMap should be created")
+
+	storedKey, exists := cm.Data["10.1.42.1"]
+	require.True(t, exists, "host key should be stored in ConfigMap")
+
+	storedKeyBytes, err := base64.StdEncoding.DecodeString(storedKey)
+	require.NoError(t, err, "failed to decode stored key")
+
+	parsedStoredKey, err := ssh.ParsePublicKey(storedKeyBytes)
+	require.NoError(t, err, "failed to parse stored key")
+
+	assert.Equal(t, hostKey.Marshal(), parsedStoredKey.Marshal(), "stored key should match original")
+
+	newValidator := NewHostKeyValidator(fakeClient, "openshift-windows-machine-config-operator", "", "10.1.42.1")
+	callback2, err := newValidator.GetHostKeyCallback(ctx)
+	require.NoError(t, err, "should retrieve key from ConfigMap")
+
+	err = callback2("test-host", &net.TCPAddr{IP: net.ParseIP("10.1.42.1"), Port: 22}, hostKey)
+	assert.NoError(t, err, "should validate against ConfigMap key")
+
+	wrongKey := generateTestHostKey(t)
+	err = callback2("test-host", &net.TCPAddr{IP: net.ParseIP("10.1.42.1"), Port: 22}, wrongKey)
+	assert.Error(t, err, "should reject different key")
+}

--- a/pkg/windows/windows.go
+++ b/pkg/windows/windows.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/instance"
 	"github.com/openshift/windows-machine-config-operator/pkg/nodeconfig/payload"
@@ -240,6 +241,8 @@ func GetK8sDir() string {
 
 // Windows contains all the methods needed to configure a Windows VM to become a worker node
 type Windows interface {
+	// GetAddress returns the network address of the instance (may be IPv4 or DNS name)
+	GetAddress() string
 	// GetIPv4Address returns the IPv4 address of the associated instance.
 	GetIPv4Address() string
 	// GetHostname returns the FQDN of the associated instance including the domain name, if any
@@ -270,10 +273,13 @@ type Windows interface {
 	// ConfigureWICD ensures that the Windows Instance Config Daemon is running on the node
 	ConfigureWICD(string, string) error
 	// RemoveFilesAndNetworks removes all files and networks created by WMCO
-	RemoveFilesAndNetworks() error
+	RemoveFilesAndNetworks(context.Context) error
 	// RunWICDCleanup ensures the WICD service is stopped and runs the cleanup command that ensures all WICD-managed
 	// services are also stopped
 	RunWICDCleanup(string, string) error
+	// RemoveHostKey removes the stored SSH host key to prevent stale keys blocking IP reuse
+	RemoveHostKey(context.Context) error
+	Close() error
 }
 
 // windows implements the Windows interface
@@ -291,16 +297,41 @@ type windows struct {
 	// defaultShellPowerShell indicates if the default SSH shell is PowerShell
 	defaultShellPowerShell bool
 	// filesToTransfer is the map of files needed for the windows VM
-	filesToTransfer map[*payload.FileInfo]string
+	filesToTransfer map[*payload.CompressedFileInfo]string
+}
+
+func (vm *windows) RemoveHostKey(ctx context.Context) error {
+	return vm.interact.removeHostKey(ctx)
+}
+
+func (vm *windows) Close() error {
+	return vm.interact.close()
 }
 
 // New returns a new Windows instance constructed from the given WindowsVM
 func New(clusterDNS string, instanceInfo *instance.Info, signer ssh.Signer, platform *config.PlatformType) (Windows, error) {
+	// For backward compatibility, use the new function with nil client
+	return NewWithClient(context.Background(), nil, clusterDNS, instanceInfo, signer, platform, "")
+}
+
+// NewWithClient creates a new Windows instance with SSH host key validation support
+func NewWithClient(ctx context.Context, c client.Client, clusterDNS string, instanceInfo *instance.Info, signer ssh.Signer, platform *config.PlatformType, namespace string) (Windows, error) {
 	log := ctrl.Log.WithName(fmt.Sprintf("wc %s", instanceInfo.Address))
 	log.V(1).Info("initializing SSH connection")
-	conn, err := newSshConnectivity(instanceInfo.Username, instanceInfo.Address, signer, log)
+
+	nodeName := ""
+	if c != nil && instanceInfo.Node != nil {
+		nodeName = instanceInfo.Node.Name
+	}
+
+	conn, err := newSshConnectivity(ctx, c, nodeName, instanceInfo.Username, instanceInfo.Address, signer, namespace, log)
 	if err != nil {
 		return nil, fmt.Errorf("unable to setup VM %s sshConnectivity: %w", instanceInfo.Address, err)
+	}
+	if nodeName != "" {
+		log.V(1).Info("SSH connection established with host key validation", "node", nodeName)
+	} else {
+		log.V(1).Info("SSH connection established with TOFU (node not yet available)")
 	}
 
 	files, err := createPayload(platform)
@@ -333,6 +364,10 @@ func defaultShellPowershell(conn connectivity) bool {
 }
 
 // Interface methods
+
+func (vm *windows) GetAddress() string {
+	return vm.instance.Address
+}
 
 func (vm *windows) GetIPv4Address() string {
 	return vm.instance.IPv4Address
@@ -494,7 +529,7 @@ func (vm *windows) RebootAndReinitialize() error {
 		return fmt.Errorf("instance reboot failed to start: %w", err)
 	}
 	// Wait for instance to come back online and reinitialize the SSH connection after the reboot
-	if err := vm.reinitialize(); err != nil {
+	if err := vm.reinitialize(ctx); err != nil {
 		return fmt.Errorf("error reinitializing SSH connection after VM reboot: %w", err)
 	}
 	vm.log.V(1).Info("successful reboot")
@@ -520,8 +555,8 @@ func (vm *windows) RunWICDCleanup(watchNamespace, wicdKubeconfig string) error {
 	return nil
 }
 
-func (vm *windows) RemoveFilesAndNetworks() error {
-	if err := vm.ensureHNSNetworksAreRemoved(); err != nil {
+func (vm *windows) RemoveFilesAndNetworks(ctx context.Context) error {
+	if err := vm.ensureHNSNetworksAreRemoved(ctx); err != nil {
 		return fmt.Errorf("unable to ensure HNS networks are removed: %w", err)
 	}
 	if err := vm.removeDirectories(); err != nil {
@@ -959,7 +994,7 @@ func (vm *windows) newFileInfo(path string) (*payload.FileInfo, error) {
 
 // ensureHNSNetworksAreRemoved ensures the HNS networks created by the hybrid-overlay configuration process are removed
 // by repeatedly checking and retrying the removal of each network.
-func (vm *windows) ensureHNSNetworksAreRemoved() error {
+func (vm *windows) ensureHNSNetworksAreRemoved(ctx context.Context) error {
 	vm.log.Info("removing HNS networks")
 	var err error
 	// VIP HNS endpoint created by the operator is also deleted when the HNS networks are deleted.
@@ -967,13 +1002,13 @@ func (vm *windows) ensureHNSNetworksAreRemoved() error {
 		err = wait.PollImmediate(retry.Interval, retry.Timeout, func() (bool, error) {
 			// reinitialize and retry on failure to avoid connection reset SSH errors
 			if err := vm.removeHNSNetwork(network); err != nil {
-				vm.log.V(1).Error(err, "error removing %s HNS network", "network", network)
-				if err := vm.reinitialize(); err != nil {
+				vm.log.V(1).Info("error removing HNS network", "network", network, "err", err.Error())
+				if err := vm.reinitialize(ctx); err != nil {
 					return false, fmt.Errorf("error reinitializing VM after removing %s HNS network: %w", network, err)
 				}
 				return false, nil
 			}
-			if err := vm.reinitialize(); err != nil {
+			if err := vm.reinitialize(ctx); err != nil {
 				return false, fmt.Errorf("error reinitializing VM after removing %s HNS network: %w", network, err)
 			}
 			out, err := vm.Run(getHNSNetworkCmd(network), true)
@@ -1030,9 +1065,9 @@ func (vm *windows) waitUntilUnreachable() error {
 		})
 }
 
-func (vm *windows) reinitialize() error {
-	if err := vm.interact.init(); err != nil {
-		return fmt.Errorf("failed to reinitialize ssh client: %v", err)
+func (vm *windows) reinitialize(ctx context.Context) error {
+	if err := vm.interact.init(ctx); err != nil {
+		return fmt.Errorf("failed to reinitialize ssh client: %w", err)
 	}
 	return nil
 }

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -59,6 +59,9 @@ func creationTestSuite(t *testing.T) {
 	}
 	t.Run("Nodes ready and schedulable", tc.testNodesBecomeReadyAndSchedulable)
 	t.Run("Node annotations", tc.testNodeAnnotations)
+	t.Run("SSH host key annotations", tc.testSSHHostKeyAnnotations)
+	t.Run("SSH host keys ConfigMap cleanup", tc.testSSHHostKeysConfigMapCleanup)
+	t.Run("Node Cloud Manager fields", tc.testNodeCloudManagerFields)
 	t.Run("Node Metadata", tc.testNodeMetadata)
 	t.Run("Services ConfigMap validation", tc.testServicesConfigMap)
 	t.Run("Services running", tc.testExpectedServicesRunning)

--- a/test/e2e/reconfigure_test.go
+++ b/test/e2e/reconfigure_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/windows-machine-config-operator/pkg/patch"
+	"github.com/openshift/windows-machine-config-operator/pkg/windows"
 	"github.com/openshift/windows-machine-config-operator/pkg/wiparser"
 )
 
@@ -18,6 +20,19 @@ func reconfigurationTestSuite(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("Re-add removed instance", tc.testReAddInstance)
 	t.Run("Change private key", testPrivateKeyChange)
+}
+
+// findNodeByConfigMapAddress finds a node where any address matches the ConfigMap address
+func (tc *testContext) findNodeByConfigMapAddress(t *testing.T, configMapAddr string) *core.Node {
+	nodes := gc.allNodes()
+	for i := range nodes {
+		for _, nodeAddr := range nodes[i].Status.Addresses {
+			if nodeAddr.Address == configMapAddr {
+				return &nodes[i]
+			}
+		}
+	}
+	return nil
 }
 
 // testReAddInstance tests the case where a Windows BYOH instance was removed from the cluster, and then re-added.
@@ -36,6 +51,18 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	for addr, data = range windowsInstances.Data {
 		break
 	}
+
+	// Ensure we have fresh node data by waiting for expected nodes
+	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
+	require.NoError(t, err, "error refreshing BYOH nodes before test")
+
+	// Capture the host key annotation before removal to verify TOFU persistence
+	// Find the node by matching addresses using controllers.GetAddress logic
+	var originalHostKey string
+	node := tc.findNodeByConfigMapAddress(t, addr)
+	require.NotNil(t, node, "could not find node with address %s before removal", addr)
+	originalHostKey = node.Annotations[windows.SSHHostKeyAnnotation]
+	require.NotEmpty(t, originalHostKey, "node should have ssh-host-key annotation before removal")
 
 	// remove the entry that was found and then update the ConfigMap
 	delete(windowsInstances.Data, addr)
@@ -72,4 +99,12 @@ func (tc *testContext) testReAddInstance(t *testing.T) {
 	err = tc.waitForConfiguredWindowsNodes(gc.numberOfBYOHNodes, true, true)
 	require.NoError(t, err, "error waiting for the Windows node to be re-added")
 	tc.testNodesBecomeReadyAndSchedulable(t)
+
+	// Verify the host key persists across the re-add (same VM should have same key - TOFU)
+	readdedNode := tc.findNodeByConfigMapAddress(t, addr)
+	require.NotNil(t, readdedNode, "could not find re-added node with address %s", addr)
+	readdedHostKey := readdedNode.Annotations[windows.SSHHostKeyAnnotation]
+	require.NotEmpty(t, readdedHostKey, "re-added node should have ssh-host-key annotation")
+	require.Equal(t, originalHostKey, readdedHostKey,
+		"host key should persist across re-add for the same instance")
 }

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
@@ -16,6 +17,7 @@ import (
 	operators "github.com/operator-framework/api/pkg/operators/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 	batch "k8s.io/api/batch/v1"
 	certificates "k8s.io/api/certificates/v1"
 	core "k8s.io/api/core/v1"
@@ -799,6 +801,87 @@ func (tc *testContext) testNodeAnnotations(t *testing.T) {
 			assert.True(t, pubKey)
 		})
 	}
+}
+
+// testSSHHostKeyAnnotations verifies that SSH host key annotations are present and valid on all Windows nodes
+func (tc *testContext) testSSHHostKeyAnnotations(t *testing.T) {
+	for _, node := range gc.allNodes() {
+		t.Run(node.GetName(), func(t *testing.T) {
+			// Verify ssh-host-key annotation exists and is valid
+			keyB64, exists := node.Annotations[windows.SSHHostKeyAnnotation]
+			require.True(t, exists, "missing %s annotation", windows.SSHHostKeyAnnotation)
+
+			keyBytes, err := base64.StdEncoding.DecodeString(keyB64)
+			require.NoError(t, err, "invalid base64 in host key annotation")
+
+			_, err = ssh.ParsePublicKey(keyBytes)
+			require.NoError(t, err, "host key annotation is not a valid SSH public key")
+
+			// Verify ssh-host-key-type annotation exists
+			keyType, exists := node.Annotations[windows.SSHHostKeyTypeAnnotation]
+			require.True(t, exists, "missing %s annotation", windows.SSHHostKeyTypeAnnotation)
+			assert.NotEmpty(t, keyType, "ssh-host-key-type should not be empty")
+
+			// Re-fetch the node to verify key stability (not regenerated on every reconcile)
+			refetchedNode, err := tc.client.K8s.CoreV1().Nodes().Get(context.TODO(), node.GetName(), meta.GetOptions{})
+			require.NoError(t, err, "failed to re-fetch node")
+			refetchedKey := refetchedNode.Annotations[windows.SSHHostKeyAnnotation]
+			require.Equal(t, keyB64, refetchedKey, "host key should be stable across re-reads")
+		})
+	}
+}
+
+// testSSHHostKeysConfigMapCleanup verifies that the windows-ssh-host-keys ConfigMap has no stale entries
+// for fully-configured nodes (keys should migrate to Node annotations)
+func (tc *testContext) testSSHHostKeysConfigMapCleanup(t *testing.T) {
+	cm, err := tc.client.K8s.CoreV1().ConfigMaps(wmcoNamespace).Get(
+		context.TODO(), windows.SSHHostKeysConfigMap, meta.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// ConfigMap not created or already fully cleaned up
+		return
+	}
+	require.NoError(t, err, "failed to get %s ConfigMap", windows.SSHHostKeysConfigMap)
+
+	// Verify no entries remain for nodes that have the host key annotation
+	for _, node := range gc.allNodes() {
+		addr, err := controllers.GetAddress(node.Status.Addresses)
+		require.NoError(t, err, "failed to get address for node %s", node.Name)
+		assert.NotContains(t, cm.Data, addr,
+			"ConfigMap should not have entry for node %s (address %s) that already has annotation", node.Name, addr)
+	}
+}
+
+// testNodeCloudManagerFields tests that all expected labels and fields are on each Windows node configured by
+// the cloud node manager
+func (tc *testContext) testNodeCloudManagerFields(t *testing.T) {
+	if tc.CloudProvider.GetType() == config.NonePlatformType {
+		t.Skip("skipping test as cloud provider is not set")
+	}
+	for _, node := range gc.allNodes() {
+		t.Run(node.GetName(), func(t *testing.T) {
+			// check labels
+			for _, label := range tc.getExpectedCloudProviderLabels() {
+				assert.Contains(t, node.Labels, label, "node missing expected label from cloud provider: %s", label)
+			}
+			// check providerID field
+			assert.Greater(t, len(node.Spec.ProviderID), 0, "node missing expected providerID field")
+		})
+	}
+}
+
+// getExpectedCloudProviderLabels returns a slice of strings containing common and platform-specific cloud provider labels
+func (tc *testContext) getExpectedCloudProviderLabels() []string {
+	// common labels
+	cloudProviderLabels := []string{core.LabelInstanceTypeStable}
+	// platform-specific labels
+	switch tc.CloudProvider.GetType() {
+	case config.VSpherePlatformType:
+		// vSphere is a special case where the topology labels are not set
+	default:
+		// all other supported platforms must have the topology labels
+		cloudProviderLabels = append(cloudProviderLabels, core.LabelTopologyRegion, core.LabelTopologyZone)
+	}
+	return cloudProviderLabels
 }
 
 // checkUsernameAnnotation checks that the username annotation value is decipherable and correct


### PR DESCRIPTION
Implements SSH host key validation using Trust On First Use (TOFU) pinning to Windows nodes.

Storage strategy:
- Node annotation (preferred): When Node object exists
- ConfigMap fallback: By address when Node doesn't exist (BYOH bootstrap)
- Automatic migration: ConfigMap → Node annotation with cleanup

SSH host key validation tests

Test 1 & 2: testSSHHostKeyAnnotations
- Verifies ssh-host-key and ssh-host-key-type annotations exist on all nodes
- Validates annotation contains valid base64-encoded SSH public key
- Re-fetches node to verify key stability (not regenerated on reconcile)

Test 3: testSSHHostKeysConfigMapCleanup
- Verifies windows-ssh-host-keys ConfigMap has no stale entries
- Confirms keys migrate from ConfigMap to Node annotations with cleanup

Test 4: testReAddInstance (extended)
- Captures host key before BYOH instance removal
- Verifies same key persists after re-add (validates TOFU property)

Backport of #4212