### PR TITLE
[release-4.23] Restrict Renovate/Mintmaker to release-5.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["release-5.0"],
   "extends": [
     "config:recommended",
     ":gitSignOff",


### PR DESCRIPTION
Without baseBranches scoping, Mintmaker/Renovate scans every branch that contains a renovate.json and opens PRs against fast-forward follower branches (e.g. release-4.23). This breaks the repo brancher fast-forward mechanism because follower branches should only receive changes via fast-forward from their upstream branch.

Adding "baseBranches": ["release-5.0"] tells Renovate to only open PRs against release-5.0 when scanning this branch's config. This prevents Mintmaker from directly targeting release-4.23 or other follower branches.