### PR TITLE
[WINC-1971] [ote] Fix OCP-68320 test missing SpecContext parameter

### DIFF
--- a/ote/test/e2e/proxy.go
+++ b/ote/test/e2e/proxy.go
@@ -184,7 +184,7 @@ var _ = g.Describe("[OTP][sig-windows][apigroup:config.openshift.io] Windows_Con
 
 	g.It("Smokerun-Author:rrasouli-Critical-68320-[node-proxy]-Import custom CA certificates into Windows node system store [Serial][Disruptive]",
 		g.SpecTimeout(45*time.Minute),
-		func() {
+		func(ctx g.SpecContext) {
 			const (
 				name                        = "OCP-68320-custom"
 				validity                    = "3650"


### PR DESCRIPTION
## Problem

Test OCP-68320 uses `g.SpecTimeout(45*time.Minute)` decorator but the function signature was missing the required context parameter.

This causes Ginkgo to fail during test discovery with:
```
Invalid NodeTimeout SpecTimeout, or GracePeriod
/build/windows-machine-config-operator/ote/test/e2e/proxy.go:185
  [It] was passed NodeTimeout, SpecTimeout, or GracePeriod but does not have a
  callback that accepts a SpecContext or context.Context
```

This prevents both `aws-e2e-ote` and `vsphere-proxy-e2e-ote` jobs from discovering any proxy tests, causing them to fail with "no tests to run".

## Solution

Changed function signature from:
```go
func() {
```

to:
```go
func(ctx g.SpecContext) {
```

## Testing

CI will verify that `openshift-tests run windows-machine-config-operator/proxy` successfully discovers and runs proxy tests.

## Related

- Introduced in: #4459
- Blocks: openshift/release#84352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end test to support context-aware execution.
  * No user-visible behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->