### PR TITLE
WINC-1875: 4.23 branching activities - decouple from 5.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "ovn-kubernetes"]
 	path = ovn-kubernetes
 	url = https://github.com/openshift/ovn-kubernetes
-	branch = release-5.0
+	branch = release-4.23
 [submodule "containernetworking-plugins"]
 	path = containernetworking-plugins
 	url = https://github.com/openshift/containernetworking-plugins
-	branch = release-5.0
+	branch = release-4.23
 [submodule "promu"]
 	path = promu
 	url = https://github.com/openshift/prometheus-promu
@@ -15,24 +15,24 @@
 [submodule "kubelet"]
 	path = kubelet
 	url = https://github.com/openshift/kubernetes
-	branch = release-5.0
+	branch = release-4.23
 [submodule "containerd"]
 	path = containerd
 	url = https://github.com/openshift/containerd
-	branch = release-5.0
+	branch = release-4.23
 [submodule "hcsshim"]
 	path = hcsshim
 	url = https://github.com/openshift/hcsshim
-	branch = release-5.0
+	branch = release-4.23
 [submodule "cloud-provider-azure"]
 	path = cloud-provider-azure
 	url = https://github.com/openshift/cloud-provider-azure
-	branch = release-5.0
+	branch = release-4.23
 [submodule "csi-proxy"]
 	path = csi-proxy
 	url = https://github.com/openshift/csi-proxy
-	branch = release-5.0
+	branch = release-4.23
 [submodule "cloud-provider-aws"]
 	path = cloud-provider-aws
 	url = https://github.com/openshift/cloud-provider-aws
-	branch = release-5.0
+	branch = release-4.23

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -6,4 +6,4 @@ spec:
   imageDigestMirrors:
   - source: registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator
     mirrors:
-      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-5-0
+      - quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-23

--- a/.tekton/windows-machine-config-operator-bundle-release-4-23-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-23-pull-request.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
-      && target_branch == "master"
+      && target_branch == "release-4.23"
       && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-release-5-0
-    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-5-0
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-23
+    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-4-23
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-bundle-release-5-0-on-pull-request
+  name: windows-machine-config-operator-bundle-release-4-23-on-pull-request
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -33,7 +33,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-5-0:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-23:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -539,7 +539,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-5-0
+    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-4-23
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-bundle-release-4-23-push.yaml
+++ b/.tekton/windows-machine-config-operator-bundle-release-4-23-push.yaml
@@ -4,19 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/windows-machine-config-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "master"
-      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
+      event == "push"
+      && target_branch == "release-4.23"
+      && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-release-5-0
-    appstudio.openshift.io/component: windows-machine-config-operator-release-5-0
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-23
+    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-4-23
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-release-5-0-on-pull-request
+  name: windows-machine-config-operator-bundle-release-4-23-on-push
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -27,13 +26,11 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: dockerfile
-    value: Containerfile
+    value: Containerfile.bundle
   - name: git-url
     value: '{{source_url}}'
-  - name: image-expires-after
-    value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-5-0:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-4-23:{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -270,6 +267,30 @@ spec:
         operator: in
         values:
         - 'false'
+    - name: fips-operator-bundle-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: fips-operator-bundle-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:1d8d73418bfdc9b0461cf91ba2ac836cc9dde3e0b871c36eed1135287fc7f6a8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - 'false'
     - name: clair-scan
       params:
       - name: image-digest
@@ -284,26 +305,6 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:f5b4415db9ac1fba3e11d993a617e0b275d1f0ed2fc669b12c400ed848c39174
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - 'false'
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
         - name: kind
           value: task
         resolver: bundles
@@ -475,14 +476,6 @@ spec:
         requests:
           memory: 8Gi
       name: use-trusted-artifact
-  - pipelineTaskName: build-container
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 8Gi
-        requests:
-          memory: 8Gi
-      name: use-trusted-artifact
   - pipelineTaskName: clone-repository
     stepSpecs:
     - computeResources:
@@ -491,6 +484,14 @@ spec:
         requests:
           memory: 8Gi
       name: create-trusted-artifact
+  - pipelineTaskName: fips-operator-bundle-check-oci-ta
+    stepSpecs:
+    - computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 8Gi
+      name: use-trusted-artifact
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
     - computeResources:
@@ -524,7 +525,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-release-5-0
+    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-4-23
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-release-4-23-pull-request.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-23-pull-request.yaml
@@ -4,18 +4,19 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/windows-machine-config-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "master"
-      && ( "Containerfile.bundle".pathChanged() || "bundle/***".pathChanged() || ".tekton/windows-machine-config-operator-bundle-*".pathChanged() )
+      event == "pull_request"
+      && target_branch == "release-4.23"
+      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-release-5-0
-    appstudio.openshift.io/component: windows-machine-config-operator-bundle-release-5-0
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-23
+    appstudio.openshift.io/component: windows-machine-config-operator-release-4-23
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-bundle-release-5-0-on-push
+  name: windows-machine-config-operator-release-4-23-on-pull-request
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -26,11 +27,13 @@ spec:
   - name: prefetch-input
     value: '{"type": "gomod", "path": "."}'
   - name: dockerfile
-    value: Containerfile.bundle
+    value: Containerfile
   - name: git-url
     value: '{{source_url}}'
+  - name: image-expires-after
+    value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-bundle-release-5-0:{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-23:on-pr-{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -267,30 +270,6 @@ spec:
         operator: in
         values:
         - 'false'
-    - name: fips-operator-bundle-check-oci-ta
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: fips-operator-bundle-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-fips-operator-bundle-check-oci-ta:0.1@sha256:1d8d73418bfdc9b0461cf91ba2ac836cc9dde3e0b871c36eed1135287fc7f6a8
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - 'false'
     - name: clair-scan
       params:
       - name: image-digest
@@ -305,6 +284,26 @@ spec:
           value: clair-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:f5b4415db9ac1fba3e11d993a617e0b275d1f0ed2fc669b12c400ed848c39174
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - 'false'
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:e438f3104d706f73812994953d3d0a9c62ac8e4a372d86337ff26bbca9902709
         - name: kind
           value: task
         resolver: bundles
@@ -476,6 +475,14 @@ spec:
         requests:
           memory: 8Gi
       name: use-trusted-artifact
+  - pipelineTaskName: build-container
+    stepSpecs:
+    - computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 8Gi
+      name: use-trusted-artifact
   - pipelineTaskName: clone-repository
     stepSpecs:
     - computeResources:
@@ -484,14 +491,6 @@ spec:
         requests:
           memory: 8Gi
       name: create-trusted-artifact
-  - pipelineTaskName: fips-operator-bundle-check-oci-ta
-    stepSpecs:
-    - computeResources:
-        limits:
-          memory: 8Gi
-        requests:
-          memory: 8Gi
-      name: use-trusted-artifact
   - pipelineTaskName: prefetch-dependencies
     stepSpecs:
     - computeResources:
@@ -525,7 +524,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-bundle-release-5-0
+    serviceAccountName: build-pipeline-windows-machine-config-operator-release-4-23
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/windows-machine-config-operator-release-4-23-push.yaml
+++ b/.tekton/windows-machine-config-operator-release-4-23-push.yaml
@@ -8,14 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: '3'
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "master"
+      && target_branch == "release-4.23"
       && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|Containerfile.bundle)$'))
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: windows-machine-config-operator-release-5-0
-    appstudio.openshift.io/component: windows-machine-config-operator-release-5-0
+    appstudio.openshift.io/application: windows-machine-config-operator-release-4-23
+    appstudio.openshift.io/component: windows-machine-config-operator-release-4-23
     pipelines.appstudio.openshift.io/type: build
-  name: windows-machine-config-operator-release-5-0-on-push
+  name: windows-machine-config-operator-release-4-23-on-push
   namespace: windows-machine-conf-tenant
 spec:
   params:
@@ -30,7 +30,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-5-0:{{revision}}
+    value: quay.io/redhat-user-workloads/windows-machine-conf-tenant/windows-machine-config-operator/windows-machine-config-operator-release-4-23:{{revision}}
   - name: revision
     value: '{{revision}}'
   pipelineSpec:
@@ -521,7 +521,7 @@ spec:
           memory: 8Gi
       name: use-trusted-artifact
   taskRunTemplate:
-    serviceAccountName: build-pipeline-windows-machine-config-operator-release-5-0
+    serviceAccountName: build-pipeline-windows-machine-config-operator-release-4-23
   workspaces:
   - name: git-auth
     secret:

--- a/Containerfile
+++ b/Containerfile
@@ -185,7 +185,7 @@ LABEL stage=operator
 
 # This block contains standard Red Hat container labels
 LABEL name="openshift4-wincw/windows-machine-config-rhel9-operator" \
-    cpe="cpe:/a:redhat:windows_machine_config:11.0::el9" \
+    cpe="cpe:/a:redhat:windows_machine_config:10.23::el9" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator" \
     io.k8s.description="Windows Machine Config Operator" \
@@ -217,7 +217,7 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v11.0.0"
-LABEL release="v11.0.0"
+LABEL version="v10.23.0"
+LABEL release="v10.23.0"
 
 USER ${USER_UID}

--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -16,10 +16,10 @@ LABEL name="openshift4-wincw/windows-machine-config-operator-bundle" \
     io.openshift.tags=""
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v11.0.0"
+LABEL version="v10.23.0"
 # Component to file bugs against
 LABEL com.redhat.component="Windows Containers"
-LABEL cpe="cpe:/a:redhat:windows_machine_config:11.0::el9"
+LABEL cpe="cpe:/a:redhat:windows_machine_config:10.23::el9"
 
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -33,10 +33,10 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 LABEL distribution-scope=public
-LABEL release="11.0.0"
-LABEL url="https://docs.redhat.com/en/documentation/openshift_container_platform/5.0/html/windows_container_support_for_openshift/index"
+LABEL release="v10.23.0"
+LABEL url="https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/index"
 LABEL vendor="Red Hat, Inc."
-LABEL com.redhat.openshift.versions="=v5.0"
+LABEL com.redhat.openshift.versions="=v4.23"
 
 # create licenses directory
 # See https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the WMCO_VERSION as arg of the bundle target (e.g make bundle WMCO_VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export WMCO_VERSION=0.0.2)
-WMCO_VERSION ?= 11.0.0
+WMCO_VERSION ?= 10.23.0
 
 # *_GIT_VERSION are the k8s versions. Any update to the build line could potentially require an update to the sed
 # command in generate_k8s_version_commit() in hack/update_submodules.sh

--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 as build
 LABEL stage=build
 
 # Silence go compliance shim output

--- a/build/Dockerfile.ci
+++ b/build/Dockerfile.ci
@@ -3,7 +3,7 @@
 # building the operator from the PR source without using the operator-sdk.
 
 # build stage for building binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 as build
 LABEL stage=build
 
 # Silence go compliance shim output
@@ -194,7 +194,7 @@ mkdir /payload/generated && \
 chmod 0777 /payload/generated
 
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-5.0
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23
 LABEL stage=operator
 
 WORKDIR /

--- a/build/Dockerfile.wmco
+++ b/build/Dockerfile.wmco
@@ -1,6 +1,6 @@
 ARG BASE_IMG=localhost/wmco-base:latest
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 as build
 LABEL stage=build
 
 # Silence go compliance shim output
@@ -52,7 +52,7 @@ LABEL stage=operator
 
 # This block contains standard Red Hat container labels
 LABEL name="openshift4-wincw/windows-machine-config-rhel9-operator" \
-    cpe="cpe:/a:redhat:windows_machine_config:11.0::el9" \
+    cpe="cpe:/a:redhat:windows_machine_config:10.23::el9" \
     License="ASL 2.0" \
     io.k8s.display-name="Windows Machine Config Operator" \
     io.k8s.description="Windows Machine Config Operator" \
@@ -84,7 +84,7 @@ RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 # Used to tag the released image. Should be a semver.
-LABEL version="v11.0.0"
-LABEL release="v11.0.0"
+LABEL version="v10.23.0"
+LABEL release="v10.23.0"
 
 USER ${USER_UID}

--- a/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.22.0 <11.0.0'
+    olm.skipRange: '>=10.22.0 <10.23.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -27,7 +27,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/windows-machine-config-operator
     support: Red Hat
-  name: windows-machine-config-operator.v11.0.0
+  name: windows-machine-config-operator.v10.23.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -35,8 +35,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/byoh-windows-instance)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/byoh-windows-instance)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -47,7 +47,7 @@ spec:
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
     * OCP 4.21 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/understanding-windows-container-workloads)
+    * [WMCO prerequisites](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -57,7 +57,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -142,9 +142,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws)
-    - [Azure](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-azure)
-    - [GCP](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-gcp)
+    - [AWS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws)
+    - [Azure](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-azure)
+    - [GCP](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-gcp)
 
     ### Limitations
     #### DeploymentConfigs
@@ -153,7 +153,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/support/troubleshooting#olm-reinstall_troubleshooting-operator-issues)
+    Please read through the [troubleshooting document](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/support/troubleshooting#olm-reinstall_troubleshooting-operator-issues)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:
@@ -548,4 +548,4 @@ spec:
   minKubeVersion: 1.36.0
   provider:
     name: Red Hat
-  version: 11.0.0
+  version: 10.23.0

--- a/bundle/windows-machine-config-operator.package.yaml
+++ b/bundle/windows-machine-config-operator.package.yaml
@@ -1,4 +1,4 @@
 channels:
-  - currentCSV: windows-machine-config-operator.v11.0.0
+  - currentCSV: windows-machine-config-operator.v10.23.0
     channels: alpha
 packageName: windows-machine-config-operator

--- a/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/windows-machine-config-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=10.22.0 <11.0.0'
+    olm.skipRange: '>=10.22.0 <10.23.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-windows-machine-config-operator
     operators.openshift.io/valid-subscription: '["Red Hat OpenShift support for Windows
@@ -33,8 +33,8 @@ spec:
   description: |-
     ### Introduction
     The Windows Machine Config Operator configures Windows Machines into nodes, enabling Windows container workloads to
-    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
-    or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/byoh-windows-instance)
+    be run on OCP clusters. Windows instances can be added either by creating a [MachineSet](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws),
+    or by specifying existing instances through a [ConfigMap](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/byoh-windows-instance)
     The operator completes all the necessary steps to configure the Windows instance so that it can join the cluster as a worker node.
 
     Usage of this operator requires an OpenShift Container Platform for Windows Containers subscription. Users looking to
@@ -45,7 +45,7 @@ spec:
     ### Pre-requisites
     * A Red Hat OpenShift Container Platform for Windows Containers [subscription](https://access.redhat.com/support/policy/updates/openshift#windows)
     * OCP 4.21 cluster running on Azure, AWS, GCP or vSphere configured with hybrid OVN Kubernetes networking
-    * [WMCO prerequisites](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/understanding-windows-container-workloads)
+    * [WMCO prerequisites](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/understanding-windows-container-workloads)
 
     ### Usage
     Once the `openshift-windows-machine-config-operator` namespace has been created, a secret must be created containing
@@ -55,7 +55,7 @@ spec:
     oc create secret generic cloud-private-key --from-file=private-key.pem=/path/to/key -n openshift-windows-machine-config-operator
     ```
     We strongly recommend not using the same
-    [private key](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default)
+    [private key](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/installing_on_azure/installing-azure-default#ssh-agent-using_installing-azure-default)
     used when installing the cluster
 
     Below is an example of a vSphere Windows MachineSet which can create Windows Machines that the WMCO can react upon.
@@ -140,9 +140,9 @@ spec:
                 server: <vCenter Server FQDN/IP>
     ```
     Example MachineSet for other cloud providers:
-    - [AWS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws)
-    - [Azure](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-azure)
-    - [GCP](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-gcp)
+    - [AWS](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-aws)
+    - [Azure](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-azure)
+    - [GCP](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/windows_container_support_for_openshift/creating-windows-machine-sets#creating-windows-machineset-gcp)
 
     ### Limitations
     #### DeploymentConfigs
@@ -151,7 +151,7 @@ spec:
 
     ### Reporting issues
     Support for this distribution of WMCO requires a Red Hat OpenShfit subscription. Support should be requested through the Red Hat Customer Portal.
-    Please read through the [troubleshooting document](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/support/troubleshooting#olm-reinstall_troubleshooting-operator-issues)
+    Please read through the [troubleshooting document](https://docs.redhat.com/en/documentation/openshift_container_platform/4.23/html/support/troubleshooting#olm-reinstall_troubleshooting-operator-issues)
     before opening a support case.
   displayName: Windows Machine Config Operator
   icon:


### PR DESCRIPTION
Version bump:
- WMCO_VERSION: 11.0.0 → 10.23.0
- Container labels: cpe, version, release updated across Containerfile, Containerfile.bundle, build/Dockerfile.wmco

Builder images:
- openshift-5.0 → openshift-4.23 in Dockerfile.base, Dockerfile.ci, Dockerfile.wmco

Submodules:
- .gitmodules: all branch = release-5.0 → release-4.23
- Submodule pointers synced for repos with release-4.23 branches: ovn-kubernetes, containernetworking-plugins, kubelet, cloud-provider-azure, cloud-provider-aws
- containerd, hcsshim, csi-proxy: .gitmodules updated but submodule pointers unchanged (no release-4.23 branch yet)

OLM/Bundle manifests:
- olm.skipRange: <11.0.0 → <10.23.0
- CSV name/version: v11.0.0 → v10.23.0
- Documentation links: 4.21 → 4.23
- Package currentCSV: v11.0.0 → v10.23.0

Tekton pipelines:
- Renamed release-5-0 → release-4-23 in all pipeline files
- CRITICAL: Fixed CEL expression target_branch from "master" to "release-4.23" to enable Konflux pipelines
- Updated images-mirror-set.yaml references
- Updated Containerfile.bundle OCP version: =v5.0 → =v4.23