### PR TITLE
[renovate] use baseBranchPatterns stanza

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["master"],
+  "baseBranchPatterns": [
+    "master"
+  ],
   "extends": [
     "config:recommended",
     ":gitSignOff",
@@ -140,14 +142,22 @@
     "branchPrefix": "konflux/mintmaker/",
     "packageRules": [
       {
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": ["!master"],
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchBaseBranches": [
+          "!master"
+        ],
         "enabled": false
       },
       {
         "groupName": "Go dependencies",
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": ["master"],
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchBaseBranches": [
+          "master"
+        ],
         "matchPackageNames": [
           "!k8s.io/kubernetes",
           "!github.com/openshift/api",


### PR DESCRIPTION
- https://github.com/openshift/windows-machine-config-operator/pull/4607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency update configuration to target the `master` branch using the current branch-pattern setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->