### PR TITLE
[release-4.23] Restrict Renovate/Mintmaker to release-5.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -180,7 +180,7 @@ chmod -R 644 /payload && chmod -R +X /payload &&\
 # Create directory for generated files with open permissions, this allows WMCO to write to this directory
 mkdir -m 0777 /payload/generated
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:d235f607e1d6d833f031db107dc42206e4dd4d5aa9142c43d3771fb7f9bea76a
 LABEL stage=operator
 
 # This block contains standard Red Hat container labels

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["release-5.0"],
   "extends": [
     "config:recommended",
     ":gitSignOff",


### PR DESCRIPTION
Without baseBranches scoping, Mintmaker/Renovate scans every branch that contains a renovate.json and opens PRs against fast-forward follower branches (e.g. release-4.23). This breaks the repo brancher fast-forward mechanism because follower branches should only receive changes via fast-forward from their upstream branch.

Adding "baseBranches": ["release-5.0"] tells Renovate to only open PRs against release-5.0 when scanning this branch's config. This prevents Mintmaker from directly targeting release-4.23 or other follower branches.