### PR TITLE
[build] Restrict Renovate/Mintmaker to master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["master"],
   "extends": [
     "config:recommended",
     ":gitSignOff",


### PR DESCRIPTION
Without baseBranches scoping, Mintmaker/Renovate scans every branch that contains a renovate.json and opens PRs against fast-forward follower branches (e.g. release-5.1, release-5.0, release-4.23). This breaks the repo brancher fast-forward mechanism because those branches should only receive changes via fast-forward from master.

Adding "baseBranches": ["master"] tells Renovate to only open PRs against master. Dependency updates will propagate to release branches via the existing fast-forward job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Configured automated dependency updates to target the `master` base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->