### PR TITLE
[release-5.0] update bundle windows-machine-config-operator-release-5-0 to ab39f9

### DIFF
--- a/Containerfile.bundle
+++ b/Containerfile.bundle
@@ -1,6 +1,6 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26@sha256:3ca2c34c83e6563fa574b7c7ecda92a5fdae2ec7a5f37a408e5e383947fb1957 as image-replacer
 COPY bundle/manifests /manifests
-RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:75b9fb5b1c14a1f4d079fb0606abfaf56d13acb90e8c9791bf85babe813202f1|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
+RUN sed -i "s|REPLACE_IMAGE|registry.redhat.io/openshift4-wincw/windows-machine-config-rhel9-operator@sha256:acb48213f80bb55fef3d30c57a9454fc7577a6ab8921ac0928b80f4b07457760|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 RUN sed -i "s|REPLACE_DATE|$(date "+%Y-%m-%dT%H:%M:%SZ")|g" /manifests/windows-machine-config-operator.clusterserviceversion.yaml
 
 FROM scratch


### PR DESCRIPTION
Image created from https://github.com/openshift/windows-machine-config-operator/commit/ab39f9e8fbc73cc6eaef3dcdb81e54164eb4a72f